### PR TITLE
Embed mcalib in verificarlo and replace the default RNG by tinymt64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ config.status
 aclocal.m4
 autoconf
 libtool
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ before_install:
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get update
-  - sudo apt-get install clang-3.4 llvm-3.4 llvm-3.4-dev dragonegg gcc-4.6 gfortran-4.6 autoconf automake build-essential
+  - sudo apt-get install libmpfr-dev clang-3.4 llvm-3.4 llvm-3.4-dev dragonegg gcc-4.6 gfortran-4.6 autoconf automake build-essential
 
 install:
   - ./autogen.sh
   - ./configure --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.6/plugin/dragonegg.so CC=gcc-4.6
   - make
 
-script: make check
+script:
+  - make check
+  - for i in $(find tests/ -maxdepth 1 -type d -name 'test_*' | sort ); do echo "************** TEST $i"; cat $i/test.log; done;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ before_install:
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get update
   - sudo apt-get install clang-3.4 llvm-3.4 llvm-3.4-dev dragonegg gcc-4.6 gfortran-4.6 autoconf automake build-essential
-  - which llvm-config
-  - git clone https://github.com/mfrechtling/mcalib.git
-  - bash -c -l "cd mcalib/ && sudo ./setupmca.sh"
 
 install:
   - ./autogen.sh

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A tool for automatic Montecarlo Arithmetic analysis.
 
 Please ensure that Verificarlo's dependencies are installed on your system:
 
-  * mcalib, https://github.com/mfrechtling/mcalib
   * LLVM, clang and opt 3.3 or 3.4, http://clang.llvm.org/
   * gcc, gfortran and dragonegg (for Fortran support), http://dragonegg.llvm.org/
   * python, version >= 2.7
@@ -43,10 +42,6 @@ For example on an x86_64 Ubuntu 14.04 release, you should use the following
 install procedure:
 
 ```bash
-   # install mcalib manually following instructions at
-   # https://github.com/mfrechtling/mcalib
-   # ensure that the installation directory is added to your LD_LIBRARY_PATH
-
    $ sudo apt-get install clang-3.3 llvm3.3-dev dragonegg-4.7 gcc-4.7 \
                gfortran-4.7 autoconf automake build-essential
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A tool for automatic Montecarlo Arithmetic analysis.
 
 Please ensure that Verificarlo's dependencies are installed on your system:
 
+  * GNU mpfr library http://www.mpfr.org/
   * LLVM, clang and opt 3.3 or 3.4, http://clang.llvm.org/
   * gcc, gfortran and dragonegg (for Fortran support), http://dragonegg.llvm.org/
   * python, version >= 2.7
@@ -30,8 +31,8 @@ following options:
                  CC=<gcc binary compatible with installed dragonegg>
 ```
 
-Once installation is over, we recommend that you run the test suite to ensure verificarlo works as expected
-on your system:
+Once installation is over, we recommend that you run the test suite to ensure
+verificarlo works as expected on your system:
 
 ```bash
    $ make check
@@ -42,8 +43,8 @@ For example on an x86_64 Ubuntu 14.04 release, you should use the following
 install procedure:
 
 ```bash
-   $ sudo apt-get install clang-3.3 llvm3.3-dev dragonegg-4.7 gcc-4.7 \
-               gfortran-4.7 autoconf automake build-essential
+   $ sudo apt-get install libmpfr-dev clang-3.3 llvm3.3-dev dragonegg-4.7 \
+       gcc-4.7 gfortran-4.7 autoconf automake build-essential
 
    $ cd verificarlo/
    $ ./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -20,10 +20,10 @@ AC_PROG_CC([gcc])
 AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path (for dragonegg and replay linking)])
 AC_SUBST(GCC_PATH, $CC)
 AX_LLVM([3.3],[all])
-AC_CHECK_LIB([c], [exit])
-AC_CHECK_LIB([gfortran], [exit])
-AC_CHECK_LIB([m], [sin])
-AC_CHECK_LIB([mpfr], [mpfr_clear])
+AC_CHECK_LIB([c], [exit]), , AC_MSG_ERROR([Could not find c library])
+AC_CHECK_LIB([gfortran], [exit], , AC_MSG_ERROR([Could not find gfortran library]))
+AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find mpfr library]))
+AC_CHECK_LIB([mpfr], [mpfr_clear], , AC_MSG_ERROR([Could not find mpfr library]))
 
 # Check that the selected GCC is compatible with the selected dragonegg
 AC_MSG_CHECKING([if gcc can compile fortran with dragonegg])
@@ -40,7 +40,7 @@ AC_MSG_ERROR([Your gcc version ($CC) cannot compile Fortran programs with your d
 fi
 
 # Check for header files.
-AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h mpfr.h])
+AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h mpfr.h], , AC_MSG_ERROR([Missing required headers]))
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL
@@ -65,7 +65,7 @@ AC_FUNC_MALLOC
 AC_FUNC_MKTIME
 AC_FUNC_REALLOC
 
