### PR TITLE
Fix shell expansion in verificarlo

### DIFF
--- a/src/libmca-quad/mcalib.c
+++ b/src/libmca-quad/mcalib.c
@@ -380,40 +380,35 @@ static inline double _mca_dbin(double a, double b, const int qop) {
 * point operators
 **********************************************************************/
 
-static float _floatadd(float a, float b) { return _mca_sbin(a, b, MCA_ADD); }
+static float _floatadd(float a, float b) {
+  return _mca_sbin(a, b, MCA_ADD);
+}
 
 static float _floatsub(float a, float b) {
-  // return a - b
   return _mca_sbin(a, b, MCA_SUB);
 }
 
 static float _floatmul(float a, float b) {
-  // return a * b
   return _mca_sbin(a, b, MCA_MUL);
 }
 
 static float _floatdiv(float a, float b) {
-  // return a / b
   return _mca_sbin(a, b, MCA_DIV);
 }
 
 static double _doubleadd(double a, double b) {
-  double tmp = _mca_dbin(a, b, MCA_ADD);
-  return tmp;
+  return _mca_dbin(a, b, MCA_ADD);
 }
 
 static double _doublesub(double a, double b) {
-  // return a - b
   return _mca_dbin(a, b, MCA_SUB);
 }
 
 static double _doublemul(double a, double b) {
-  // return a * b
   return _mca_dbin(a, b, MCA_MUL);
 }
 
 static double _doublediv(double a, double b) {
-  // return a / b
   return _mca_dbin(a, b, MCA_DIV);
 }
 

--- a/tests/test_backends/check.py
+++ b/tests/test_backends/check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-THRESHOLD = 1
+THRESHOLD = 2
 
 import sys
 
@@ -14,7 +14,7 @@ for quad, mpfr in zip(file("out_quad"), file("out_mpfr")):
 	max = delta
         print "ERROR:", q, m
 
-if max > THRESHOLD:        
+if max > THRESHOLD:
         print "MAX > THRESHOLD"
 	sys.exit(1)
 

--- a/tests/test_backends/test.sh
+++ b/tests/test_backends/test.sh
@@ -16,12 +16,12 @@ Check() {
         export VERIFICARLO_BACKEND="QUAD"
         ./test > out_quad.orig
         cat out_quad.orig | grep 'TEST>' | cut -d'>' -f 2 > out_quad
-        
         ./check.py
         if [ $? -ne 0 ] ; then
             echo "error"
-        else 
-	    echo "ok for precision $PREC"
+            exit 1
+        else
+            echo "ok for precision $PREC"
         fi
     done
 }
@@ -29,8 +29,8 @@ Check() {
 # Test operates at different precisions, and different operands.
 # It compares s': the estimated number of significant digits across the MCA samples.
 
-
 for op in "+" "*" "/" ; do
+    export VERIFICARLO_MCAMODE="MCA"
     echo "Checking $op float"
     verificarlo -D REAL=float -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
     Check 24

--- a/tests/test_shell_expansion/test.c
+++ b/tests/test_shell_expansion/test.c
@@ -1,0 +1,4 @@
+#include<stdio.h>
+int main() {
+  printf("%s\n", PLATFORM);
+}

--- a/tests/test_shell_expansion/test.sh
+++ b/tests/test_shell_expansion/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+verificarlo -DPLATFORM='"linux"' test.c

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -3,7 +3,8 @@
 #                                                                              *
 #  This file is part of Verificarlo.                                           *
 #                                                                              *
-#  Copyright (c) 2015-2016                                                     *
+#  Copyright (c) 2015-2019                                                     *
+#     Verificarlo contributors                                                 *
 #     Universite de Versailles St-Quentin-en-Yvelines                          *
 #     CMLA, Ecole Normale Superieure de Cachan                                 *
 #                                                                              *
@@ -66,6 +67,9 @@ def is_fortran(name):
 def is_c(name):
     return os.path.splitext(name)[1].lower() in C_EXTENSIONS
 
+def shell_escape(argument):
+    # prevents argument expansion in shell call
+    return "'" + argument + "'"
 
 def parse_extra_args(args):
     sources = []
@@ -80,7 +84,7 @@ def parse_extra_args(args):
         elif is_c(a):
             sources.append(a)
         else:
-            options.append(a)
+            options.append(shell_escape(a))
 
     return sources, ' '.join(options)
 
@@ -199,12 +203,12 @@ if __name__ == "__main__":
     sources, llvm_options = parse_extra_args(other)
 
     # check input files
-
     if len(sources) > 1 and args.o:
         fail('cannot specify -o when generating multiple output files')
 
+    # check mutually excluding args
     if args.function and args.functions_file:
-        fail("Cannot used --function and --functions-file together")
+        fail('Cannot use --function and --functions-file together')
 
     output = "-o " + args.o if args.o else ""
     if args.c:


### PR DESCRIPTION
Verificarlo passes extra options to clang through the shell, if the arguments are shell expanded this can cause problems.

Example: 
   ```verificarlo -DPLATFORM="linux"``` 
gets expanded to
   ```verificarlo -DPLATFORM=linux``` 
one clang is called which fails.

Reported by @gkiar. 

This issue is a work in progress,
- [x] Does the fix proposed is general enough?
- [x] Must add some tests
- [x] Should we consider rewritting verificarlo.in.in to perform subprocess calls directly without going through the shell? This could be more robust, but may bring also problems with PATH and environment and requires rewritting a good part of the wrapper.