### PR TITLE
Mpfr backend optimizations

### DIFF
--- a/src/backends/interflop-mca-mpfr/interflop_mca_mpfr.c
+++ b/src/backends/interflop-mca-mpfr/interflop_mca_mpfr.c
@@ -183,7 +183,7 @@ static float _mca_sbin(float a, float b, mpfr_bin mpfr_op) {
     _mca_inexact(mpfr_a, rnd);
   }
   float ret = mpfr_get_flt(mpfr_a, rnd);
-  return NEAREST_FLOAT(ret);
+  return ret;
 }
 
 static float _mca_sunr(float a, mpfr_unr mpfr_op) {
@@ -199,7 +199,7 @@ static float _mca_sunr(float a, mpfr_unr mpfr_op) {
     _mca_inexact(mpfr_a, rnd);
   }
   float ret = mpfr_get_flt(mpfr_a, rnd);
-  return NEAREST_FLOAT(ret);
+  return ret;
 }
 
 static double _mca_dbin(double a, double b, mpfr_bin mpfr_op) {
@@ -218,7 +218,7 @@ static double _mca_dbin(double a, double b, mpfr_bin mpfr_op) {
     _mca_inexact(mpfr_a, rnd);
   }
   double ret = mpfr_get_d(mpfr_a, rnd);
-  return NEAREST_DOUBLE(ret);
+  return ret;
 }
 
 static double _mca_dunr(double a, mpfr_unr mpfr_op) {
@@ -234,7 +234,7 @@ static double _mca_dunr(double a, mpfr_unr mpfr_op) {
     _mca_inexact(mpfr_a, rnd);
   }
   double ret = mpfr_get_d(mpfr_a, rnd);
-  return NEAREST_DOUBLE(ret);
+  return ret;
 }
 
 /************************* FPHOOKS FUNCTIONS *************************

--- a/src/backends/interflop-mca-mpfr/interflop_mca_mpfr.c
+++ b/src/backends/interflop-mca-mpfr/interflop_mca_mpfr.c
@@ -133,7 +133,7 @@ static int _mca_inexact(mpfr_ptr a, mpfr_rnd_t rnd_mode) {
   /* get_exp reproduce frexp behavior,  */
   /* i.e. exp corresponding to a normalization in the interval [1/2 1[ */
   /* remove one to normalize in [1 2[ like ieee numbers */
-  mpfr_exp_t e_a = mpfr_get_exp(a)-1;
+  mpfr_exp_t e_a = mpfr_get_exp(a) - 1;
   mpfr_prec_t p_a = mpfr_get_prec(a);
   MPFR_DECL_INIT(mpfr_rand, p_a);
   e_a = e_a - (MCALIB_T - 1);