-AC_CHECK_FUNCS([atexit floor gettimeofday memset mkdir pow sqrt strchr strdup strerror strrchr strstr strtoul tzset utime])
+AC_CHECK_FUNCS([atexit floor gettimeofday getpid memset mkdir pow sqrt strchr strdup strerror strrchr strstr strtoul tzset utime])
 
 # Check for Python 2.7
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,10 +20,10 @@ AC_PROG_CC([gcc])
 AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path (for dragonegg and replay linking)])
 AC_SUBST(GCC_PATH, $CC)
 AX_LLVM([3.3],[all])
-AC_CHECK_LIB([mca], [_mca_seed])
 AC_CHECK_LIB([c], [exit])
 AC_CHECK_LIB([gfortran], [exit])
 AC_CHECK_LIB([m], [sin])
+AC_CHECK_LIB([mpfr], [mpfr_clear])
 
 # Check that the selected GCC is compatible with the selected dragonegg
 AC_MSG_CHECKING([if gcc can compile fortran with dragonegg])
@@ -40,7 +40,7 @@ AC_MSG_ERROR([Your gcc version ($CC) cannot compile Fortran programs with your d
 fi
 
 # Check for header files.
-AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h])
+AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h mpfr.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL
@@ -105,6 +105,7 @@ fi
 AC_CONFIG_FILES([Makefile
                  src/Makefile
                  src/libmcainstrument/Makefile
+                 src/mcalib/Makefile
                  tests/Makefile])
 
 AC_CONFIG_FILES([verificarlo], [chmod +x verificarlo])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS=libmcainstrument
+SUBDIRS=libmcainstrument mcalib

--- a/src/mcalib/Makefile.am
+++ b/src/mcalib/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = libmca.la
-libmca_la_SOURCES = mcalib.c
-EXTRA_DIST=mcalib.h mcalib_types.h
+libmca_la_SOURCES = mcalib.c tinymt64.c
+EXTRA_DIST=mcalib.h mcalib_types.h tinymt64.h
 MCA_LIBRARY_VERSION=0:0:0
 libmca_la_LDFLAGS = -version-info $(MCA_LIBRARY_VERSION) -lm
 library_includedir=$(includedir)/

--- a/src/mcalib/Makefile.am
+++ b/src/mcalib/Makefile.am
@@ -1,0 +1,7 @@
+lib_LTLIBRARIES = libmca.la
+libmca_la_SOURCES = mcalib.c
+EXTRA_DIST=mcalib.h mcalib_types.h
+MCA_LIBRARY_VERSION=0:0:0
+libmca_la_LDFLAGS = -version-info $(MCA_LIBRARY_VERSION) -lm
+library_includedir=$(includedir)/
+library_include_HEADERS = mcalib.h mcalib_types.h

