### PR TITLE
Control MCA parameters through environement vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ If you only wish to instrument a specific function in your program, use the
    $ verificarlo *.c -o ./program --function=specificfunction
 ```
 
+## MCA Configuration Parameters
+
+Two environement variables control the Montecarlo Arithmetic parameters.
+
+The environement variable `VERIFICARLO_MCAMODE` controls the arithmetic error
+mode. It accepts the following values:
+
+ * `MCA`: (default mode) Montecarlo Arithmetic with inbound and outbound errors
+ * `IEEE`: the program uses standard IEEE arithmetic, no errors are introduced
+ * `PB`: Precision Bounding inbound errors only
+ * `RR`: Random Rounding outbound errors only
+
+The environement variable `VERIFICARLO_PRECISION` controls the virtual
+precision used for the floating point operations. It accept an integer value
+that represents the number of significant digits. The default value is 23.
+
 ### Examples
 
 The `tests/` directory contains various examples of Verificarlo usage.

--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AC_FUNC_MALLOC
 AC_FUNC_MKTIME
 AC_FUNC_REALLOC
 
-AC_CHECK_FUNCS([atexit floor gettimeofday getpid memset mkdir pow sqrt strchr strdup strerror strrchr strstr strtoul tzset utime])
+AC_CHECK_FUNCS([atexit floor getenv gettimeofday getpid memset mkdir pow sqrt strchr strdup strerror strrchr strstr strtol tzset utime])
 
 # Check for Python 2.7
 

--- a/src/mcawrapper/mcawrapper.c
+++ b/src/mcawrapper/mcawrapper.c
@@ -1,10 +1,59 @@
+#include<mcalib.h>
+#include<errno.h>
 #include<stdio.h>
-#include <mcalib.h>
+#include<stdlib.h>
+#include<string.h>
+
+#define VERIFICARLO_PRECISION "VERIFICARLO_PRECISION"
+#define VERIFICARLO_MCAMODE "VERIFICARLO_MCAMODE"
+#define VERIFICARLO_PRECISION_DEFAULT 24
+#define VERIFICARLO_MCAMODE_DEFAULT MCALIB_MCA
+
 __attribute__((constructor)) void begin (void)
 {
     _mca_seed();
-    MCALIB_T = 40;
-    MCALIB_OP_TYPE = MCALIB_MCA;
+
+    char * endptr;
+
+    /* Set default values for MCALIB*/
+
+    MCALIB_T = VERIFICARLO_PRECISION_DEFAULT;
+    MCALIB_OP_TYPE = VERIFICARLO_MCAMODE_DEFAULT;
+
+    /* If VERIFICARLO_PRECISION is set, try to parse it */
+    char * precision = getenv(VERIFICARLO_PRECISION);
+    if (precision != NULL) {
+        errno = 0;
+        int val = strtol(precision, &endptr, 10);
+        if (errno != 0 || val <= 0) {
+            /* Invalid value provided */
+            fprintf(stderr, VERIFICARLO_PRECISION
+                   " invalid value provided, defaulting to default\n");
+        } else {
+            MCALIB_T = val;
+        }
+    }
+
+     /* If VERIFICARLO_MCAMODE is set, try to parse it */
+    char * mode = getenv(VERIFICARLO_MCAMODE);
+    if (mode != NULL) {
+        if (strcmp("IEEE", mode) == 0) {
+            MCALIB_OP_TYPE = MCALIB_IEEE;
+        }
+        else if (strcmp("MCA", mode) == 0) {
+            MCALIB_OP_TYPE = MCALIB_MCA;
+        }
+        else if (strcmp("PB", mode) == 0) {
+            MCALIB_OP_TYPE = MCALIB_PB;
+        }
+        else if (strcmp("RR", mode) == 0) {
+            MCALIB_OP_TYPE = MCALIB_RR;
+        } else {
+            /* Invalid value provided */
+            fprintf(stderr, VERIFICARLO_MCAMODE
+                   " invalid value provided, defaulting to default\n");
+        }
+    }
 }
 
 typedef double double2 __attribute__((ext_vector_type(2)));


### PR DESCRIPTION
The environment variable `VERIFICARLO_MCAMODE` controls the arithmetic error
mode. It accepts the following values:

 * `MCA`: (default mode) Montecarlo Arithmetic with inbound and outbound errors
 * `IEEE`: the program uses standard IEEE arithmetic, no errors are introduced
 * `PB`: Precision Bounding inbound errors only
 * `RR`: Random Rounding outbound errors only

The environment variable `VERIFICARLO_PRECISION` controls the virtual
precision used for the floating point operations. It accept an integer value
that represents the number of significant digits. The default value is 23.

