### PR TITLE
Add and document --without-dragonegg configure flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A tool for automatic Montecarlo Arithmetic analysis.
 Please ensure that Verificarlo's dependencies are installed on your system:
 
   * GNU mpfr library http://www.mpfr.org/
-  * LLVM, clang and opt 3.3 or 3.4, http://clang.llvm.org/
+  * LLVM, clang and opt 3.3, 3.4 or 3.5, http://clang.llvm.org/
   * gcc, gfortran and dragonegg (for Fortran support), http://dragonegg.llvm.org/
   * python, version >= 2.7
   * autotools (automake, autoconf)
@@ -19,6 +19,14 @@ Then run the following command inside verificarlo directory:
 ```bash
    $ ./autogen.sh
    $ ./configure
+   $ make
+```
+
+If you do not care about Fortran support, you can avoid installing gfortran and dragonegg, by passing the option `--without-dragonegg` to `configure`:
+
+```bash
+   $ ./autogen.sh
+   $ ./configure --without-dragonegg
    $ make
 ```
 
@@ -38,6 +46,7 @@ verificarlo works as expected on your system:
    $ make check
 ```
 
+If you disable dragonegg support during configure, fortran_test will fail.
 
 For example on an x86_64 Ubuntu 14.04 release, you should use the following
 install procedure:

--- a/configure.ac
+++ b/configure.ac
@@ -19,24 +19,29 @@ AC_PROG_MAKE_SET
 AC_PROG_CC([gcc])
 AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path (for dragonegg and replay linking)])
 AC_SUBST(GCC_PATH, $CC)
-AX_LLVM([3.3],[all])
+AX_LLVM([3.3],[3.5.2],[all])
+
 AC_CHECK_LIB([c], [exit], , AC_MSG_ERROR([Could not find c library]))
 AC_CHECK_LIB([gfortran], [exit], , AC_MSG_ERROR([Could not find gfortran library]))
 AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find mpfr library]))
 AC_CHECK_LIB([mpfr], [mpfr_clear], , AC_MSG_ERROR([Could not find mpfr library]))
 
 # Check that the selected GCC is compatible with the selected dragonegg
-AC_MSG_CHECKING([if gcc can compile fortran with dragonegg])
-cat <<EOF >conftest.f90
-module conftest_module
-end module conftest_module
-EOF
-doit='$CC -S -fplugin=$DRAGONEGG_PATH -fplugin-arg-dragonegg-emit-ir conftest.f90'
-if AC_TRY_EVAL(doit); then
-AC_MSG_RESULT([yes])
+if test -z "$DRAGONEGG_PATH"; then
+    AC_MSG_NOTICE([Fortran support disabled.])
 else
-AC_MSG_RESULT([no])
-AC_MSG_ERROR([Your gcc version ($CC) cannot compile Fortran programs with your dragonegg plugin ($DRAGONEGG_PATH)])
+    AC_MSG_CHECKING([if gcc can compile fortran with dragonegg])
+    cat <<EOF >conftest.f90
+    module conftest_module
+    end module conftest_module
+EOF
+    doit='$CC -S -fplugin=$DRAGONEGG_PATH -fplugin-arg-dragonegg-emit-ir conftest.f90'
+    if AC_TRY_EVAL(doit); then
+        AC_MSG_RESULT([yes])
+    else
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([Your gcc version ($CC) cannot compile Fortran programs with your dragonegg plugin ($DRAGONEGG_PATH)])
+    fi
 fi
 
 # Check for header files.

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -28,6 +28,10 @@ class NoPrefixParser(argparse.ArgumentParser):
     def _get_option_tuples(self, option_string):
         return []
 
+def fail(msg):
+    print(sys.argv[0] + ': ' + msg, file=sys.stderr)
+    sys.exit(1)
+
 def is_fortran(name):
     return os.path.splitext(name)[1] in FORTRAN_EXTENSIONS
 
@@ -39,7 +43,12 @@ def parse_extra_args(args):
     options = []
 
     for a in args:
-        if is_fortran(a) or is_c(a):
+        if is_fortran(a):
+	    if not dragonegg:
+		fail("fortran not supported. "
+		     + "--without-fortran was used during configuration.")
+	    sources.append(a)
+	elif is_c(a):
             sources.append(a)
         else:
             options.append(a)


### PR DESCRIPTION
 * llvm 3.5 is now supported
 * --without-dragonegg disables dragonegg dependency but removes fortran support

Fixes #18.