--- a/src/mcalib/mcalib.c
+++ b/src/mcalib/mcalib.c
@@ -1,0 +1,377 @@
+// The Monte Carlo Arihmetic Library - A tool for automated rounding error
+// analysis of floating point software. Copyright (C) 2014 The Computer
+// Engineering Laboratory, The University of Sydney. Maintained by Michael
+// Frechtling:
+// 
+// 	michael.frechtling@sydney.edu.au
+// 
+// This file is part of the Monte Carlo Arithmetic Library, (MCALIB). MCALIB is
+// free software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+// 
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+#include "mcalib_types.h"
+
+#define NEAREST_FLOAT(x)	((float) (x))
+#define	NEAREST_DOUBLE(x)	((double) (x))
+
+int 	MCALIB_OP_TYPE 		= MCALIB_IEEE;
+int 	MCALIB_T		= 24;
+
+/******************** MCA RANDOM FUNCTIONS ********************
+* The following functions are used to calculate the random
+* perturbations used for MCA and apply these to MPFR format
+* operands
+***************************************************************/	
+
+double _mca_rand(void) {
+	while(1) {
+		double d_rand = ((double)rand() / (double)RAND_MAX);
+		if ((d_rand > 0.) & (d_rand < 1.0)) {
+			return d_rand;
+		}
+	}
+}
+
+int _mca_inexact(mpfr_ptr a, mpfr_rnd_t rnd_mode) {
+	if (MCALIB_OP_TYPE == MCALIB_IEEE) {
+		return 0;
+	}
+	mpfr_exp_t e_a = mpfr_get_exp(a);
+	mpfr_prec_t p_a = mpfr_get_prec(a);
+	mpfr_t mpfr_rand, mpfr_offset, mpfr_zero;
+	e_a = e_a - (MCALIB_T - 1);
+	mpfr_inits2(p_a, mpfr_rand, mpfr_offset, mpfr_zero, (mpfr_ptr) 0);
+	mpfr_set_d(mpfr_zero, 0., rnd_mode);
+	int cmp = mpfr_cmp(a, mpfr_zero);
+	if (cmp == 0) {
+		mpfr_clear(mpfr_rand);
+		mpfr_clear(mpfr_offset);
+		mpfr_clear(mpfr_zero);
+		return 0;
+	}
+	double d_rand = (_mca_rand() - 0.5);
+	double d_offset = pow(2, e_a);
+	mpfr_set_d(mpfr_rand, d_rand, rnd_mode);
+	mpfr_set_d(mpfr_offset, d_offset, rnd_mode);
+	mpfr_mul(mpfr_rand, mpfr_rand, mpfr_offset, rnd_mode);
+	mpfr_add(a, a, mpfr_rand, rnd_mode);
+	mpfr_clear(mpfr_rand);
+	mpfr_clear(mpfr_offset);
+	mpfr_clear(mpfr_zero);
+}
+
+void _mca_seed(void) {
+	struct timeval t1;
+	gettimeofday(&t1, NULL);
+	srand(t1.tv_usec * t1.tv_sec);
+}
+
+/******************** MCA ARITHMETIC FUNCTIONS ********************
+* The following set of functions perform the MCA operation. Operands
+* are first converted to MPFR format, inbound and outbound perturbations
+* are applied using the _mca_inexact function, and the result converted
+* to the original format for return
+*******************************************************************/
+
+float _mca_sbin(float a, float b, mpfr_bin mpfr_op) {
+	mpfr_t mpfr_a, mpfr_b, mpfr_r;
+	mpfr_prec_t prec = 24 + MCALIB_T;
+	mpfr_rnd_t rnd = MPFR_RNDN;
+	mpfr_inits2(prec, mpfr_a, mpfr_b, mpfr_r, (mpfr_ptr) 0);
+	mpfr_set_flt(mpfr_a, a, rnd);
+	mpfr_set_flt(mpfr_b, b, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_RR) {
+		_mca_inexact(mpfr_a, rnd);
+		_mca_inexact(mpfr_b, rnd);
+	}
+	mpfr_op(mpfr_r, mpfr_a, mpfr_b, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_PB) {
+		_mca_inexact(mpfr_r, rnd);
+	}
+	float ret = mpfr_get_flt(mpfr_r, rnd);
+	mpfr_clear(mpfr_a);
+	mpfr_clear(mpfr_b);
+	mpfr_clear(mpfr_r);
+	return NEAREST_FLOAT(ret);
+}
+
+float _mca_sunr(float a, mpfr_unr mpfr_op) {
+	mpfr_t mpfr_a, mpfr_r;
+	mpfr_prec_t prec = 24 + MCALIB_T;
+	mpfr_rnd_t rnd = MPFR_RNDN;
+	mpfr_inits2(prec, mpfr_a, mpfr_r, (mpfr_ptr) 0);
+	mpfr_set_flt(mpfr_a, a, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_RR) {
+		_mca_inexact(mpfr_a, rnd);
+	}
+	mpfr_op(mpfr_r, mpfr_a, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_PB) {
+		_mca_inexact(mpfr_r, rnd);
+	}
+	float ret = mpfr_get_flt(mpfr_r, rnd);
+	mpfr_clear(mpfr_a);
+	mpfr_clear(mpfr_r);
+	return NEAREST_FLOAT(ret);
+}
+
+double _mca_dbin(double a, double b, mpfr_bin mpfr_op) {
+	mpfr_t mpfr_a, mpfr_b, mpfr_r;
+	mpfr_prec_t prec = 53 + MCALIB_T;
+	mpfr_rnd_t rnd = MPFR_RNDN;
+	mpfr_inits2(prec, mpfr_a, mpfr_b, mpfr_r, (mpfr_ptr) 0);
+	mpfr_set_d(mpfr_a, a, rnd);
+	mpfr_set_d(mpfr_b, b, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_RR) {
+		_mca_inexact(mpfr_a, rnd);
+		_mca_inexact(mpfr_b, rnd);
+	}
+	mpfr_op(mpfr_r, mpfr_a, mpfr_b, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_PB) {
+		_mca_inexact(mpfr_r, rnd);
+	}
+	double ret = mpfr_get_d(mpfr_r, rnd);
+	mpfr_clear(mpfr_a);
+	mpfr_clear(mpfr_b);
+	mpfr_clear(mpfr_r);
+	return NEAREST_DOUBLE(ret);
+}
+
+double _mca_dunr(double a, mpfr_unr mpfr_op) {
+	mpfr_t mpfr_a, mpfr_r;
+	mpfr_prec_t prec = 53 + MCALIB_T;
+	mpfr_rnd_t rnd = MPFR_RNDN;
+	mpfr_inits2(prec, mpfr_a, mpfr_r, (mpfr_ptr) 0);
+	mpfr_set_d(mpfr_a, a, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_RR) {
+		_mca_inexact(mpfr_a, rnd);
+	}
+	mpfr_op(mpfr_r, mpfr_a, rnd);
+	if (MCALIB_OP_TYPE != MCALIB_PB) {
+		_mca_inexact(mpfr_r, rnd);
+	}
+	double ret = mpfr_get_d(mpfr_r, rnd);
+	mpfr_clear(mpfr_a);
+	mpfr_clear(mpfr_r);
+	return NEAREST_DOUBLE(ret);
+}
+
+/******************** MCA COMPARE FUNCTIONS ********************
+* Compare operations do not require MCA and as such these functions
+* only convert the operands to MPFR format and execute the mpfr_cmp
+* function, the integer result is then passed back to the original
+* fphook function.
+****************************************************************/
+
+int _mca_scmp(float a, float b) {
+	mpfr_t mpfr_a, mpfr_b;
+	mpfr_prec_t prec = 24;
+	mpfr_rnd_t rnd = MPFR_RNDN;
+	mpfr_inits2(prec, mpfr_a, mpfr_b, (mpfr_ptr) 0);
+	mpfr_set_flt(mpfr_a, a, rnd);
+	mpfr_set_flt(mpfr_b, b, rnd);
+	int cmp_r = mpfr_cmp(mpfr_a, mpfr_b);
+	mpfr_clear(mpfr_a);
+	mpfr_clear(mpfr_b);
+	return cmp_r;
+}
+
+int _mca_dcmp(double a, double b) {
+	mpfr_t mpfr_a, mpfr_b;
+	mpfr_prec_t prec = 53;
+	mpfr_rnd_t rnd = MPFR_RNDN;
+	mpfr_inits2(prec, mpfr_a, mpfr_b, (mpfr_ptr) 0);
+	mpfr_set_d(mpfr_a, a, rnd);
+	mpfr_set_d(mpfr_b, b, rnd);
+	int cmp_r = mpfr_cmp(mpfr_a, mpfr_b);
+	mpfr_clear(mpfr_a);
+	mpfr_clear(mpfr_b);
+	return cmp_r;
+}
+
+/************************* FPHOOKS FUNCTIONS *************************
+* These functions correspond to those inserted into the source code 
+* during source to source compilation and are replacement to floating 
+* point operators
+**********************************************************************/
+
+int _floateq(float a, float b) {
+	//return a == b
+	int res = _mca_scmp(a, b);
+	return (res == 0 ? 1 : 0);
+}
+
+int _floatne(float a, float b) {
+	//return a != b
+	int res = _mca_scmp(a, b);
+	return (res == 0 ? 0 : 1);
+}
+
+int _floatlt(float a, float b) {
+	//return a < b
+	int res = _mca_scmp(a, b);
+	return (res < 0 ? 1 : 0);
+}
+
+int _floatgt(float a, float b) {
+	//return a > b
+	int res = _mca_scmp(a, b);
+	return (res > 0 ? 1 : 0);
+}
+
+int _floatle(float a, float b) {
+	//return a <= b
+	int res = _mca_scmp(a, b);
+	return (res <= 0 ? 1 : 0);
+}
+
+int _floatge(float a, float b) {
+	//return a >= b
+	int res = _mca_scmp(a, b);
+	return (res >= 0 ? 1 : 0);
+}
+
+int _doubleeq(double a, double b) {
+	//return a == b
+	int res = _mca_dcmp(a, b);
+	return (res == 0 ? 1 : 0);
+}
+
+int _doublene(double a, double b) {
+	//return a != b
+	int res = _mca_dcmp(a, b);
+	return (res == 0 ? 0 : 1);
+}
+
+int _doublelt(double a, double b) {
+	//return a < b
+	int res = _mca_dcmp(a, b);
+	return (res < 0 ? 1 : 0);
+}
+
+int _doublegt(double a, double b) {
+	//return a > b
+	int res = _mca_dcmp(a, b);
+	return (res > 0 ? 1 : 0);
+}
+
+int _doublele(double a, double b) {
+	//return a <= b
+	int res = _mca_dcmp(a, b);
+	return (res <= 0 ? 1 : 0);
+}
+
+int _doublege(double a, double b) {
+	//return a >= b
+	int res = _mca_dcmp(a, b);
+	return (res >= 0 ? 1 : 0);
+}
+
+int _longeq(long double a, long double b) {
+	return (a == b);
+}
+
+int _longne(long double a, long double b) {
+	return (a != b);
+}
+
+int _longlt(long double a, long double b) {
+	return (a < b);
+}
+
+int _longgt(long double a, long double b) {
+	return (a > b);
+}
+
+int _longle(long double a, long double b) {
+	return (a <= b);
+}
+
+int _longge(long double a, long double b) {
+	return (a >= b);
+}
+
+
+float _floatadd(float a, float b) {
+	//return a + b
+	return _mca_sbin(a, b,(mpfr_bin)MP_ADD);
+}
+
+float _floatsub(float a, float b) {
+	//return a - b
+	return _mca_sbin(a, b, (mpfr_bin)MP_SUB);
+}
+
+float _floatmul(float a, float b) {
+	//return a * b
+	return _mca_sbin(a, b, (mpfr_bin)MP_MUL);
+}
+
+float _floatdiv(float a, float b) {
+	//return a / b
+	return _mca_sbin(a, b, (mpfr_bin)MP_DIV);
+}
+
+float _floatneg(float a) {
+	//return -a
+	return _mca_sunr(a, (mpfr_unr)MP_NEG);
+}
+
+double _doubleadd(double a, double b) {
+	//return a + b
+	return _mca_dbin(a, b, (mpfr_bin)MP_ADD);
+}
+
+double _doublesub(double a, double b) {
+	//return a - b
+	return _mca_dbin(a, b, (mpfr_bin)MP_SUB);
+}
+
+double _doublemul(double a, double b) {
+	//return a * b
+	return _mca_dbin(a, b, (mpfr_bin)MP_MUL);
+}
+
+double _doublediv(double a, double b) {
+	//return a / b
+	return _mca_dbin(a, b, (mpfr_bin)MP_DIV);
+}
+
+double _doubleneg(double a) {
+	//return -a
+	return _mca_dunr(a, (mpfr_unr)MP_NEG);
+}
+
+long double _longadd(long double a, long double b) {
+	long double ret = a + b;
+	return ret;
+}
+
+long double _longsub(long double a, long double b) {
+	long double ret = a - b;
+	return ret;
+}
+
+long double _longmul(long double a, long double b) {
+	long double ret = a * b;
+	return ret;
+}
+
+long double _longdiv(long double a, long double b) {
+	long double ret = a / b;
+	return ret;
+}
+
+long double _longneg(long double a) {
+	long double ret = -a;
+	return ret;
+}

