### PR TITLE
Fix broken Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,7 @@ RUN git clone --depth=1 https://github.com/verificarlo/verificarlo.git &&  \
     ./configure --with-llvm=${LLVM_INSTALL_PATH} --with-dragonegg=${DRAGONEGG_PATH} CC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} || cat config.log 
 
 # Build and test verificarlo
-RUN cat $HOME/.bashrc && \
-    cd verificarlo && \
+RUN cd verificarlo && \
     make && sudo make install && \
     make installcheck
 

--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,6 @@ AC_CONFIG_FILES([Makefile
                  tests/paths.sh
                 ])
 
-AC_CONFIG_FILES([verificarlo.in], [])
+AC_CONFIG_FILES([verificarlo.in tests/test_bitmask_backend/test.sh], [chmod +x tests/test_bitmask_backend/test.sh])
 
 AC_OUTPUT

--- a/tests/test_bitmask_backend/test.sh.in
+++ b/tests/test_bitmask_backend/test.sh.in
@@ -64,8 +64,9 @@ check() {
 
 SAMPLES=100
 
-gcc -D REAL=double -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_float -lquadmath
-gcc -D REAL=float -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_double -lquadmath
+GCC="@GCC_PATH@"
+$GCC -D REAL=double -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_float -lquadmath
+$GCC -D REAL=float -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_double -lquadmath
 
 # Test operates at different precisions, and different operands.
 # It compares that results are equivalents up to the bit.


### PR DESCRIPTION
    - test_bitmask_backend/test.sh uses gcc that is unknown in Docker environment
    - creates a test_bitmask_backend/test.sh.in to generate the right path for gcc