### PR TITLE
Clean-up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![DOI](https://zenodo.org/badge/34260221.svg)](https://zenodo.org/badge/latestdoi/34260221)
 [![Coverity](https://scan.coverity.com/projects/19956/badge.svg)](https://scan.coverity.com/projects/verificarlo-verificarlo)
 
-A tool for debugging floating point precision and reproducibility.
+A tool for debugging and assessing floating point precision and reproducibility.
 
    * [Using Verificarlo through its Docker image](#using-verificarlo-through-its-docker-image)
    * [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ Usage: libinterflop_ieee.so [OPTION...]
 
   -b, --debug-binary         enable binary debug output
   -d, --debug                enable debug output
-  -n, --print-new-line       print new lines after debug output
-  -s, --no-print-debug-mode  do not print debug mode before debug outputting
+  -n, --print-new-line       add a new line after debug ouput
+  -o, --print-subnormal-normalized
+                             normalize subnormal numbers
+  -s, --no-backend-name      do not print backend name in debug output
   -?, --help                 Give this help list
       --usage                Give a short usage message
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ For questions, feedbacks or discussions about Verificarlo you can join our group
 https://groups.google.com/forum/#!forum/verificarlo
 
 ## License
-Copyright (c) 2019
+Copyright (c) 2019-2020
    Verificarlo Contributors
 
 Copyright (c) 2018

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@
 
 A tool for debugging floating point precision and reproducibility.
 
+   * [Using Verificarlo through its Docker image](#using-verificarlo-through-its-docker-image)
+   * [Installation](#installation)
+      * [Example on x86_64 Ubuntu 14.04 release without Fortran support](#example-on-x86_64-ubuntu-1404-release-without-fortran-support)
+      * [Fortran support](#fortran-support)
+      * [Checking installation](#checking-installation)
+   * [Usage](#usage)
+   * [Examples and Tutorial](#examples-and-tutorial)
+   * [Backends](#backends)
+      * [IEEE Backend (libinterflop_ieee.so)](#ieee-backend-libinterflop_ieeeso)
+      * [MCA Backend (libinterflop_mca.so)](#mca-backend-libinterflop_mcaso)
+      * [MCA-MPFR Backend (libinterflop_mca_mpfr.so)](#mca-mpfr-backend-libinterflop_mca_mpfrso)
+      * [Bitmask Backend (libinterflop_bitmask.so)](#bitmask-backend-libinterflop_bitmaskso)
+   * [Verificarlo inclusion / exclusion options](#verificarlo-inclusion--exclusion-options)
+   * [Postprocessing](#postprocessing)
+   * [Unstable branch detection](#unstable-branch-detection)
+   * [Branch instrumentation](#branch-instrumentation)
+   * [How to cite Verificarlo](#how-to-cite-verificarlo)
+   * [Discussion Group](#discussion-group)
+   * [License](#license)
+
+
 ## Using Verificarlo through its Docker image
 
 A docker image is available at https://hub.docker.com/r/verificarlo/verificarlo/. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![DOI](https://zenodo.org/badge/34260221.svg)](https://zenodo.org/badge/latestdoi/34260221)
 [![Coverity](https://scan.coverity.com/projects/19956/badge.svg)](https://scan.coverity.com/projects/verificarlo-verificarlo)
 
-A tool for automatic Montecarlo Arithmetic analysis.
+A tool for debugging floating point precision and reproducibility.
 
 ## Using Verificarlo through its Docker image
 
@@ -14,7 +14,7 @@ A docker image is available at https://hub.docker.com/r/verificarlo/verificarlo/
 This image uses the latest git master version of Verificarlo and includes
 support for Fortran. It uses llvm-3.6.1 and gcc-4.9.
 
-Example of usage:
+Example of usage with Monte Carlo arithmetic:
 
 ```bash
 $ cat > test.c <<HERE
@@ -58,62 +58,7 @@ Then run the following command inside verificarlo directory:
    $ sudo make install
 ```
 
-### Fortran support
-
-The use of c++11 standard specific features force us to use gcc from 4.9.
-Unfornately, official dragonegg repository does not provide `dragonegg.so`
-for this version (4.9) and above. We plan to move to `flang` in the next release. In the meantime, if you need Fortran support you can either use the provided [docker image](https://hub.docker.com/r/verificarlo/verificarlo/) or follow the instructions below,
-
-```bash
-   $ sudo apt install gcc-4.9 gcc-4.9-plugin-dev g++-4.9 gfortran-4.9 libgfortran-4.9-dev
-```
-
-For getting llvm-3.6.1, run the following commands:
-
-```bash
-   $ wget http://releases.llvm.org/3.6.1/clang+llvm-3.6.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-   $ tar xvf clang+llvm-3.6.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz llvm-3.6.1
-   $ export LLVM_INSTALL_PATH=$PWD/llvm-3.6.1
-```
-
-For getting dragonegg.so, run the following commands:
-
-```bash
-   $ git clone -b gcc-llvm-3.6 --depth=1 https://github.com/yohanchatelain/DragonEgg.git
-   $ cd DragonEgg
-   $ LLVM_CONFIG=${LLVM_INSTALL_PATH}/bin/llvm-config GCC=gcc-4.9 CXX=g++-4.9 make
-   $ export DRAGONEGG_PATH=$PWD/dragonegg.so
-```   
-
-Then run the configuration with the appropriate paths:
-
-```bash
-   $ cd verificarlo/
-   $ ./autogen.sh
-   $ ./configure --with-llvm=${LLVM_INSTALL_PATH} \
-                 --with-dragonegg=${DRAGONEGG_PATH} \
-                 CC=gcc-4.9 CXX=g++4.9
-```
-
-Then you can follow the normal installation process
-
-```bash
-   $ make
-   $ sudo make install
-```   
-
-### Checking installation
-
-Once installation is over, we recommend that you run the test suite to ensure
-verificarlo works as expected on your system:
-
-```bash
-   $ make installcheck
-```
-
-### Example on x86_64 Ubuntu 14.04 release
-
-If you disable dragonegg support during configure, fortran_test will be disabled and considered as passing the test.
+### Example on x86_64 Ubuntu 14.04 release without Fortran support
 
 For example on an x86_64 Ubuntu 14.04 release, you should use the following
 install procedure:
@@ -130,30 +75,53 @@ install procedure:
    $ sudo make install
 ```
 
-### Delta debug
+### Fortran support
 
-In order to use the delta debug features, you need to export the path
-of the corresponding python packages. For example, for a global
-install, this would resemble (edit for your installed Python version):
+In the upcoming release Fortran support will be provided by `flang`. In the meantime, if you need Fortran support you can either use the provided [docker image](https://hub.docker.com/r/verificarlo/verificarlo/) or follow the instructions below to install `dragongegg.so` with a recent gcc.
+
+```bash
+   # Install gcc-4.9, gfortran-4.9 and llvm-3.6.1 with the following commands:
+   $ sudo apt install gcc-4.9 gcc-4.9-plugin-dev g++-4.9 gfortran-4.9 libgfortran-4.9-dev
+   $ wget http://releases.llvm.org/3.6.1/clang+llvm-3.6.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+   $ tar xvf clang+llvm-3.6.1-x86_64-linux-gnu-ubuntu-14.04.tar.xz llvm-3.6.1
+   $ export LLVM_INSTALL_PATH=$PWD/llvm-3.6.1
+
+   # Install dragonegg
+   $ git clone -b gcc-llvm-3.6 --depth=1 https://github.com/yohanchatelain/DragonEgg.git
+   $ cd DragonEgg
+   $ LLVM_CONFIG=${LLVM_INSTALL_PATH}/bin/llvm-config GCC=gcc-4.9 CXX=g++-4.9 make
+   $ export DRAGONEGG_PATH=$PWD/dragonegg.so
+   
+   # Install Verificarlo
+   $ cd verificarlo/
+   $ ./autogen.sh
+   $ ./configure --with-llvm=${LLVM_INSTALL_PATH} --with-dragonegg=${DRAGONEGG_PATH} CC=gcc-4.9 CXX=g++4.9
+   $ make && sudo make install
+```
+
+### Checking installation
+
+Once installation is over, we recommend that you run the test suite to ensure
+verificarlo works as expected on your system.
+
+You may need to export the path of the installed python packages. For example, for a global install, this would resemble (edit for your installed Python version):
 
 ```bash
 	$ export PYTHONPATH=${PYTHONPATH}:/usr/local/lib/pythonXXX.XXX/site-packages
 ```
 
-You can then check if your install was successful using:
+You can make the above change permanent by editing your `~/.bashrc`, `~/.profile` or whichever
+configuration file is relevant for your system.
+
+Then you can run the test suite with,
 
 ```bash
-	$ make installcheck
+   $ make installcheck
 ```
 
-Alternatively, you can make the changes required for `ddebug`
-permanent by editing your `~/.bashrc`, `~/.profile` or whichever
-configuration file is relevant for your system by adding the above
-line, and then reloading your environment using:
+If you disable dragonegg support during configure, Fortran tests will be disabled and considered as passing the test.
 
-```bash
-	$ source ~/.bashrc
-```
+
 
 ## Usage
 
@@ -181,6 +149,12 @@ It is important to include the necessary link flags if you use extra libraries.
 For example, you should include `-lm` if you are linking against the math
 library and include `-lstdc++` if you use functions in the standard C++
 library.
+
+## Examples and Tutorial
+
+The `tests/` directory contains various examples of Verificarlo usage.
+
+A [tutorial](https://github.com/verificarlo/verificarlo/wiki/Tutorials) is available.
 
 ## Backends
 
@@ -259,13 +233,6 @@ interflop_ieee 1.23457e-05 * 9.87654e+12 -> 1.21933e+08
 interflop_ieee 1.23457e-05 / 9.87654e+12 -> 1.25e-18
 ...
 
-VFC_BACKENDS="libinterflop_ieee.so --debug --no-print-debug-mode" ./test
-test: verificarlo loaded backend libinterflop_ieee.so
-1.23457e-05 - 9.87654e+12 -> -9.87654e+12
-1.23457e-05 * 9.87654e+12 -> 1.21933e+08
-1.23457e-05 / 9.87654e+12 -> 1.25e-18
-...
-
 VFC_BACKENDS="libinterflop_ieee.so --debug-binary --print-new-line" ./test
 test: verificarlo loaded backend libinterflop_ieee.so
 interflop_ieee_bin 
@@ -287,10 +254,9 @@ interflop_ieee_bin
 
 ### MCA Backend (libinterflop_mca.so)
 
-The MCA backends implements Montecarlo Arithmetic.  It uses quad types to
-compute MCA operations on doubles and the double type to compute MCA operations
-on floats. It is much faster than the MCA-MPFR backend, but it is recent and
-still experimental.
+The MCA backends implements Montecarlo Arithmetic.  It uses quad type to
+compute MCA operations on doubles and double type to compute MCA operations
+on floats. It is much faster than the legacy MCA-MPFR backend.
 
 ```
 VFC_BACKENDS="libinterflop_mca.so --help" ./test
@@ -322,9 +288,8 @@ precision used for the floating point operations in double precision
 (respectively for single precision with --precision-binary32) It
 accepts an integer value that represents the virtual precision at
 which MCA operations are performed. Its default value is 53 for
-binary64 and 24 for binary32. For a more precise definition of the
-virtual precision, you can refer to
-https://hal.archives-ouvertes.fr/hal-01192668.
+binary64 and 24 for binary32. A precise definition of the
+virtual precision is given [here](https://hal.archives-ouvertes.fr/hal-01192668).
 
 One should note when using the QUAD backend, that the round operations during
 MCA computation always use round-to-zero mode.
@@ -346,11 +311,9 @@ MCA-MPFR backend accepts the same options than the MCA backend.
 ### Bitmask Backend (libinterflop_bitmask.so)
 
 The Bitmask backend implements a fast first order model of noise. It
-relies on bitmask operations to achieve low overhead
-(~$\times$4). Contrary to MCA backends, introduced noise is biased,
-which means that the expected value of the noise is not equal to
-0. For more details, you can refer to the section 2.3.2 of
-https://tel.archives-ouvertes.fr/tel-02473301/document.
+relies on bitmask operations to achieve low overhead. Unlike MCA backends, 
+the introduced noise is biased, which means that the expected value of the noise 
+is not equal to 0 as explained in [Chatelain's thesis, section 2.3.2](https://tel.archives-ouvertes.fr/tel-02473301/document).
 
 ```
 VFC_BACKENDS="libinterflop_bitmask.so --help" ./test
@@ -437,13 +400,6 @@ module3 *
 
 Inclusion and exclusion files can be used together, in that case inclusion
 takes precedence over inclusion.
-
-## Examples and Tutorial
-
-The `tests/` directory contains various examples of Verificarlo usage.
-
-A [tutorial](https://github.com/verificarlo/verificarlo/wiki/Tutorials) in
-english and french is available.
 
 ## Postprocessing
 

--- a/src/backends/interflop-ieee/interflop_ieee.c
+++ b/src/backends/interflop-ieee/interflop_ieee.c
@@ -39,7 +39,7 @@
 typedef enum {
   KEY_DEBUG = 'd',
   KEY_DEBUG_BINARY = 'b',
-  KEY_NO_PRINT_DEBUG_MODE = 's',
+  KEY_NO_BACKEND_NAME = 's',
   KEY_PRINT_NEW_LINE = 'n',
   KEY_PRINT_SUBNORMAL_NORMALIZED
 } key_args;
@@ -47,7 +47,7 @@ typedef enum {
 typedef struct {
   bool debug;
   bool debug_binary;
-  bool no_print_debug_mode;
+  bool no_backend_name;
   bool print_new_line;
   bool print_subnormal_normalized;
 } t_context;
@@ -121,7 +121,7 @@ void debug_print(void *context, char *fmt_flt, char *fmt, ...) {
         ((t_context *)context)->print_subnormal_normalized ? true : false;     \
     if (debug || debug_binary) {                                               \
       bool print_header =                                                      \
-          (((t_context *)context)->no_print_debug_mode) ? false : true;        \
+          (((t_context *)context)->no_backend_name) ? false : true;            \
       char *header = (debug) ? DEBUG_HEADER : DEBUG_BINARY_HEADER;             \
       char *float_fmt =                                                        \
           (subnormal_normalized) ? FMT_SUBNORMAL_NORMALIZED(a) : FMT(a);       \
@@ -343,12 +343,12 @@ static struct argp_option options[] = {
     /* --debug, sets the variable debug = true */
     {"debug", KEY_DEBUG, 0, 0, "enable debug output"},
     {"debug-binary", KEY_DEBUG_BINARY, 0, 0, "enable binary debug output"},
-    {"no-print-debug-mode", KEY_NO_PRINT_DEBUG_MODE, 0, 0,
-     "do not print debug mode before debug outputting"},
+    {"no-backend-name", KEY_NO_BACKEND_NAME, 0, 0,
+     "do not print backend name in debug output"},
     {"print-new-line", KEY_PRINT_NEW_LINE, 0, 0,
-     "print new lines after debug output"},
+     "add a new line after debug ouput"},
     {"print-subnormal-normalized", KEY_PRINT_SUBNORMAL_NORMALIZED, 0, 0,
-     "print subnormal numbers as normalized"},
+     "normalize subnormal numbers"},
     {0}};
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
@@ -360,8 +360,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   case KEY_DEBUG_BINARY:
     ctx->debug_binary = true;
     break;
-  case KEY_NO_PRINT_DEBUG_MODE:
-    ctx->no_print_debug_mode = true;
+  case KEY_NO_BACKEND_NAME:
+    ctx->no_backend_name = true;
     break;
   case KEY_PRINT_NEW_LINE:
     ctx->print_new_line = true;
@@ -379,7 +379,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 void init_context(t_context *context) {
   context->debug = false;
   context->debug_binary = false;
-  context->no_print_debug_mode = false;
+  context->no_backend_name = false;
   context->print_new_line = false;
   context->print_subnormal_normalized = false;
 }

--- a/tests/test_ieee_backend/test_options.sh
+++ b/tests/test_ieee_backend/test_options.sh
@@ -46,12 +46,12 @@ for TYPE in float double; do
     check "$(grep -q "interflop_ieee_bin" log; echo $?)" "Error debug mode (interflop_ieee_bin) not printed"
 
     DEBUG_MODE="--debug"
-    OPTIONS="--no-print-debug-mode"
+    OPTIONS="--no-backend-name"
     run
     check "$(grep -vq "interflop_ieee" log; echo $?)" "Error debug mode (interflop_ieee) printed"
 
     DEBUG_MODE="--debug-binary"
-    OPTIONS="--no-print-debug-mode"
+    OPTIONS="--no-backend-name"
     run
     check "$(grep -vq "interflop_ieee_bin" log; echo $?)" "Error debug mode (interflop_ieee_bin) printed"
 

--- a/tests/test_ieee_backend_debug_binary/test.sh
+++ b/tests/test_ieee_backend_debug_binary/test.sh
@@ -42,7 +42,7 @@ compare() {
 export VFC_BACKENDS_SILENT_LOAD="TRUE"
 
 echo "denormal denormalized"
-export VFC_BACKENDS="libinterflop_ieee.so --debug-binary --print-new-line --no-print-debug-mode"
+export VFC_BACKENDS="libinterflop_ieee.so --debug-binary --print-new-line --no-backend-name"
 for REALTYPE in "float" "double"; do
     compile $REALTYPE
     run $REALTYPE 
@@ -50,7 +50,7 @@ for REALTYPE in "float" "double"; do
 done
 
 echo "denormal normalized"
-export VFC_BACKENDS="libinterflop_ieee.so --debug-binary --print-new-line --no-print-debug-mode --print-subnormal-normalized"
+export VFC_BACKENDS="libinterflop_ieee.so --debug-binary --print-new-line --no-backend-name --print-subnormal-normalized"
 for REALTYPE in "float" "double"; do
     compile $REALTYPE
     run $REALTYPE "denormal"


### PR DESCRIPTION
Clean up and reorganize README.

- Rephrased and shortened some sections
- Reorganized document for clarity
- Added a TOC
- Changed name of IEEE option no-print-debug which was not clear