--- a/src/mcalib/mcalib.h
+++ b/src/mcalib/mcalib.h
@@ -1,0 +1,78 @@
+// The Monte Carlo Arihmetic Library - A tool for automated rounding error
+// analysis of floating point software. Copyright (C) 2014 The Computer
+// Engineering Laboratory, The University of Sydney. Maintained by Michael
+// Frechtling:
+// 
+// 	michael.frechtling@sydney.edu.au
+// 
+// This file is part of the Monte Carlo Arithmetic Library, (MCALIB). MCALIB is
+// free software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+// 
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef MCALIB
+#define MCALIB
+
+#define MP_ADD &mpfr_add
+#define MP_SUB &mpfr_sub
+#define MP_MUL &mpfr_mul
+#define MP_DIV &mpfr_div
+#define MP_NEG &mpfr_neg
+
+#define MCALIB_IEEE	0
+#define MCALIB_MCA 	1
+#define MCALIB_PB 	2
+#define MCALIB_RR	3
+
+extern int MCALIB_OP_TYPE;
+extern int MCALIB_T;
+
+extern void _mca_seed(void);
+
+extern int _floateq(float a, float b);
+extern int _floatne(float a, float b);
+extern int _floatlt(float a, float b);
+extern int _floatgt(float a, float b);
+extern int _floatle(float a, float b);
+extern int _floatge(float a, float b);
+
+extern int _doubleeq(double a, double b);
+extern int _doublene(double a, double b);
+extern int _doublelt(double a, double b);
+extern int _doublegt(double a, double b);
+extern int _doublele(double a, double b);
+extern int _doublege(double a, double b);
+
+extern int _longeq(long double a, long double b);
+extern int _longne(long double a, long double b);
+extern int _longlt(long double a, long double b);
+extern int _longgt(long double a, long double b);
+extern int _longle(long double a, long double b);
+extern int _longge(long double a, long double b);
+
+extern float _floatadd(float a, float b);
+extern float _floatsub(float a, float b);
+extern float _floatmul(float a, float b);
+extern float _floatdiv(float a, float b);
+extern float _floatneg(float a);
+
+extern double _doubleadd(double a, double b);
+extern double _doublesub(double a, double b);
+extern double _doublemul(double a, double b);
+extern double _doublediv(double a, double b);
+extern double _doubleneg(double a);
+
+extern long double _longadd(long double a, long double b);
+extern long double _longsub(long double a, long double b);
+extern long double _longmul(long double a, long double b);
+extern long double _longdiv(long double a, long double b);
+extern long double _longneg(long double a);
+#endif 

