### PR TITLE
Verificarlo can be installed system wide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - ./autogen.sh
   - ./configure --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.6/plugin/dragonegg.so CC=gcc-4.6 || cat config.log
   - make
-  - make install
+  - sudo make install
 
 script:
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - ./autogen.sh
   - ./configure --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.6/plugin/dragonegg.so CC=gcc-4.6 || cat config.log
   - make
+  - make install
 
 script:
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - ./configure --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.6/plugin/dragonegg.so CC=gcc-4.6 || cat config.log
   - make
   - sudo make install
+  - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 script:
   - make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,3 @@
 ACLOCAL_AMFLAGS=-I m4
 SUBDIRS=src/ tests/
+dist_bin_SCRIPTS=verificarlo

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,14 @@
 ACLOCAL_AMFLAGS=-I m4
 SUBDIRS=src/ tests/
 dist_bin_SCRIPTS=verificarlo
+
+
+edit_script = $(SED) -e 's,%LIBDIR%,$(libdir),'g $(NULL)
+
+verificarlo: verificarlo.in Makefile
+	$(AM_V_GEN)rm -f $@ $@.tmp && \
+	$(edit_script) $< >$@.tmp && \
+	chmod a-w $@.tmp && \
+	mv $@.tmp $@
+
+CLEANFILES = verificarlo

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then run the following command inside verificarlo directory:
    $ ./autogen.sh
    $ ./configure
    $ make
-   $ make install
+   $ sudo make install
 ```
 
 If you do not care about Fortran support, you can avoid installing gfortran and dragonegg, by passing the option `--without-dragonegg` to `configure`:
@@ -31,7 +31,7 @@ If you do not care about Fortran support, you can avoid installing gfortran and 
    $ ./autogen.sh
    $ ./configure --without-dragonegg
    $ make
-   $ make install
+   $ sudo make install
 ```
 
 If needed LLVM path, dragonegg path, and gcc path can be configured with the
@@ -64,7 +64,9 @@ install procedure:
    $ ./configure \
        --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.7/plugin/dragonegg.so \
        CC=gcc-4.7
-   $ make && make install && make check
+   $ make 
+   $ sudo make install
+   $ make check
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then run the following command inside verificarlo directory:
    $ ./autogen.sh
    $ ./configure
    $ make
+   $ make install
 ```
 
 If you do not care about Fortran support, you can avoid installing gfortran and dragonegg, by passing the option `--without-dragonegg` to `configure`:
@@ -30,6 +31,7 @@ If you do not care about Fortran support, you can avoid installing gfortran and 
    $ ./autogen.sh
    $ ./configure --without-dragonegg
    $ make
+   $ make install
 ```
 
 If needed LLVM path, dragonegg path, and gcc path can be configured with the
@@ -62,18 +64,14 @@ install procedure:
    $ ./configure \
        --with-dragonegg=/usr/lib/gcc/x86_64-linux-gnu/4.7/plugin/dragonegg.so \
        CC=gcc-4.7
