### PR TITLE
Avoid collision in MCA backend

### DIFF
--- a/src/libmca-mpfr/mcalib.c
+++ b/src/libmca-mpfr/mcalib.c
@@ -44,8 +44,8 @@
 #include "../common/mca_const.h"
 
 
-int 	MCALIB_OP_TYPE 		= MCAMODE_IEEE;
-int 	MCALIB_T		    = 53;
+static int 	MCALIB_OP_TYPE 		= MCAMODE_IEEE;
+static int 	MCALIB_T		    = 53;
 
 #define MP_ADD &mpfr_add
 #define MP_SUB &mpfr_sub

--- a/src/libmca-quad/mcalib.c
+++ b/src/libmca-quad/mcalib.c
@@ -47,8 +47,8 @@
 #include "../common/tinymt64.h"
 #include "../common/mca_const.h"
 
-int 	MCALIB_OP_TYPE 		= MCAMODE_IEEE;
-int 	MCALIB_T		    = 53;
+static int 	MCALIB_OP_TYPE 		= MCAMODE_IEEE;
+static int 	MCALIB_T		    = 53;
 
 //possible op values
 #define MCA_ADD 1

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -63,7 +63,7 @@ def linker_mode(sources, options, output, args):
         mcalib_includes=' '.join(["-I " + d for d in mcalib_dirs])))
 
     if args.static:
-        shell('{linker} {output} {options} {sources} -static .vfcwrapper.o {mcalib_static} -lmpfr -lgmp -lm -lgfortran'.format(
+        shell('{linker} {output} {options} {sources} -static .vfcwrapper.o {mcalib_static} -lmpfr -lgmp -lgfortran -lm'.format(
             linker=clang,
             output=output,
             sources=' '.join([os.path.splitext(s)[0]+'.o' for s in sources]),


### PR DESCRIPTION
 * declare MCALIB_T, MCALIB_OP_T as static
 * fix order between libmath and libfortran

Signed-off-by: Pablo de Oliveira <pablo@sifflez.org>