### PR TITLE
Verificarlo must be initialized before C++ constructors

### DIFF
--- a/src/libvfcinstrument/libVFCInstrument.cpp
+++ b/src/libvfcinstrument/libVFCInstrument.cpp
@@ -125,8 +125,6 @@ namespace {
 
             mca_interface_type = getMCAInterfaceType();
 
-            StringRef SelectedFunction = StringRef(VfclibInstFunction);
-
             // Find the list of functions to instrument
             // Instrumentation adds stubs to mcalib function which we
             // never want to instrument.  Therefore it is important to

--- a/src/vfcwrapper/vfcwrapper.c
+++ b/src/vfcwrapper/vfcwrapper.c
@@ -94,7 +94,7 @@ int vfc_set_precision_and_mode(unsigned int precision, int mode) {
 }
 
 /* vfc_init is run when loading vfcwrapper and initializes vfc libraries */
-__attribute__((constructor))
+__attribute__((constructor(0)))
 static void vfc_init (void)
 {
     char * endptr;


### PR DESCRIPTION
In some boost codes, C++ constructors use floating point arithmetic
and are called before Verificarlo initialises its instrumentation
vtable; causing a SEGFAULT.

By using high priority in the library constructor we can ensure that
verificarlo is always initialized first.

Thanks to Vincent Picaud for reporting and helping debug the issue.

Fixes #44