### PR TITLE
Fix issue with argument parsing in ieee backend

### DIFF
--- a/src/backends/interflop-ieee/interflop_ieee.c
+++ b/src/backends/interflop-ieee/interflop_ieee.c
@@ -313,6 +313,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   default:
     return ARGP_ERR_UNKNOWN;
   }
+  return 0;
 }
 
 static struct argp argp = {options, parse_opt, "", ""};


### PR DESCRIPTION
Closes issue #131.
According to the [man page](https://www.gnu.org/software/libc/manual/html_node/Argp-Example-3.html#Argp-Example-3), a `return 0` was missing:

> It should return either 0, meaning success, ARGP_ERR_UNKNOWN, meaning the given KEY wasn’t recognized, or an errno value indicating some other error.