### PR TITLE
review the subnormal code for mca quad and fix all verificarlo related coverity bug

### DIFF
--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -191,8 +191,7 @@ static inline __float128 qnoise(int exp) {
     if (exp < -(QUAD_EXP_MIN + QUAD_PMAN_SIZE)) {
       SET_FLT128_WORDS64(noise, QMINF_hx, QMINF_lx);
       return noise;
-    }
-    // noise will be a subnormal
+    } else{// noise will be a subnormal
     // build HX with sign of d_rand, exp
     uint64_t u_hx = ((uint64_t)(-QUAD_EXP_MIN + QUAD_EXP_COMP))
                     << QUAD_HX_PMAN_SIZE;
@@ -200,7 +199,7 @@ static inline __float128 qnoise(int exp) {
     uint64_t sign = u_rand & DOUBLE_GET_SIGN;
     u_hx = u_hx + sign;
     // erase the sign bit from u_rand
-    u_rand = u_rand - sign;
+    u_rand = u_rand << 1;
 
     uint64_t u_lx=0;
     
@@ -222,7 +221,7 @@ static inline __float128 qnoise(int exp) {
          u_lx = 0;
       
       SET_FLT128_WORDS64(noise, u_hx, u_lx);
-    }
+    }}
     // char buf[128];
     // int len=quadmath_snprintf (buf, sizeof(buf), "%+-#*.20Qe", width, noise);
     // if ((size_t) len < sizeof(buf))

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -202,29 +202,27 @@ static inline __float128 qnoise(int exp) {
     // erase the sign bit from u_rand
     u_rand = u_rand - sign;
 
-    if (exp + QUAD_EXP_MIN > QUAD_LX_PMAN_SIZE) {
+    uint64_t u_lx=0;
+    
+    if (-exp - QUAD_EXP_MIN < QUAD_HX_PMAN_SIZE) {
       // the higher part of the noise start in HX of noise
       // set the mantissa part: U_rand>> by -exp-QUAD_EXP_MIN
       u_hx += u_rand >> (-exp - QUAD_EXP_MIN + QUAD_EXP_SIZE + 1 /*SIGN_SIZE*/);
       // build LX with the remaining bits of the noise
       // (-exp-QUAD_EXP_MIN-QUAD_HX_PMAN_SIZE) at the msb of LX
       // remove the bit already used in hx and put the remaining at msb of LX
-      uint64_t u_lx = u_rand << (QUAD_HX_PMAN_SIZE + exp + QUAD_EXP_MIN);
+      u_lx = u_rand << (QUAD_HX_PMAN_SIZE + exp + QUAD_EXP_MIN);
       SET_FLT128_WORDS64(noise, u_hx, u_lx);
-    } 
-    
-      // the noise as been already implicitly shifeted by QUAD_HX_PMAN_SIZE when
-      // starting in LX
+    } else{
       int32_t shift=-exp - QUAD_EXP_MIN - QUAD_HX_PMAN_SIZE;
-      uint64_t u_lx=0;
-      //shift by 64 and mor is undifinied in the C norm
+      //shift by 64 and more is undifinied in the C norm
       if (shift<64)
         u_lx = u_rand >> shift;
       else
          u_lx = 0;
       
       SET_FLT128_WORDS64(noise, u_hx, u_lx);
-    
+    }
     // char buf[128];
     // int len=quadmath_snprintf (buf, sizeof(buf), "%+-#*.20Qe", width, noise);
     // if ((size_t) len < sizeof(buf))


### PR DESCRIPTION
remains the llvm one. This can be tune  in coverity configuration to avoid scanning external dep modules