### PR TITLE
Make verificarlo compatible with LLVM up to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 
 install:
   - ./autogen.sh
-  - ./configure --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.6/plugin/dragonegg.so CC=gcc-4.6
+  - ./configure --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.6/plugin/dragonegg.so CC=gcc-4.6 || cat config.log
   - make
 
 script:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A tool for automatic Montecarlo Arithmetic analysis.
 Please ensure that Verificarlo's dependencies are installed on your system:
 
   * GNU mpfr library http://www.mpfr.org/
-  * LLVM, clang and opt 3.3, 3.4 or 3.5, http://clang.llvm.org/
+  * LLVM, clang and opt from 3.3 up to 3.8 (the last version with Fortran support is 3.6), http://clang.llvm.org/
   * gcc, gfortran and dragonegg (for Fortran support), http://dragonegg.llvm.org/
   * python, version >= 2.7
   * autotools (automake, autoconf)

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path (for dragonegg and replay link
 AC_SUBST(GCC_PATH, $CC)
 AX_LLVM([3.3],[3.8.1],[all])
 
-AC_PATH_PROGS([CLANG], [clang "$LLVM_BINDIR"/clang clang-"$LLVM_VERSION_MAJOR"."$LLVM_VERSION_MINOR"], "")
+AC_PATH_PROGS([CLANG], ["$LLVM_BINDIR"/clang clang-"$LLVM_VERSION_MAJOR"."$LLVM_VERSION_MINOR" clang], "")
 if test -z "$CLANG"; then
   AC_MSG_ERROR([Could not find clang])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,14 @@ AC_PROG_MAKE_SET
 AC_PROG_CC([gcc])
 AC_DEFINE_UNQUOTED([GCC_PATH], ["$CC"], [GCC path (for dragonegg and replay linking)])
 AC_SUBST(GCC_PATH, $CC)
-AX_LLVM([3.3],[3.5.2],[all])
+AX_LLVM([3.3],[3.8.1],[all])
+
+AC_PATH_PROGS([CLANG], [clang "$LLVM_BINDIR"/clang clang-"$LLVM_VERSION_MAJOR"."$LLVM_VERSION_MINOR"], "")
+if test -z "$CLANG"; then
+  AC_MSG_ERROR([Could not find clang])
+fi
+AC_DEFINE_UNQUOTED([CLANG_PATH], ["$CLANG"], [CLANG path])
+AC_SUBST(CLANG_PATH, $CLANG)
 
 AC_CHECK_LIB([c], [exit], , AC_MSG_ERROR([Could not find c library]))
 AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find mpfr library]))