@@ -141,7 +141,7 @@ static int _mca_inexact(mpfr_ptr a, mpfr_rnd_t rnd_mode) {
   mpfr_set_d(mpfr_rand, d_rand, rnd_mode);
   /* rand = rand * 2 ^ (e_a) */
   mpfr_mul_2si(mpfr_rand, mpfr_rand, e_a, rnd_mode);
-  mpfr_add(a, a, mpfr_rand, rnd_mode);  
+  mpfr_add(a, a, mpfr_rand, rnd_mode);
 }
 
 static void _set_mca_seed(int choose_seed, uint64_t seed) {
@@ -278,7 +278,6 @@ static void _interflop_div_double(double a, double b, double *c,
                                   void *context) {
   *c = _mca_dbin(a, b, (mpfr_bin)MP_DIV);
 }
-
 
 static struct argp_option options[] = {
     /* --debug, sets the variable debug = true */

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -241,6 +241,7 @@ static inline __float128 qnoise(int exp) {
 }
 
 static bool _is_representableq(__float128 *qa) {
+
   /* Check if *qa is exactly representable
    * in the current virtual precision */
   uint64_t hx, lx;
@@ -265,11 +266,12 @@ static bool _is_representableq(__float128 *qa) {
 }
 
 static bool _is_representabled(double *da) {
+
   /* Check if *da is exactly representable
    * in the current virtual precision */
   uint64_t p_mantissa = (*((uint64_t *)da)) & DOUBLE_GET_PMAN;
   /* here we know that (MCALIB_T-1) < 53 */
-  return ((p_mantissa << (MCALIB_T - 1)) == 0);
+  return ((p_mantissa << (MCALIB_T + DOUBLE_EXP_SIZE)) == 0);
 }
 
 static int _mca_inexactq(__float128 *qa) {

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -156,7 +156,7 @@ static inline uint32_t rexpq(__float128 x) {
   // remove sign bit, mantissa will be erased by the next shift
   ix = hx & QUAD_HX_ERASE_SIGN;
   // shift exponent to have LSB on position 0 and complement
-  exp += (ix >> QUAD_HX_PMAN_SIZE) - QUAD_EXP_COMP;
+  exp = (ix >> QUAD_HX_PMAN_SIZE) - QUAD_EXP_COMP;
   return exp;
 }
 
@@ -170,7 +170,7 @@ static inline uint32_t rexpd(double x) {
   // remove sign bit, mantissa will be erased by the next shift
   ix = hex & DOUBLE_ERASE_SIGN;
   // shift exponent to have LSB on position 0 and complement
-  exp += (ix >> DOUBLE_PMAN_SIZE) - DOUBLE_EXP_COMP;
+  exp = (ix >> DOUBLE_PMAN_SIZE) - DOUBLE_EXP_COMP;
   return exp;
 }
 

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -288,6 +288,7 @@ static int _mca_inexactq(__float128 *qa) {
   int32_t e_n = e_a - (MCALIB_T - 1);
   __float128 noise = qnoise(e_n);
   *qa = noise + *qa;
+
   return 1;
 }
 
@@ -307,6 +308,7 @@ static int _mca_inexactd(double *da) {
   int32_t e_n = e_a - (MCALIB_T - 1);
   double d_rand = (_mca_rand() - 0.5);
   *da = *da + pow2d(e_n) * d_rand;
+
   return 1;
 }
 

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -279,6 +279,11 @@ static int _mca_inexactq(__float128 *qa) {
     return 0;
   }
 
+  /* Checks that we are not in a special cases */
+  if (fpclassifyq(*qa) != FP_NORMAL && fpclassifyq(*qa) != FP_SUBNORMAL) {
+    return 0;
+  }
+
   /* In RR if the number is representable in current virtual precision,
    * do not add any noise */
   if (MCALIB_OP_TYPE == MCAMODE_RR && _is_representableq(qa)) {
@@ -296,6 +301,11 @@ static int _mca_inexactq(__float128 *qa) {
 
 static int _mca_inexactd(double *da) {
   if (MCALIB_OP_TYPE == MCAMODE_IEEE) {
+    return 0;
+  }
+
+  /* Checks that we are not in a special cases */
+  if (fpclassify(*da) != FP_NORMAL && fpclassify(*da) != FP_SUBNORMAL) {
     return 0;
   }
 

--- a/src/vfcwrapper/vfcwrapper.c
+++ b/src/vfcwrapper/vfcwrapper.c
@@ -97,7 +97,7 @@ __attribute__((constructor)) static void vfc_init(void) {
     /* load the backend .so */
     void *handle = dlopen(backend_argv[0], RTLD_NOW);
     if (handle == NULL) {
-      errx(1, "Cannot load backend %s: dlopen error", token);
+      errx(1, "Cannot load backend %s: dlopen error\n%s", token, dlerror());
     }
 
     warnx("verificarlo loaded backend %s", token);

--- a/tests/test_backends/test.c
+++ b/tests/test_backends/test.c
@@ -1,51 +1,15 @@
-#include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <math.h>
-#include <float.h>
 
-REAL data[SAMPLES];
+#ifndef NB_ITER
+#define NB_ITER 50
+#endif
 
-static double compute_mean(int N, REAL data[]) {
-  assert (N >= 1);
-
-  double sum = data[0];
-  double c = 0.0,y,t;
-  int i;
-
-  for (i=1; i<N; i++) {
-    y = data[i] - c;
-    t = sum + y;
-    c = (t - sum) - y;
-    sum = t;
-  }
-
-  return sum/(double)N;
-}
-
-static double compute_variance(int N, double mean, REAL data[]) {
-  /* Knuth compensated online variance */
-  assert(N >= 2);
-
-  int i;
-  int n = 0;
-  double m = mean, M2 = 0.0;
-
-  for (i=0; i<N; i++) {
-    n ++;
-    double delta = data[i] - m;
-    m += delta/(double)n;
-    M2 += delta*(data[i] - m);
-  }
-
-  return M2 / (double)(n - 1);
-}
-
-static double compute_sig(int N, REAL data[]) {
-  double mean = compute_mean(N, data);
-  double stdev = sqrt(compute_variance(N, mean, data));
-  return -log2(stdev/mean);
-}
+#if REAL == double
+#define FMT "%.13a\n"
+#elif REAL == float
+#define FMT "%.6a\n"
+#endif
 
 REAL operate(REAL a, REAL b) {
     return a OPERATION b;
@@ -54,9 +18,7 @@ REAL operate(REAL a, REAL b) {
 static void do_test(REAL a, REAL b) {
   int i;
   for (i = 0; i < SAMPLES; i++) {
-    //printf("expecting a+b=%.17g\n", a+b);
-    data[i] = operate(a,b);
-    //printf("noisy a+b=%.17g\n", data[i]);
+    printf(FMT, operate(a,b));
   }
   double sig = compute_sig(SAMPLES, data);
 
@@ -68,14 +30,10 @@ int main(void) {
   // initialize random seed
   srand(0);
 
-  // Test with 50 different random operands
-  for (i=0; i<50; i ++) {
+  // Test with NB_ITER different random operands
+  for (i=0; i<NB_ITER; i ++) {
     do_test((REAL)rand()/(REAL)RAND_MAX, (REAL)rand()/(REAL)RAND_MAX);
   }
 
-  // Test with extreme values
-  //do_test(DBL_MIN,DBL_MAX);
-  //do_test(DBL_MIN,DBL_MIN);
-  //do_test(DBL_MAX,DBL_MAX);
   return 0;
 }

--- a/tests/test_backends/test.c
+++ b/tests/test_backends/test.c
@@ -1,38 +1,58 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #ifndef NB_ITER
 #define NB_ITER 50
 #endif
 
 #if REAL == double
-#define FMT "%.13a\n"
+#define FMT "%.13a"
 #elif REAL == float
-#define FMT "%.6a\n"
+#define FMT "%.6a"
 #endif
+
+typedef union {
+  uint32_t u32[2];
+  uint64_t u64;
+  double f64;
+} binary64;
 
 REAL operate(REAL a, REAL b) {
     return a OPERATION b;
 }
 
+REAL get_rand() {
+#if REAL == double
+  binary64 b64;
+  b64.u32[0] = rand();
+  b64.u32[1] = rand();
+  return b64.f64;
+#elif REAL == float
+  int r = rand();
+  return *(float*)&r;
+#endif
+}
+
+#define QUOTE(name) #name
+#define STR(macro) QUOTE(macro)
+#define STR_OPERATION STR(OPERATION)
+
 static void do_test(REAL a, REAL b) {
   int i;
   for (i = 0; i < SAMPLES; i++) {
-    printf(FMT, operate(a,b));
+    printf(FMT STR_OPERATION  FMT " = " FMT "\n", a, b, operate(a,b));
   }
-  double sig = compute_sig(SAMPLES, data);
-
-  printf("TEST>%g\n", sig);
 }
 
 int main(void) {
   int i;
-  // initialize random seed
+  /* initialize random seed */
   srand(0);
 
-  // Test with NB_ITER different random operands
+  /* Test with NB_ITER different random operands */
   for (i=0; i<NB_ITER; i ++) {
-    do_test((REAL)rand()/(REAL)RAND_MAX, (REAL)rand()/(REAL)RAND_MAX);
+    do_test(get_rand(), get_rand());
   }
 
   return 0;

--- a/tests/test_backends/test.sh
+++ b/tests/test_backends/test.sh
@@ -7,16 +7,15 @@ Check() {
       for PREC in $(seq 3 10 $MAX_PREC) ; do
 
         echo "Checking at PRECISION $PREC MODE $MODE"
-        rm -f out_mpfr out_quad out_quad.orig out_mpfr.orig
-        export VFC_BACKENDS="libinterflop_mca.so --precision $PREC --mode $MODE"
-        ./test > out_mpfr.orig
-        cat out_mpfr.orig |grep 'TEST>' | cut -d'>' -f 2 > out_mpfr
+        rm -f out_mpfr out_quad
+        export VFC_BACKENDS="libinterflop_mca_mpfr.so --precision $PREC --mode $MODE --seed=0"
+        ./test > out_mpfr
 
-        export VFC_BACKENDS="libinterflop_mca_mpfr.so --precision $PREC --mode $MODE"
-        ./test > out_quad.orig
-        cat out_quad.orig | grep 'TEST>' | cut -d'>' -f 2 > out_quad
-        ./check.py
-        if [ $? -ne 0 ] ; then
+        export VFC_BACKENDS="libinterflop_mca.so --precision $PREC --mode $MODE --seed=0"
+        ./test > out_quad
+
+	diff out_mpfr out_quad
+	if [ $? -ne 0 ] ; then
           echo "error"
           exit 1
         else
@@ -27,14 +26,14 @@ Check() {
 }
 
 # Test operates at different precisions, and different operands.
-# It compares s': the estimated number of significant digits across the MCA samples.
+# It compares that results are equivalents up to the bit.
 
-for op in "+" "*" "/" ; do
+for op in "+" "-" "*" "/" ; do
     echo "Checking $op float"
-    verificarlo -D REAL=float -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
+    verificarlo -D REAL=float -D SAMPLES=100 -D OPERATION="$op" -O0 test.c -o test
     Check 24
 
     echo "Checking $op double"
-    verificarlo -D REAL=double -D SAMPLES=1000 -D OPERATION="$op" -O0 -lm --function operate test.c -o test
+    verificarlo -D REAL=double -D SAMPLES=100 -D OPERATION="$op" -O0 test.c -o test
     Check 53
 done

--- a/tests/test_backends/test.sh
+++ b/tests/test_backends/test.sh
@@ -8,7 +8,7 @@ Check() {
     START_PREC=$2
     MAX_PREC=$1
     for MODE in "PB" "RR" "MCA" ; do
-	for PREC in $(seq $START_PREC 10 $MAX_PREC) ; do
+	for PREC in $(seq $START_PREC 5 $MAX_PREC) ; do
 	    echo "Checking at PRECISION $PREC MODE $MODE"
 	    rm -f out_mpfr out_quad
 	    export VFC_BACKENDS="libinterflop_mca_mpfr.so --precision $PREC --mode $MODE --seed=$SEED"

--- a/tests/test_backends/test.sh
+++ b/tests/test_backends/test.sh
@@ -1,27 +1,30 @@
 #!/bin/bash
 #set -e
 
+SEED=$RANDOM
+echo "Seed: $SEED"
+
 Check() {
+    START_PREC=$2
     MAX_PREC=$1
-    for MODE in "MCA" ; do #FIXME test with "RR"
-      for PREC in $(seq 3 10 $MAX_PREC) ; do
+    for MODE in "PB" "RR" "MCA" ; do
+	for PREC in $(seq $START_PREC 10 $MAX_PREC) ; do
+	    echo "Checking at PRECISION $PREC MODE $MODE"
+	    rm -f out_mpfr out_quad
+	    export VFC_BACKENDS="libinterflop_mca_mpfr.so --precision $PREC --mode $MODE --seed=$SEED"
+	    ./test > out_mpfr
 
-        echo "Checking at PRECISION $PREC MODE $MODE"
-        rm -f out_mpfr out_quad
-        export VFC_BACKENDS="libinterflop_mca_mpfr.so --precision $PREC --mode $MODE --seed=0"
-        ./test > out_mpfr
+	    export VFC_BACKENDS="libinterflop_mca.so --precision $PREC --mode $MODE --seed=$SEED"
+	    ./test > out_quad
 
-        export VFC_BACKENDS="libinterflop_mca.so --precision $PREC --mode $MODE --seed=0"
-        ./test > out_quad
-
-	diff out_mpfr out_quad
-	if [ $? -ne 0 ] ; then
-          echo "error"
-          exit 1
-        else
-          echo "ok for precision $PREC"
-        fi
-      done
+	    diff out_mpfr out_quad
+	    if [ $? -ne 0 ] ; then
+		echo "error"
+		exit
+	    else
+		echo "ok for precision $PREC"
+	    fi
+	done
     done
 }
 
@@ -31,9 +34,9 @@ Check() {
 for op in "+" "-" "*" "/" ; do
     echo "Checking $op float"
     verificarlo -D REAL=float -D SAMPLES=100 -D OPERATION="$op" -O0 test.c -o test
-    Check 24
+    Check 24 4
 
     echo "Checking $op double"
     verificarlo -D REAL=double -D SAMPLES=100 -D OPERATION="$op" -O0 test.c -o test
-    Check 53
+    Check 53 3
 done


### PR DESCRIPTION
Optimize the mpfr-mca backend:
  - Reuse variables to decrease the initialization time of mpfr variables
  - Fix the precision of the intermediate computations
  - Fix #87
  - Ensure that both backends have the same results up to the bit
  - Speedup over previous version (x2)