--- a/src/mcalib/mcalib_types.h
+++ b/src/mcalib/mcalib_types.h
@@ -1,0 +1,49 @@
+// The Monte Carlo Arihmetic Library - A tool for automated rounding error
+// analysis of floating point software. Copyright (C) 2014 The Computer
+// Engineering Laboratory, The University of Sydney. Maintained by Michael
+// Frechtling:
+// 
+// 	michael.frechtling@sydney.edu.au
+// 
+// This file is part of the Monte Carlo Arithmetic Library, (MCALIB). MCALIB is
+// free software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+// 
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef MCALIB_TYPES
+#define MCALIB_TYPES
+#include "mpfr.h"
+#include "stdio.h"
+#include "math.h"
+#include "stdlib.h"
+#include <sys/time.h>
+
+#define MCALIB_IEEE 	0
+#define MCALIB_MCA 	1
+#define MCALIB_PB	2
+#define MCALIB_RR	3
+
+#define MP_ADD &mpfr_add
+#define MP_SUB &mpfr_sub
+#define MP_MUL &mpfr_mul
+#define MP_DIV &mpfr_div
+#define MP_NEG &mpfr_neg
+
+typedef int (*mpfr_bin)(mpfr_t, mpfr_t, mpfr_t, mpfr_rnd_t);
+typedef int (*mpfr_unr)(mpfr_t, mpfr_t, mpfr_rnd_t);
+
+extern float _mca_sbin(float a, float b, mpfr_bin mpfr_op);
+extern float _mca_sunr(float a, mpfr_unr mpfr_op);
+extern int _mca_scmp(float a, float b);
+extern double _mca_dbin(double a, double b, mpfr_bin mpfr_op);
+extern double _mca_dunr(double a, mpfr_unr mpfr_op);
+extern int _mca_dcmp(double a, double b);
+#endif

