### PR TITLE
Add support for selecting MCA backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Verificarlo
+## Verificarlo v0.0.2
 
 [![Build Status](https://travis-ci.org/verificarlo/verificarlo.svg?branch=master)](https://travis-ci.org/verificarlo/verificarlo)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ The environement variable `VERIFICARLO_PRECISION` controls the virtual
 precision used for the floating point operations. It accept an integer value
 that represents the number of significant digits. The default value is 53.
 
+Verificarlo supports two MCA backends. The environement variable
+`VERIFICARLO_BACKEND` is used to select the backend. It can be set to `QUAD` or
+`MPFR`
+
+The default backend, MPFR, uses the GNU multiple precision library to compute
+MCA operations. It is heavily based on mcalib MPFR backend.
+
+Verificarlo offers an alternative MCA backend: the QUAD backend. QUAD backend
+uses the GCC quad types to compute MCA operations on doubles and the double type
+to compute MCA operations on floats. It is much faster than the MPFR backend,
+but is very recent and still experimental.
+
 ### Examples
 
 The `tests/` directory contains various examples of Verificarlo usage.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([verificarlo], [0.0.1], [])
+AC_INIT([verificarlo], [0.0.2], [])
 AM_SILENT_RULES([yes])
 AC_CONFIG_AUX_DIR(autoconf)
 AC_CONFIG_MACRO_DIR([m4])

--- a/src/vfcwrapper/vfcwrapper.c
+++ b/src/vfcwrapper/vfcwrapper.c
@@ -34,12 +34,16 @@
 
 #define VERIFICARLO_PRECISION "VERIFICARLO_PRECISION"
 #define VERIFICARLO_MCAMODE "VERIFICARLO_MCAMODE"
+#define VERIFICARLO_BACKEND "VERIFICARLO_BACKEND"
 #define VERIFICARLO_PRECISION_DEFAULT 53
-#define VERIFICARLO_MCAMODE_DEFAULT MCAMODE_MCA;
+#define VERIFICARLO_MCAMODE_DEFAULT MCAMODE_MCA
+#define VERIFICARLO_BACKEND_DEFAULT MCABACKEND_QUAD
+
 
 /* Set default values for MCA*/
 int verificarlo_precision = VERIFICARLO_PRECISION_DEFAULT;
 int verificarlo_mcamode = VERIFICARLO_MCAMODE_DEFAULT;
+int verificarlo_backend = VERIFICARLO_BACKEND_DEFAULT;
 
 /* This is the vtable for the current MCA backend */
 struct mca_interface_t _vfc_current_mca_interface;
@@ -73,11 +77,13 @@ int vfc_set_precision_and_mode(unsigned int precision, int mode) {
     verificarlo_precision = precision;
     verificarlo_mcamode = mode;
 
-    /* For now only one backend is used. When multiple backend
-       exists, here we will select the appropriate backend depending
-       on the required precision */
-    //vfc_select_interface_mpfr();
-    vfc_select_interface_quad();	
+    /* Choose the required backend */
+    if (verificarlo_backend == MCABACKEND_MPFR) {
+      vfc_select_interface_mpfr();
+    }
+    else {
+      vfc_select_interface_quad();
+    }
     return 0;
 }
 
@@ -120,6 +126,21 @@ static void vfc_init (void)
             fprintf(stderr, VERIFICARLO_MCAMODE
                    " invalid value provided, defaulting to default\n");
         }
+    }
+
+    /* If VERIFICARLO_BACKEND is set, try to parse it */
+    char * backend = getenv(VERIFICARLO_BACKEND);
+    if (backend != NULL) {
+      if (strcmp("QUAD", backend) == 0) {
+        verificarlo_backend = MCABACKEND_QUAD;
+      }
+      else if (strcmp("MPFR", backend) == 0) {
+        verificarlo_backend = MCABACKEND_MPFR;
+      } else {
+        /* Invalid value provided */
+        fprintf(stderr, VERIFICARLO_BACKEND
+                " invalid value provided, defaulting to default\n");
+      }
     }
 
     /* seed the backends */

--- a/src/vfcwrapper/vfcwrapper.h
+++ b/src/vfcwrapper/vfcwrapper.h
@@ -27,6 +27,10 @@
 #define MCAMODE_PB   2
 #define MCAMODE_RR   3
 
+/* define the available MCA backends */
+#define MCABACKEND_QUAD 0
+#define MCABACKEND_MPFR 1
+
 /* seeds all the MCA backends */
 void vfc_seed(void);
 

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -7,6 +7,7 @@ import os
 import sys
 import subprocess
 
+PACKAGE_STRING = "@PACKAGE_STRING@"
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 libvfcinstrument = PROJECT_ROOT + '/src/libvfcinstrument/.libs/libvfcinstrument.so'
 mcalib_static = "{0}/src/libmca-mpfr/.libs/libmcampfr.a {0}/src/libmca-quad/.libs/libmcaquad.a".format(PROJECT_ROOT) 
@@ -132,6 +133,7 @@ if __name__ == "__main__":
     parser.add_argument('-o', metavar='file', help='write output to <file>')
     parser.add_argument('--function', metavar='function', help='only instrument <function>')
     parser.add_argument('-static', '--static', action='store_true', help='produce a static binary')
+    parser.add_argument('--version', action='version', version=PACKAGE_STRING)
     args, other = parser.parse_known_args()
 
     sources, llvm_options = parse_extra_args(other)


### PR DESCRIPTION
Add support for selecting MCA backend.

Add support for printing version number.

Bump to version 0.0.2

Default backend is MPFR until we add some tests for QUAD backend.