### PR TITLE
Reset LIBS dependencies in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,11 @@ EOF
     fi
 fi
 
+# Reset libs after ac_check_lib We do not want each and every backend or the
+# libvfcinstrument frontend to be linked against libmpfr or libgfortran for
+# example. -l flags should be added individually in each Makefile.am
+LIBS=""
+
 # Check for header files.
 AC_CHECK_HEADERS([fcntl.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h mpfr.h], , AC_MSG_ERROR([Missing required headers]))
 

--- a/src/backends/interflop-mca-mpfr/Makefile.am
+++ b/src/backends/interflop-mca-mpfr/Makefile.am
@@ -1,5 +1,5 @@
 lib_LTLIBRARIES = libinterflop_mca_mpfr.la
 libinterflop_mca_mpfr_la_SOURCES = interflop_mca_mpfr.c
-libinterflop_mca_mpfr_la_LDFLAGS = -lm
+libinterflop_mca_mpfr_la_LDFLAGS = -lm -lmpfr
 libinterflop_mca_mpfr_la_LIBADD = ../../common/libtinymt64.la
 library_includedir =$(includedir)/

--- a/tests/test_static_mode/test.c
+++ b/tests/test_static_mode/test.c
@@ -1,0 +1,19 @@
+#include<stdio.h>
+
+__attribute__ ((noinline)) double compute(double a, double b) {
+  return (a-b) + (a*b) + (a/b);
+}
+
+int main(void) {
+  double a = 1.2345678e-5;
+  double b = 9.8765432e12;
+  double c = compute(a,b);
+  double ref = (a-b) + (a*b) + (a/b);
+  if (c == ref) {
+    printf("result is correct %g == %g (ref)\n", c, ref);
+    return 0;
+  } else {
+    printf("result is not correct %g != %g (ref)\n", c, ref);
+    return 1;
+  }
+}

--- a/tests/test_static_mode/test.sh
+++ b/tests/test_static_mode/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+verificarlo -static -O0 test.c -o test
+VFC_BACKENDS="libinterflop_ieee.so --debug" ./test


### PR DESCRIPTION
Reset libs after ac_check_lib. We do not want each and every backend or the
libvfcinstrument frontend to be linked against libmpfr or libgfortran for
example. -l flags should be added individually in each Makefile.am

* Fix a bug with static link mode.
* Added a test for static link mode.