### PR TITLE
Fix bug on assert enabled llvm version

### DIFF
--- a/src/libvfcinstrument/libVFCInstrument.cpp
+++ b/src/libvfcinstrument/libVFCInstrument.cpp
@@ -212,6 +212,9 @@ namespace {
                 Instruction *newInst = CREATE_CALL2(hookFunc,
 				                   I->getOperand(0), I->getOperand(1));
 
+		// Remove instruction from parent so it can be
+		// inserted in a new context
+		if (newInst->getParent() != NULL) newInst->removeFromParent();
                 return newInst;
             }
             // For scalar types, we go directly through the struct of pointer function


### PR DESCRIPTION
ReplaceInstWithInst checks that the inserted instruction is parent less. This was causing bugs with source-compiled LLVM versions.