-   $ make && make check
+   $ make && make install && make check
 ```
 
 ### Usage
 
 To automatically instrument a program with Verificarlo you must compile it using
-the `verificarlo` command. First make sure to add the `verificarlo/` root
-directory to your path with
-
-```bash
-   $ export PATH=<verificarlo path>:$PATH
-```
+the `verificarlo` command. First make sure that the verificarlo installation
+directory is in your PATH.
 
 Then you can use the `verificarlo` command to compile your programs. Either modify 
 your makefile to use `verificarlo` as the compiler (`CC=verificarlo` and

--- a/configure.ac
+++ b/configure.ac
@@ -119,8 +119,9 @@ AC_CONFIG_FILES([Makefile
                  src/libvfcinstrument/Makefile
                  src/libmca-mpfr/Makefile
 		 src/libmca-quad/Makefile
+		 src/common/Makefile
                  tests/Makefile])
 
-AC_CONFIG_FILES([verificarlo], [chmod +x verificarlo])
+AC_CONFIG_FILES([verificarlo.in], [])
 
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,3 @@
 SUBDIRS=libvfcinstrument libmca-mpfr libmca-quad
+include_HEADERS=vfcwrapper/vfcwrapper.c vfcwrapper/vfcwrapper.h
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS=libvfcinstrument libmca-mpfr libmca-quad
+SUBDIRS=common libvfcinstrument libmca-mpfr libmca-quad
 include_HEADERS=vfcwrapper/vfcwrapper.c vfcwrapper/vfcwrapper.h
 

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,0 +1,5 @@
+noinst_LTLIBRARIES = libtinymt64.la
+libtinymt64_la_CFLAGS = -fPIC -static
+libtinymt64_la_SOURCES = \
+	tinymt64.h \
+	tinymt64.c

--- a/src/libmca-mpfr/Makefile.am
+++ b/src/libmca-mpfr/Makefile.am
@@ -1,6 +1,7 @@
 lib_LTLIBRARIES = libmcampfr.la
-libmcampfr_la_SOURCES = mcalib.c ../common/tinymt64.c
+libmcampfr_la_SOURCES = mcalib.c
 EXTRA_DIST = libmca-mpfr.h
 libmcampfr_la_LDFLAGS = -lm
+libmcampfr_la_LIBADD = ../common/libtinymt64.la
 library_includedir =$(includedir)/
 library_include_HEADERS = libmca-mpfr.h

--- a/src/libmca-quad/Makefile.am
+++ b/src/libmca-quad/Makefile.am
@@ -1,6 +1,7 @@
 lib_LTLIBRARIES = libmcaquad.la
-libmcaquad_la_SOURCES = mcalib.c ../common/tinymt64.c
+libmcaquad_la_SOURCES = mcalib.c
 EXTRA_DIST = libmca-quad.h
 libmcaquad_la_LDFLAGS = -lm
+libmcaquad_la_LIBADD = ../common/libtinymt64.la
 library_includedir =$(includedir)/
 library_include_HEADERS = libmca-quad.h

--- a/tests/test_backends/test.sh
+++ b/tests/test_backends/test.sh
@@ -27,10 +27,10 @@ Check() {
 
 for op in + "*" ; do
     echo "Checking $op float"
-    ../../verificarlo -D REAL=float -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
+    verificarlo -D REAL=float -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
     Check 24
 
     echo "Checking $op double"
-    ../../verificarlo -D REAL=double -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
+    verificarlo -D REAL=double -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
     Check 53
 done

--- a/tests/test_ffastmath/test.sh
+++ b/tests/test_ffastmath/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Compile program with -O2
-../../verificarlo -O2 test.c -o test
+verificarlo -O2 test.c -o test
 
 echo "z y" > output1
 for i in $(seq 1 30); do
@@ -10,7 +10,7 @@ done
 
 
 # Compile program with -O2 -ffastmath -freciprocalmath
-../../verificarlo -O2 -ffast-math -freciprocal-math test.c -o test
+verificarlo -O2 -ffast-math -freciprocal-math test.c -o test
 
 echo "z y" > output2
 for i in $(seq 1 30); do

--- a/tests/test_fortran/test.sh
+++ b/tests/test_fortran/test.sh
@@ -8,8 +8,8 @@ fi
 
 # Compile newton.f90 using MCA lib instrumentation
 
-../../verificarlo -c newton.f90 -o newton.o
-../../verificarlo newton.o -o newton
+verificarlo -c newton.f90 -o newton.o
+verificarlo newton.o -o newton
 
 # Check that two executions differ
 ./newton > output1

--- a/tests/test_fortran/test.sh
+++ b/tests/test_fortran/test.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if grep "DRAGONEGG_PATH \"\"" ../../config.h > /dev/null; then
+	echo "this test is not run when using --without-dragonegg"
+	exit 0
+fi
+
 # Compile newton.f90 using MCA lib instrumentation
 
 ../../verificarlo -c newton.f90 -o newton.o

--- a/tests/test_kahan/test.sh
+++ b/tests/test_kahan/test.sh
@@ -3,7 +3,7 @@ set -e
 
 export VERIFICARLO_PRECISION=53
 
-../../verificarlo --function sum_kahan -O0 kahan.c -o test
+verificarlo --function sum_kahan -O0 kahan.c -o test
 
 echo "z y" > output1
 for z in 100; do
@@ -14,7 +14,7 @@ for z in 100; do
 done
 
 
-../../verificarlo --function sum_kahan -O3 -ffast-math kahan.c -o test
+verificarlo --function sum_kahan -O3 -ffast-math kahan.c -o test
 
 echo "z y" > output2
 for z in 100; do

--- a/tests/test_per_function/test.sh
+++ b/tests/test_per_function/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-../../verificarlo test.c -o test --function=f
+verificarlo test.c -o test --function=f
 
 export VERIFICARLO_PRECISION=52
 

--- a/tests/test_tchebychev/test.sh
+++ b/tests/test_tchebychev/test.sh
@@ -7,7 +7,7 @@ set -e
 # single precision
 export VERIFICARLO_PRECISION=23
 
-../../verificarlo tchebychev.c -o tchebychev
+verificarlo tchebychev.c -o tchebychev
 
 # Run 15 iterations of tchebychev for all values in [.0:1.0:.01]
 echo "z y" > output

--- a/verificarlo.in
+++ b/verificarlo.in
@@ -32,12 +32,12 @@ import tempfile
 
 PACKAGE_STRING = "@PACKAGE_STRING@"
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
-libvfcinstrument = PROJECT_ROOT + '/src/libvfcinstrument/.libs/libvfcinstrument.so'
-mcalib_static = "{0}/src/libmca-mpfr/.libs/libmcampfr.a {0}/src/libmca-quad/.libs/libmcaquad.a".format(PROJECT_ROOT) 
+libvfcinstrument = PROJECT_ROOT + '/../lib/libvfcinstrument.so'
+mcalib_static = "{0}/../lib/libmcampfr.a {0}/../lib/libmcaquad.a".format(PROJECT_ROOT)
 mcalib_dynamic = "-lmcampfr -lmcaquad"
-mcalib_dirs = [PROJECT_ROOT + '/src/libmca-mpfr/',
-	       PROJECT_ROOT + '/src/libmca-quad/']
-vfcwrapper = PROJECT_ROOT + '/src/vfcwrapper/vfcwrapper.c'
+mcalib_options = "-rpath {0}/../lib/ -L {0}/../lib/".format(PROJECT_ROOT)
+mcalib_includes = PROJECT_ROOT + "/../include/"
+vfcwrapper = mcalib_includes + 'vfcwrapper.c'
 llvm_bindir = "@LLVM_BINDIR@"
 clang = '@CLANG_PATH@'
 opt = llvm_bindir + '/opt'
@@ -89,10 +89,10 @@ def shell(cmd):
         fail('command failed:\n' + cmd)
 
 def linker_mode(sources, options, output, args):
-    shell('{clang} -c -O2 -static -o .vfcwrapper.o {vfcwrapper} {mcalib_includes}'.format(
+    shell('{clang} -c -O2 -static -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
         clang=clang,
         vfcwrapper=vfcwrapper,
-        mcalib_includes=' '.join(["-I " + d for d in mcalib_dirs])))
+        mcalib_includes=mcalib_includes))
 
     # Only include lgfortran if fortran support is enabled
     gfortran = "-lgfortran" if dragonegg else ""
@@ -107,14 +107,11 @@ def linker_mode(sources, options, output, args):
             gfortran=gfortran))
        
     else:
-	mcalib_options = []
-	for d in mcalib_dirs:
-	    mcalib_options.append("-rpath {0}/.libs -L {0}/.libs".format(d))
         f.write('{output} {options} {sources} .vfcwrapper.o {mcalib_options} {mcalib_dynamic} {gfortran}'.format(
             output=output,
             sources=' '.join([os.path.splitext(s)[0]+'.o' for s in sources]),
             options=options,
-            mcalib_options=' '.join(mcalib_options),
+            mcalib_options=mcalib_options,
             mcalib_dynamic=mcalib_dynamic,
             gfortran=gfortran))
 

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -31,12 +31,12 @@ import subprocess
 import tempfile
 
 PACKAGE_STRING = "@PACKAGE_STRING@"
-PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
-libvfcinstrument = PROJECT_ROOT + '/../lib/libvfcinstrument.so'
-mcalib_static = "{0}/../lib/libmcampfr.a {0}/../lib/libmcaquad.a".format(PROJECT_ROOT)
+LIBDIR = "%LIBDIR%"
+libvfcinstrument = LIBDIR + '/libvfcinstrument.so'
+mcalib_static = "{0}/libmcampfr.a {0}/libmcaquad.a".format(LIBDIR)
 mcalib_dynamic = "-lmcampfr -lmcaquad"
-mcalib_options = "-rpath {0}/../lib/ -L {0}/../lib/".format(PROJECT_ROOT)
-mcalib_includes = PROJECT_ROOT + "/../include/"
+mcalib_options = "-rpath {0} -L {0}".format(LIBDIR)
+mcalib_includes = LIBDIR + "/../include/"
 vfcwrapper = mcalib_includes + 'vfcwrapper.c'
 llvm_bindir = "@LLVM_BINDIR@"
 clang = '@CLANG_PATH@'


### PR DESCRIPTION
With this PR verificarlo can (and must) be installed with `make
install`. This is a prerequisite for #12.