--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -59,10 +59,10 @@ AC_DEFUN([AX_LLVM],
   LLVM_VERSION=`$LLVM_CONFIG --version`
   AC_DEFINE_UNQUOTED([LLVM_VERSION], ["$LLVM_VERSION"], [The llvm version])
 
-  LLVM_VERSION_MAJOR=`echo $LLVM_VERSION |cut -d'.' -f1`
+  LLVM_VERSION_MAJOR=`echo $LLVM_VERSION | cut -d'.' -f1 | cut -c 1`
   AC_DEFINE_UNQUOTED([LLVM_VERSION_MAJOR], [$LLVM_VERSION_MAJOR], [The llvm major version])
 
-  LLVM_VERSION_MINOR=`echo $LLVM_VERSION |cut -d'.' -f2`
+  LLVM_VERSION_MINOR=`echo $LLVM_VERSION | cut -d'.' -f2 | cut -c 1`
   AC_DEFINE_UNQUOTED([LLVM_VERSION_MINOR], [$LLVM_VERSION_MINOR], [The llvm minor version])
 
   AC_MSG_CHECKING([for LLVM version])
@@ -82,8 +82,9 @@ AC_DEFUN([AX_LLVM],
 
   LLVM_BINDIR=`$LLVM_CONFIG --bindir`
   AC_DEFINE_UNQUOTED([LLVM_BINDIR], ["$LLVM_BINDIR"], [The llvm bin dir])
-  LLVM_CPPFLAGS=`$LLVM_CONFIG --cxxflags`
-  if test "$LLVM_VERSION_MINOR" = 5; then
+  LLVM_CPPFLAGS=`$LLVM_CONFIG --cxxflags | sed s/-Wcovered-switch-default// | sed s/-Werror=date-time//`
+  AC_DEFINE_UNQUOTED([LLVM_CPPFLAGS], ["$LLVM_CPPFLAGS"], [The llvm CPPFLAGS])
+  if test "$LLVM_VERSION_MINOR" -gt 4; then
     LLVM_LDFLAGS=`$LLVM_CONFIG --system-libs`
   else
     LLVM_LDFLAGS=`$LLVM_CONFIG --ldflags`

--- a/src/libvfcinstrument/libVFCInstrument.cpp
+++ b/src/libvfcinstrument/libVFCInstrument.cpp
@@ -30,7 +30,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 
-#if LLVM_VERSION_MINOR <= 5
+#if LLVM_VERSION_MINOR <= 6
 #define CREATE_CALL2(func, op1, op2) (builder.CreateCall2(func, op1, op2, ""))
 #define CREATE_STRUCT_GEP(i, p) (builder.CreateStructGEP(i, p))
 #else

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -39,7 +39,7 @@ mcalib_dirs = [PROJECT_ROOT + '/src/libmca-mpfr/',
 	       PROJECT_ROOT + '/src/libmca-quad/']
 vfcwrapper = PROJECT_ROOT + '/src/vfcwrapper/vfcwrapper.c'
 llvm_bindir = "@LLVM_BINDIR@"
-clang = llvm_bindir + '/clang'
+clang = '@CLANG_PATH@'
 opt = llvm_bindir + '/opt'
 dragonegg = "@DRAGONEGG_PATH@"
 gcc = "@GCC_PATH@"
@@ -97,34 +97,30 @@ def linker_mode(sources, options, output, args):
     # Only include lgfortran if fortran support is enabled
     gfortran = "-lgfortran" if dragonegg else ""
 
+    f=tempfile.NamedTemporaryFile()
     if args.static:
-        f=tempfile.NamedTemporaryFile()
-        f.write(b'{output} {options} {sources} -static .vfcwrapper.o {mcalib_static} -lmpfr -lgmp {gfortran} -lm'.format(
+        f.write('{output} {options} {sources} -static .vfcwrapper.o {mcalib_static} -lmpfr -lgmp {gfortran} -lm'.format(
             output=output,
             sources=' '.join([os.path.splitext(s)[0]+'.o' for s in sources]),
             options=options,
             mcalib_static=mcalib_static,
             gfortran=gfortran))
-        f.seek(0)
-        shell('clang @'+f.name)
-        f.close()
        
     else:
 	mcalib_options = []
 	for d in mcalib_dirs:
 	    mcalib_options.append("-rpath {0}/.libs -L {0}/.libs".format(d))
-        f=tempfile.NamedTemporaryFile()
-        f.write(b'{output} {options} {sources} .vfcwrapper.o {mcalib_options} {mcalib_dynamic} {gfortran}'.format(
+        f.write('{output} {options} {sources} .vfcwrapper.o {mcalib_options} {mcalib_dynamic} {gfortran}'.format(
             output=output,
             sources=' '.join([os.path.splitext(s)[0]+'.o' for s in sources]),
             options=options,
             mcalib_options=' '.join(mcalib_options),
             mcalib_dynamic=mcalib_dynamic,
             gfortran=gfortran))
-        f.seek(0)
-        shell('clang @'+f.name)
-        f.close()
-       
+
+    f.flush()
+    shell('{clang} @{temp}'.format(clang=clang, temp=f.name))
+    f.close()
 
 def compiler_mode(sources, options, output, args):
     for source in sources:


### PR DESCRIPTION
This pull request makes Verificarlo compatible with LLVM versions up to 3.8 and keeps the code backwards compatible with LLVM versions as old as 3.3.

It also fixes an annoying bug with clang detection on ubuntu and debian systems. Now it should not be necessary anymore to add a symlink to clang when installing verificarlo.