### PR TITLE
Fix #96: fix support for bool vectors

### DIFF
--- a/src/vfcwrapper/vfcwrapper.c
+++ b/src/vfcwrapper/vfcwrapper.c
@@ -160,8 +160,8 @@ typedef double double2 __attribute__((ext_vector_type(2)));
 typedef double double4 __attribute__((ext_vector_type(4)));
 typedef float float2 __attribute__((ext_vector_type(2)));
 typedef float float4 __attribute__((ext_vector_type(4)));
-typedef bool bool2 __attribute__((ext_vector_type(2)));
-typedef bool bool4 __attribute__((ext_vector_type(4)));
+typedef int int2 __attribute__((ext_vector_type(2)));
+typedef int int4 __attribute__((ext_vector_type(4)));
 
 /* Arithmetic vector wrappers */
 
@@ -197,8 +197,8 @@ double2 _2xdoublediv(double2 a, double2 b) {
     return c;
 }
 
-bool2 _2xdoublecmp(double2 a, double2 b, enum FCMP_PREDICATE p) {
-    bool2 c;
+int2 _2xdoublecmp(double2 a, double2 b, enum FCMP_PREDICATE p) {
+    int2 c;
 
     c[0] = _vfc_current_mca_interface.doublecmp(a[0],b[0],p);
     c[1] = _vfc_current_mca_interface.doublecmp(a[1],b[1],p);
@@ -247,8 +247,8 @@ double4 _4xdoublediv(double4 a, double4 b) {
     return c;
 }
 
-bool4 _4xdoublecmp(double4 a, double4 b, enum FCMP_PREDICATE p) {
-    bool4 c;
+int4 _4xdoublecmp(double4 a, double4 b, enum FCMP_PREDICATE p) {
+    int4 c;
 
     c[0] = _vfc_current_mca_interface.doublecmp(a[0],b[0],p);
     c[1] = _vfc_current_mca_interface.doublecmp(a[1],b[1],p);
@@ -291,8 +291,8 @@ float2 _2xfloatdiv(float2 a, float2 b) {
     return c;
 }
 
-bool2 _2xfloatcmp(float2 a, float2 b, enum FCMP_PREDICATE p) {
-    bool2 c;
+int2 _2xfloatcmp(float2 a, float2 b, enum FCMP_PREDICATE p) {
+    int2 c;
 
     c[0] = _vfc_current_mca_interface.floatcmp(a[0],b[0],p);
     c[1] = _vfc_current_mca_interface.floatcmp(a[1],b[1],p);
@@ -341,8 +341,8 @@ float4 _4xfloatdiv(float4 a, float4 b) {
     return c;
 }
 
-bool4 _4xfloatcmp(float4 a, float4 b, enum FCMP_PREDICATE p) {
-    bool4 c;
+int4 _4xfloatcmp(float4 a, float4 b, enum FCMP_PREDICATE p) {
+    int4 c;
 
     c[0] = _vfc_current_mca_interface.floatcmp(a[0],b[0],p);
     c[1] = _vfc_current_mca_interface.floatcmp(a[1],b[1],p);

--- a/tests/test_branch_instrumentation/run.c
+++ b/tests/test_branch_instrumentation/run.c
@@ -1,0 +1,22 @@
+#include<assert.h>
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+  float taba [100];
+  float tabb [100];
+  int tabc[100];
+
+  for (int i = 0; i < 100; i ++) {
+    taba[i] = (i%2 ==0)?i*1.2:i*1.1;
+    tabb[i] = (i%2 ==0)?i*1.1:i*1.2;
+  }
+
+  for (int i = 0; i < 100; i ++) {
+    tabc[i] = taba[i] > tabb[i];
+  }
+
+  assert(!tabc[0]);
+  assert(!tabc[1]);
+  assert(tabc[2]);
+  assert(tabc[98]);
+}

--- a/tests/test_branch_instrumentation/test.sh
+++ b/tests/test_branch_instrumentation/test.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+verificarlo -c test.c
+
+if grep "fcmp ogt" test.2.ll || grep "fcmp ole" test.2.ll ; then
+  echo "comparison operations not instrumented"
+else
+  echo "comparison operations INSTRUMENTED without --inst-fcmp"
+  exit 1
+fi
+
+
 verificarlo --inst-fcmp -c test.c
 
 if grep "fcmp ogt" test.2.ll || grep "fcmp ole" test.2.ll ; then
@@ -17,13 +27,10 @@ else
   exit 1
 fi
 
-verificarlo -c test.c
-
-if grep "fcmp ogt" test.2.ll || grep "fcmp ole" test.2.ll ; then
-  echo "comparison operations not instrumented"
-else
-  echo "comparison operations INSTRUMENTED without --inst-fcmp"
-  exit 1
-fi
+# Test correct interposition for scalar and vector cases
+verificarlo --inst-fcmp run.c -o run
+./run
+verificarlo --inst-fcmp -O2 run.c -o run
+./run
 
 exit 0


### PR DESCRIPTION
Bool vectors are not supported in LLVM, the support for fcmp vector
instructions was broken and we could not return the proper value.

Here we rewrite fcmp vector hooks to return int vectors instead,
libVFCInstrument is modified to perform an appropriate cast when
replacing vector fcmp instructions.

We add a runtime test that checks that the return value of fcmp
instructions is properly handled.

Thanks to @yohanchatelain for reporting the bug.