--- a/src/mcalib/tinymt64.c
+++ b/src/mcalib/tinymt64.c
@@ -1,0 +1,130 @@
+/**
+ * @file tinymt64.c
+ *
+ * @brief 64-bit Tiny Mersenne Twister only 127 bit internal state
+ *
+ * @author Mutsuo Saito (Hiroshima University)
+ * @author Makoto Matsumoto (The University of Tokyo)
+ *
+ * Copyright (C) 2011 Mutsuo Saito, Makoto Matsumoto,
+ * Hiroshima University and The University of Tokyo.
+ * All rights reserved.
+ *
+ * The 3-clause BSD License is applied to this software, see
+ * LICENSE.txt
+ */
+#include "tinymt64.h"
+
+#define MIN_LOOP 8
+
+/**
+ * This function represents a function used in the initialization
+ * by init_by_array
+ * @param[in] x 64-bit integer
+ * @return 64-bit integer
+ */
+static uint64_t ini_func1(uint64_t x) {
+    return (x ^ (x >> 59)) * UINT64_C(2173292883993);
+}
+
+/**
+ * This function represents a function used in the initialization
+ * by init_by_array
+ * @param[in] x 64-bit integer
+ * @return 64-bit integer
+ */
+static uint64_t ini_func2(uint64_t x) {
+    return (x ^ (x >> 59)) * UINT64_C(58885565329898161);
+}
+
+/**
+ * This function certificate the period of 2^127-1.
+ * @param random tinymt state vector.
+ */
+static void period_certification(tinymt64_t * random) {
+    if ((random->status[0] & TINYMT64_MASK) == 0 &&
+	random->status[1] == 0) {
+	random->status[0] = 'T';
+	random->status[1] = 'M';
+    }
+}
+
+/**
+ * This function initializes the internal state array with a 64-bit
+ * unsigned integer seed.
+ * @param random tinymt state vector.
+ * @param seed a 64-bit unsigned integer used as a seed.
+ */
+void tinymt64_init(tinymt64_t * random, uint64_t seed) {
+    int i;
+    random->status[0] = seed ^ ((uint64_t)random->mat1 << 32);
+    random->status[1] = random->mat2 ^ random->tmat;
+    for (i = 1; i < MIN_LOOP; i++) {
+	random->status[i & 1] ^= i + UINT64_C(6364136223846793005)
+	    * (random->status[(i - 1) & 1]
+	       ^ (random->status[(i - 1) & 1] >> 62));
+    }
+    period_certification(random);
+}
+
+/**
+ * This function initializes the internal state array,
+ * with an array of 64-bit unsigned integers used as seeds
+ * @param random tinymt state vector.
+ * @param init_key the array of 64-bit integers, used as a seed.
+ * @param key_length the length of init_key.
+ */
+void tinymt64_init_by_array(tinymt64_t * random, const uint64_t init_key[],
+			    int key_length) {
+    const int lag = 1;
+    const int mid = 1;
+    const int size = 4;
+    int i, j;
+    int count;
+    uint64_t r;
+    uint64_t st[4];
+
+    st[0] = 0;
+    st[1] = random->mat1;
+    st[2] = random->mat2;
+    st[3] = random->tmat;
+    if (key_length + 1 > MIN_LOOP) {
+	count = key_length + 1;
+    } else {
+	count = MIN_LOOP;
+    }
+    r = ini_func1(st[0] ^ st[mid % size]
+		  ^ st[(size - 1) % size]);
+    st[mid % size] += r;
+    r += key_length;
+    st[(mid + lag) % size] += r;
+    st[0] = r;
+    count--;
+    for (i = 1, j = 0; (j < count) && (j < key_length); j++) {
+	r = ini_func1(st[i] ^ st[(i + mid) % size] ^ st[(i + size - 1) % size]);
+	st[(i + mid) % size] += r;
+	r += init_key[j] + i;
+	st[(i + mid + lag) % size] += r;
+	st[i] = r;
+	i = (i + 1) % size;
+    }
+    for (; j < count; j++) {
+	r = ini_func1(st[i] ^ st[(i + mid) % size] ^ st[(i + size - 1) % size]);
+	st[(i + mid) % size] += r;
+	r += i;
+	st[(i + mid + lag) % size] += r;
+	st[i] = r;
+	i = (i + 1) % size;
+    }
+    for (j = 0; j < size; j++) {
+	r = ini_func2(st[i] + st[(i + mid) % size] + st[(i + size - 1) % size]);
+	st[(i + mid) % size] ^= r;
+	r -= i;
+	st[(i + mid + lag) % size] ^= r;
+	st[i] = r;
+	i = (i + 1) % size;
+    }
+    random->status[0] = st[0] ^ st[1];
+    random->status[1] = st[2] ^ st[3];
+    period_certification(random);
+}

