### PR TITLE
Added option for position independent code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ before_install:
   - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get update
-  - sudo apt-get install libmpfr-dev clang-3.5 llvm-3.5 llvm-3.5-dev dragonegg-4.7 gcc-4.7 g++-4.7 gfortran-4.7 libgfortran-4.7-dev autoconf automake build-essential libedit-dev
+  - sudo apt-get install libmpfr-dev clang-3.5 llvm-3.5 llvm-3.5-dev dragonegg-4.7 gcc-4.7 g++-4.7 gfortran-4.7 libgfortran-4.7-dev autoconf automake build-essential libedit-dev python3-dev python3-pip
+  - pip3 install cython
 
 install:
   - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo add-apt-repository ppa:dns/gnu -y
   - sudo apt-get update
   - sudo apt-get install libmpfr-dev clang-3.5 llvm-3.5 llvm-3.5-dev dragonegg-4.7 gcc-4.7 g++-4.7 gfortran-4.7 libgfortran-4.7-dev autoconf automake build-essential libedit-dev python3-dev python3-pip
-  - pip3 install cython
+  - sudo pip3 install cython
 
 install:
   - ./autogen.sh

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ directly:
    $ verificarlo *.c *.f90 -o ./program
 ```
 
+If you are trying to compile a shared library, such as those built by the Cython
+extension to Python, you can then also set the shared linker environment variable
+(`LDSHARED='verificarlo -shared'`) to enable position-independent linking.
+
 If you only wish to instrument a specific function in your program, use the
 `--function` option:
 

--- a/tests/test_cython/setup.py
+++ b/tests/test_cython/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+
+extensions = Extension("test", ["test.pyx"])
+
+setup(name='Test MCA Cython App',
+      ext_modules=cythonize(extensions,
+                            compiler_directives={'language_level': '3'}))

--- a/tests/test_cython/test.pyx
+++ b/tests/test_cython/test.pyx
@@ -1,0 +1,6 @@
+def test_function(int x):
+    cdef double result
+    result = 1.4
+    for i in range(x):
+        result += 0.1
+    print(result)

--- a/tests/test_cython/test.sh
+++ b/tests/test_cython/test.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if python3 -c "import cython" 2>/dev/null; then
+    echo "this test is not running without Cython installed"
+    exit 0
+fi
+
 str="verificarlo"
 
 export CC=$str

--- a/tests/test_cython/test.sh
+++ b/tests/test_cython/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+str="verificarlo"
+
+export CC=$str
+export FC=$str
+export LDSHARED="$str -shared"
+
+# Build library
+python3 setup.py build_ext --inplace
+
+num=200
+# Test build
+python3 -c "from test import test_function as f; f($num)"

--- a/tests/test_cython/test.sh
+++ b/tests/test_cython/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if python3 -c "import cython" 2>/dev/null; then
+if !python3 -c "import cython" 2>/dev/null; then
     echo "this test is not running without Cython installed"
     exit 0
 fi

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -76,9 +76,9 @@ def parse_extra_args(args):
             if not dragonegg:
                 fail("fortran not supported. "
                      + "--without-fortran was used during configuration.")
-                sources.append(a)
-            elif is_c(a):
-                sources.append(a)
+            sources.append(a)
+        elif is_c(a):
+            sources.append(a)
         else:
             options.append(a)
 
@@ -93,8 +93,8 @@ def shell(cmd):
 
 
 def linker_mode(sources, options, output, args):
-    positionmode = "static" if args.static else "fPIC"
-    shell('{clang} -c -O2 -{positionmode} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
+    positionmode = "-static" if args.static else "-fPIC"
+    shell('{clang} -c -O2 {positionmode} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
         clang=clang,
         positionmode=positionmode,
         vfcwrapper=vfcwrapper,

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -44,23 +44,28 @@ clang = '@CLANG_PATH@'
 opt = llvm_bindir + '/opt'
 dragonegg = "@DRAGONEGG_PATH@"
 gcc = "@GCC_PATH@"
-FORTRAN_EXTENSIONS=[".f", ".f90", ".f77"]
-C_EXTENSIONS=[".c", ".cpp", ".cc", ".cxx"]
+FORTRAN_EXTENSIONS = [".f", ".f90", ".f77"]
+C_EXTENSIONS = [".c", ".cpp", ".cc", ".cxx"]
+
 
 class NoPrefixParser(argparse.ArgumentParser):
     # ignore prefix autocompletion of options
     def _get_option_tuples(self, option_string):
         return []
 
+
 def fail(msg):
     print(sys.argv[0] + ': ' + msg, file=sys.stderr)
     sys.exit(1)
 
+
 def is_fortran(name):
     return os.path.splitext(name)[1].lower() in FORTRAN_EXTENSIONS
 
+
 def is_c(name):
     return os.path.splitext(name)[1].lower() in C_EXTENSIONS
+
 
 def parse_extra_args(args):
     sources = []
@@ -68,26 +73,24 @@ def parse_extra_args(args):
 
     for a in args:
         if is_fortran(a):
-	    if not dragonegg:
-		fail("fortran not supported. "
-		     + "--without-fortran was used during configuration.")
-	    sources.append(a)
-	elif is_c(a):
-            sources.append(a)
+            if not dragonegg:
+                fail("fortran not supported. "
+                     + "--without-fortran was used during configuration.")
+                sources.append(a)
+            elif is_c(a):
+                sources.append(a)
         else:
             options.append(a)
 
     return sources, ' '.join(options)
 
-def fail(msg):
-    print(sys.argv[0] + ': ' + msg, file=sys.stderr)
-    sys.exit(1)
 
 def shell(cmd):
     try:
         subprocess.check_call(cmd, shell=True)
     except subprocess.CalledProcessError:
         fail('command failed:\n' + cmd)
+
 
 def linker_mode(sources, options, output, args):
     shell('{clang} -c -O2 -static -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
@@ -98,7 +101,7 @@ def linker_mode(sources, options, output, args):
     # Only include lgfortran if fortran support is enabled
     gfortran = "-lgfortran" if dragonegg else ""
 
-    f=tempfile.NamedTemporaryFile()
+    f = tempfile.NamedTemporaryFile()
     if args.static:
         f.write('{output} {sources} {options} -static .vfcwrapper.o {mcalib_static} -lmpfr -lgmp {gfortran} -lm'.format(
             output=output,
@@ -119,6 +122,7 @@ def linker_mode(sources, options, output, args):
     f.flush()
     shell('{clang} @{temp}'.format(clang=clang, temp=f.name))
     f.close()
+
 
 def compiler_mode(sources, options, output, args):
     for source in sources:
@@ -176,6 +180,7 @@ def compiler_mode(sources, options, output, args):
             output=output,
             ins=ins,
             options=options))
+
 
 if __name__ == "__main__":
     parser = NoPrefixParser(description='Compiles a program replacing floating point operation with calls to the mcalib (Montecarlo Arithmetic).')

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -93,10 +93,10 @@ def shell(cmd):
 
 
 def linker_mode(sources, options, output, args):
-    mode = "static" if args.static else "fPIC"
-    shell('{clang} -c -O2 -{mode} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
+    positionmode = "static" if args.static else "fPIC"
+    shell('{clang} -c -O2 -{positionmode} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
         clang=clang,
-        mode=mode,
+        mode=positionmode,
         vfcwrapper=vfcwrapper,
         mcalib_includes=mcalib_includes))
 

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -93,8 +93,10 @@ def shell(cmd):
 
 
 def linker_mode(sources, options, output, args):
-    shell('{clang} -c -O2 -static -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
+    mode = "static" if args.static else "fPIC"
+    shell('{clang} -c -O2 -{mode} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
         clang=clang,
+        mode=mode,
         vfcwrapper=vfcwrapper,
         mcalib_includes=mcalib_includes))
 

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -96,7 +96,7 @@ def linker_mode(sources, options, output, args):
     positionmode = "static" if args.static else "fPIC"
     shell('{clang} -c -O2 -{positionmode} -o .vfcwrapper.o {vfcwrapper} -I {mcalib_includes}'.format(
         clang=clang,
-        mode=positionmode,
+        positionmode=positionmode,
         vfcwrapper=vfcwrapper,
         mcalib_includes=mcalib_includes))
 


### PR DESCRIPTION
- Following patch provided by @pablooliveira, added option for position-independent compilation of `.vcfwrapper.o` when not using the `-static` argument during compilation.
- This bug fix enables Cython libraries to be compiled+linked with verificarlo
- Added test demonstrating the build of Cython libraries using verificarlo
- Minor Python style fixes