### PR TITLE
Remove setarch command in vfc_ddebug 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
   - export PYTHONPATH=/usr/local/lib/python${PYTHON_VERSION}/site-packages/:$PYTHONPATH
 
 script:
-  - sudo -E env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH make installcheck
+  - make installcheck
 
 after_success:
   - for i in $(find tests/ -maxdepth 1 -type d -name 'test_*' | sort ); do echo "************** TEST $i"; cat $i/test.log; done;

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,56 +55,6 @@ RUN cat $HOME/.bashrc && \
     make && sudo make install && \
     make installcheck
 
-
-ARG PYTHON_VERSION=3.5
-ARG LLVM_VERSION=3.6.1
-ARG GCC_VERSION=4.9
-ARG GCC_PATH=/usr/lib/gcc/x86_64-linux-gnu/${GCC_VERSION}
-ENV LD_LIBRARY_PATH /usr/local/lib:$LD_LIBRARY_PATH
-ENV PATH /usr/local/bin:$PATH
-ENV PYTHONPATH=/usr/local/lib/python$PYTHON_VERSION/site-packages/:$PYTHONPATH
-
-# Retrieve dependencies
-RUN apt-get -y update && apt-get -y install --no-install-recommends \
-    bash ca-certificates make git libmpfr-dev \
-    gcc-${GCC_VERSION} gcc-${GCC_VERSION}-plugin-dev g++-${GCC_VERSION} gfortran-${GCC_VERSION} libgfortran-${GCC_VERSION}-dev \
-    autoconf automake libedit-dev libtool libz-dev \
-    python3 python3-numpy python3-matplotlib binutils vim sudo wget xz-utils && \
-    rm -rf /var/lib/apt/lists/
-
-WORKDIR /build/
-
-# Download llvm-3.6.1 since it does not work with the version llvm-3.6.2 provided by apt
-RUN wget http://releases.llvm.org/3.6.1/clang+llvm-3.6.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz && \
-    tar xvf clang+llvm-3.6.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz && \
-    ln -s clang+llvm-3.6.1-x86_64-linux-gnu llvm-3.6.1
-
-ENV LLVM_INSTALL_PATH /build/llvm-3.6.1
-ENV LIBRARY_PATH ${GCC_PATH}:${LLVM_INSTALL_PATH}:$LIBRARY_PATH
-
-# Download dragonegg from a non official repo since the official
-# version does not work with llvm-3.6.1 and gcc-4.9. gcc-4.9 and
-# higher version is required for using _Generic feature.  This is
-# temporary since we are planning to move to flang and do not use
-# dragonegg anymore.
-RUN git clone -b gcc-llvm-3.6 --depth=1 https://github.com/yohanchatelain/DragonEgg.git
-WORKDIR DragonEgg
-RUN LLVM_CONFIG=${LLVM_INSTALL_PATH}/bin/llvm-config GCC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} make
-ARG DRAGONEGG_PATH=/build/DragonEgg/dragonegg.so
-
-# Download and configure verificarlo from git master
-WORKDIR /build/verificarlo
-RUN git clone --depth=1 https://github.com/verificarlo/verificarlo.git &&  \
-    cd verificarlo && \
-    ./autogen.sh && \
-    ./configure --with-llvm=${LLVM_INSTALL_PATH} --with-dragonegg=${DRAGONEGG_PATH} CC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} || cat config.log 
-
-# Build and test verificarlo
-RUN cat $HOME/.bashrc && \
-    cd verificarlo && \
-    make && sudo make install && \
-    make installcheck
-
 # Setup working directory
 VOLUME /workdir
 WORKDIR /workdir

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN git clone --depth=1 https://github.com/verificarlo/verificarlo.git &&  \
 RUN cat $HOME/.bashrc && \
     cd verificarlo && \
     make && sudo make install && \
-    sudo -E env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH make installcheck
+    make installcheck
 
 
 ARG PYTHON_VERSION=3.5
@@ -103,7 +103,7 @@ RUN git clone --depth=1 https://github.com/verificarlo/verificarlo.git &&  \
 RUN cat $HOME/.bashrc && \
     cd verificarlo && \
     make && sudo make install && \
-    sudo -E env PYTHONPATH=$PYTHONPATH LD_LIBRARY_PATH=$LD_LIBRARY_PATH make installcheck
+    make installcheck
 
 # Setup working directory
 VOLUME /workdir

--- a/src/vfc_ddebug
+++ b/src/vfc_ddebug
@@ -28,8 +28,7 @@ class DDline(DD_stoch.DDStoch):
     def coerce(self, delta_config):
         return "\n".join([l[:-1] for l in delta_config])
 
-# This hack is an ugly but portable alternative to #!/usr/bin/env -S python3 -u
-# we call personality(ADDR_NO_RANDOMIZE) to disable ASLR, so that addresses during reference run
+# We call personality(ADDR_NO_RANDOMIZE) to disable ASLR, so that addresses during reference run
 # always match addresses during sample runs (even for .so code).
 def disable_ASLR():
     ADDR_NO_RANDOMIZE = 0x0040000

--- a/src/vfc_ddebug
+++ b/src/vfc_ddebug
@@ -1,9 +1,7 @@
-#!/bin/sh
-''''exec setarch $(uname -m) -R python3 -u "$0" "$@" #'''
-# This hack is an ugly but portable alternative to #!/usr/bin/env -S python3 -u
-# we call setarch -R to disable ASLR, so that addresses during reference run
-# always match addresses during sample runs (even for .so code).
+#!/usr/bin/env python3
 
+import ctypes
+import ctypes.util
 import sys
 import os
 from verificarlo import dd_config
@@ -30,7 +28,15 @@ class DDline(DD_stoch.DDStoch):
     def coerce(self, delta_config):
         return "\n".join([l[:-1] for l in delta_config])
 
+def disable_ASLR():
+    ADDR_NO_RANDOMIZE = 0x0040000
+    libc_name = ctypes.util.find_library('c')
+    libc = ctypes.CDLL(libc_name)
+    personality = libc.personality
+    personality(ADDR_NO_RANDOMIZE)
+
 if __name__ == "__main__":
+    disable_ASLR()
     et=DD_exec_stat.exec_stat("dd.line")
     config=dd_config.ddConfig(sys.argv,os.environ)
     dd = DDline(config)

--- a/src/vfc_ddebug
+++ b/src/vfc_ddebug
@@ -28,6 +28,9 @@ class DDline(DD_stoch.DDStoch):
     def coerce(self, delta_config):
         return "\n".join([l[:-1] for l in delta_config])
 
+# This hack is an ugly but portable alternative to #!/usr/bin/env -S python3 -u
+# we call personality(ADDR_NO_RANDOMIZE) to disable ASLR, so that addresses during reference run
+# always match addresses during sample runs (even for .so code).
 def disable_ASLR():
     ADDR_NO_RANDOMIZE = 0x0040000
     libc_name = ctypes.util.find_library('c')


### PR DESCRIPTION
- Uses [personality](http://man7.org/linux/man-pages/man2/personality.2.html) function with ADDR_NO_RANDOMIZE
> ADDR_NO_RANDOMIZE (since Linux 2.6.12)
              With this flag set, disable address-space-layout
              randomization.
- Allows to run vfc_ddebug without sudo mode