### PR TITLE
Fix regression in libVFCInstrument

### DIFF
--- a/tests/test_ieee_backend/test.sh
+++ b/tests/test_ieee_backend/test.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 set -e
 verificarlo -O0 test.c -o test
+
+# Check that all the operations have been instrumented
+for op in fadd fsub fmul fdiv; do
+  if grep $op test.2.ll; then
+    echo "Some $op have not been instrumented"
+    exit 1
+  fi
+done
+
 VFC_BACKENDS="libinterflop_ieee.so" ./test
 VFC_BACKENDS="libinterflop_ieee.so --debug" ./test
+


### PR DESCRIPTION
After #493f7ece, ReplaceInstWithValue was invalidating the instruction
iterator. In some cases some operations were not properly instrumented.

Fix the bug and modify simple test so that it checks for this.