--- a/src/mcalib/tinymt64.h
+++ b/src/mcalib/tinymt64.h
@@ -1,0 +1,218 @@
+#ifndef TINYMT64_H
+#define TINYMT64_H
+/**
+ * @file tinymt64.h
+ *
+ * @brief Tiny Mersenne Twister only 127 bit internal state
+ *
+ * @author Mutsuo Saito (Hiroshima University)
+ * @author Makoto Matsumoto (The University of Tokyo)
+ *
+ * Copyright (C) 2011 Mutsuo Saito, Makoto Matsumoto,
+ * Hiroshima University and The University of Tokyo.
+ * All rights reserved.
+ *
+ * The 3-clause BSD License is applied to this software, see
+ * LICENSE.txt
+ */
+
+#include <stdint.h>
+#include <inttypes.h>
+
+#define TINYMT64_MEXP 127
+#define TINYMT64_SH0 12
+#define TINYMT64_SH1 11
+#define TINYMT64_SH8 8
+#define TINYMT64_MASK UINT64_C(0x7fffffffffffffff)
+#define TINYMT64_MUL (1.0 / 9007199254740992.0)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * tinymt64 internal state vector and parameters
+ */
+struct TINYMT64_T {
+    uint64_t status[2];
+    uint32_t mat1;
+    uint32_t mat2;
+    uint64_t tmat;
+};
+
+typedef struct TINYMT64_T tinymt64_t;
+
+void tinymt64_init(tinymt64_t * random, uint64_t seed);
+void tinymt64_init_by_array(tinymt64_t * random, const uint64_t init_key[],
+			    int key_length);
+
+#if defined(__GNUC__)
+/**
+ * This function always returns 127
+ * @param random not used
+ * @return always 127
+ */
+inline static int tinymt64_get_mexp(
+    tinymt64_t * random  __attribute__((unused))) {
+    return TINYMT64_MEXP;
+}
+#else
+inline static int tinymt64_get_mexp(tinymt64_t * random) {
+    return TINYMT64_MEXP;
+}
+#endif
+
+/**
+ * This function changes internal state of tinymt64.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ */
+inline static void tinymt64_next_state(tinymt64_t * random) {
+    uint64_t x;
+
+    random->status[0] &= TINYMT64_MASK;
+    x = random->status[0] ^ random->status[1];
+    x ^= x << TINYMT64_SH0;
+    x ^= x >> 32;
+    x ^= x << 32;
+    x ^= x << TINYMT64_SH1;
+    random->status[0] = random->status[1];
+    random->status[1] = x;
+    random->status[0] ^= -((int64_t)(x & 1)) & random->mat1;
+    random->status[1] ^= -((int64_t)(x & 1)) & (((uint64_t)random->mat2) << 32);
+}
+
+/**
+ * This function outputs 64-bit unsigned integer from internal state.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ * @return 64-bit unsigned pseudorandom number
+ */
+inline static uint64_t tinymt64_temper(tinymt64_t * random) {
+    uint64_t x;
+#if defined(LINEARITY_CHECK)
+    x = random->status[0] ^ random->status[1];
+#else
+    x = random->status[0] + random->status[1];
+#endif
+    x ^= random->status[0] >> TINYMT64_SH8;
+    x ^= -((int64_t)(x & 1)) & random->tmat;
+    return x;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ * @return floating point number r (1.0 <= r < 2.0)
+ */
+inline static double tinymt64_temper_conv(tinymt64_t * random) {
+    uint64_t x;
+    union {
+	uint64_t u;
+	double d;
+    } conv;
+#if defined(LINEARITY_CHECK)
+    x = random->status[0] ^ random->status[1];
+#else
+    x = random->status[0] + random->status[1];
+#endif
+    x ^= random->status[0] >> TINYMT64_SH8;
+    conv.u = ((x ^ (-((int64_t)(x & 1)) & random->tmat)) >> 12)
+	| UINT64_C(0x3ff0000000000000);
+    return conv.d;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * Users should not call this function directly.
+ * @param random tinymt internal status
+ * @return floating point number r (1.0 < r < 2.0)
+ */
+inline static double tinymt64_temper_conv_open(tinymt64_t * random) {
+    uint64_t x;
+    union {
+	uint64_t u;
+	double d;
+    } conv;
+#if defined(LINEARITY_CHECK)
+    x = random->status[0] ^ random->status[1];
+#else
+    x = random->status[0] + random->status[1];
+#endif
+    x ^= random->status[0] >> TINYMT64_SH8;
+    conv.u = ((x ^ (-((int64_t)(x & 1)) & random->tmat)) >> 12)
+	| UINT64_C(0x3ff0000000000001);
+    return conv.d;
+}
+
+/**
+ * This function outputs 64-bit unsigned integer from internal state.
+ * @param random tinymt internal status
+ * @return 64-bit unsigned integer r (0 <= r < 2^64)
+ */
+inline static uint64_t tinymt64_generate_uint64(tinymt64_t * random) {
+    tinymt64_next_state(random);
+    return tinymt64_temper(random);
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using multiplying by (1 / 2^53).
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 <= r < 1.0)
+ */
+inline static double tinymt64_generate_double(tinymt64_t * random) {
+    tinymt64_next_state(random);
+    return (tinymt64_temper(random) >> 11) * TINYMT64_MUL;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using union trick.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 <= r < 1.0)
+ */
+inline static double tinymt64_generate_double01(tinymt64_t * random) {
+    tinymt64_next_state(random);
+    return tinymt64_temper_conv(random) - 1.0;
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using union trick.
+ * @param random tinymt internal status
+ * @return floating point number r (1.0 <= r < 2.0)
+ */
+inline static double tinymt64_generate_double12(tinymt64_t * random) {
+    tinymt64_next_state(random);
+    return tinymt64_temper_conv(random);
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using union trick.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 < r <= 1.0)
+ */
+inline static double tinymt64_generate_doubleOC(tinymt64_t * random) {
+    tinymt64_next_state(random);
+    return 2.0 - tinymt64_temper_conv(random);
+}
+
+/**
+ * This function outputs floating point number from internal state.
+ * This function is implemented using union trick.
+ * @param random tinymt internal status
+ * @return floating point number r (0.0 < r < 1.0)
+ */
+inline static double tinymt64_generate_doubleOO(tinymt64_t * random) {
+    tinymt64_next_state(random);
+    return tinymt64_temper_conv_open(random) - 1.0;
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -9,6 +9,7 @@ import subprocess
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 libmcainstrument = PROJECT_ROOT + '/src/libmcainstrument/.libs/libmcainstrument.so'
+mcalib_dir = PROJECT_ROOT + '/src/mcalib/.libs/'
 mcawrapper = PROJECT_ROOT + '/src/mcawrapper/mcawrapper.c'
 llvm_bindir = "@LLVM_BINDIR@"
 clang = llvm_bindir + '/clang'
@@ -55,11 +56,12 @@ def linker_mode(sources, options, output):
     shell('{clang} -c -o .mcawrapper.o {mcawrapper}'.format(
         clang=clang,
         mcawrapper=mcawrapper))
-    shell('{linker} {output} {options} {sources} .mcawrapper.o -lmca -lgfortran'.format(
+    shell('{linker} {output} {options} {sources} .mcawrapper.o -rpath {mcalib_dir} -L {mcalib_dir} -lmca -lgfortran'.format(
         linker=clang,
         output=output,
         sources=' '.join([os.path.splitext(s)[0]+'.o' for s in sources]),
-        options=options))
+        options=options,
+        mcalib_dir = mcalib_dir))
 
 def compiler_mode(sources, options, output, args):
     for source in sources:

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -9,7 +9,7 @@ import subprocess
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 libmcainstrument = PROJECT_ROOT + '/src/libmcainstrument/.libs/libmcainstrument.so'
-mcalib_dir = PROJECT_ROOT + '/src/mcalib/.libs/'
+mcalib_dir = PROJECT_ROOT + '/src/mcalib/'
 mcawrapper = PROJECT_ROOT + '/src/mcawrapper/mcawrapper.c'
 llvm_bindir = "@LLVM_BINDIR@"
 clang = llvm_bindir + '/clang'
@@ -53,15 +53,16 @@ def shell(cmd):
         fail('command failed:\n' + cmd)
 
 def linker_mode(sources, options, output):
-    shell('{clang} -c -o .mcawrapper.o {mcawrapper}'.format(
+    shell('{clang} -c -o .mcawrapper.o {mcawrapper} -I {mcalib_dir}'.format(
         clang=clang,
-        mcawrapper=mcawrapper))
-    shell('{linker} {output} {options} {sources} .mcawrapper.o -rpath {mcalib_dir} -L {mcalib_dir} -lmca -lgfortran'.format(
+        mcawrapper=mcawrapper,
+        mcalib_dir=mcalib_dir))
+    shell('{linker} {output} {options} {sources} .mcawrapper.o -rpath {mcalib_dir}/.libs -L {mcalib_dir}/.libs -lmca -lgfortran'.format(
         linker=clang,
         output=output,
         sources=' '.join([os.path.splitext(s)[0]+'.o' for s in sources]),
         options=options,
-        mcalib_dir = mcalib_dir))
+        mcalib_dir=mcalib_dir))
 
 def compiler_mode(sources, options, output, args):
     for source in sources:


### PR DESCRIPTION
The default libc RNG used in mcalib was not reentrant and caused problems when intrumenting programs also using libc `rand()` and `srand()`.
    
It is better to use a reentrant RNG in mcalib, also the new RNG is fast and of much better quality.
    
Finally we seed it not only with the current time, but also with the pid, to eventually cope with parallel simulations: we guarantee that simultaneously launched processes have different starting seeds.
