### PR TITLE
Fixes #98: correctly detect non supported fp types

### DIFF
--- a/src/libvfcinstrument/libVFCInstrument.cpp
+++ b/src/libvfcinstrument/libVFCInstrument.cpp
@@ -246,7 +246,12 @@ struct VfclibInst : public ModulePass {
     StructType *mca_interface_type = getMCAInterfaceType(Builder);
 
     Type *opType = I->getOperand(0)->getType();
+    // Check that the type of the operation is supported
     Type *baseType = opType;
+    if (!baseType->isDoubleTy() && !baseType->isFloatTy()) {
+      errs() << "Unsupported operand type: " << *opType << "\n";
+      return nullptr;
+    }
 
     // We use a builder adding instructions before the
     // instruction to replace
@@ -305,7 +310,7 @@ struct VfclibInst : public ModulePass {
       vectorName = "4x";
     } else {
       errs() << "Unsuported vector size: " << size << "\n";
-      assert(0);
+      return nullptr;
     }
 
     // Check the type of the operation
@@ -315,7 +320,7 @@ struct VfclibInst : public ModulePass {
       baseTypeName = "float";
     } else {
       errs() << "Unsupported operand type: " << *opType << "\n";
-      assert(0);
+      return nullptr;
     }
 
     // For vector types, helper functions in vfcwrapper are called
@@ -385,7 +390,8 @@ struct VfclibInst : public ModulePass {
       if (VfclibInstVerbose)
         errs() << "Instrumenting" << I << '\n';
       Value *val = replaceWithMCACall(M, &I, opCode);
-      ReplaceInstWithValue(B.getInstList(), ii, val);
+      if (val != nullptr)
+        ReplaceInstWithValue(B.getInstList(), ii, val);
       modified = true;
     }
 

--- a/tests/test_fp80/rotg.c
+++ b/tests/test_fp80/rotg.c
@@ -1,0 +1,46 @@
+/* Simplified test case from OpenBlas */
+#include <math.h>
+
+#define FLOAT double
+#define ONE 1.0
+#define ZERO 0.0
+
+void CNAME(FLOAT *DA, FLOAT *DB, FLOAT *C, FLOAT *S){
+  long double da = *DA;
+  long double db = *DB;
+  long double c;
+  long double s;
+  long double r, roe, z;
+
+  long double ada = fabsl(da);
+  long double adb = fabsl(db);
+  long double scale = ada + adb;
+
+  roe = db;
+  if (ada > adb) roe = da;
+
+  if (scale == ZERO) {
+    *C = ONE;
+    *S = ZERO;
+    *DA = ZERO;
+    *DB = ZERO;
+  } else {
+    r = sqrt(da * da + db * db);
+    if (roe < 0) r = -r;
+    c = da / r;
+    s = db / r;
+    z = ONE;
+    if (da != ZERO) {
+      if (ada > adb){
+	z = s;
+      } else {
+	z = ONE / c;
+      }
+    }
+
+    *C = c;
+    *S = s;
+    *DA = r;
+    *DB = z;
+  }
+}

--- a/tests/test_fp80/test.sh
+++ b/tests/test_fp80/test.sh
@@ -1,0 +1,14 @@
+#/bin/bash
+set -e
+
+# Verificarlo should not fail
+verificarlo -O2 -c rotg.c 2> error
+
+# But is should report the unsupported type
+if grep "Unsupported operand type: x86_fp80" error; then
+  echo "verificarlo correctly reported unsupported x86_fp80 type"
+  exit 0
+else
+  echo "verificarlo failed silently"
+  exit 1
+fi


### PR DESCRIPTION
We warn and ignore unsupported fp types such as x86_fp80.
Add a test.