### PR TITLE
New version release 0.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,13 @@
 Verificarlo CHANGELOG
 
-UNRELEASED
-    * Unstable branch detection
-    * Branch instrumentation
+[v0.2.2] 2019/08/07
+    * Unstable branch detection with gcov
+    * Branch instrumentation of FCMP instructions
     * Fixed linking of shared libraries
     * Fixed shell expansion in optional arguments
+    * Fix bug with configure LLVM flags in m4/ax_llvm
     * Improved support for complex inclusion/exclusion schemes
+    * Add new tests
 
 [v0.2.1] 2018/11/22
     * Support for LLVM up to 4.0.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![verificarlo logo](https://avatars1.githubusercontent.com/u/12033642)
 
-## Verificarlo v0.2.1
+## Verificarlo v0.2.2
 
 [![Build Status](https://travis-ci.org/verificarlo/verificarlo.svg?branch=master)](https://travis-ci.org/verificarlo/verificarlo)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([verificarlo], [0.2.1], [])
+AC_INIT([verificarlo], [0.2.2], [])
 AM_SILENT_RULES([yes])
 AC_CONFIG_AUX_DIR(autoconf)
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
[v0.2.2] 2019/08/07
    * Unstable branch detection with gcov
    * Branch instrumentation of FCMP instructions
    * Fixed linking of shared libraries
    * Fixed shell expansion in optional arguments
    * Fix bug with configure LLVM flags in m4/ax_llvm
    * Improved support for complex inclusion/exclusion schemes
    * Add new tests