### PR TITLE
Internal git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - libmpfr-dev
       - gcc-4.9 gcc-4.9-plugin-dev g++-4.9 gfortran-4.9 libgfortran-4.9-dev
       - autoconf automake build-essential libedit-dev binutils
-      - python3-dev python3-numpy cython3 wget xz-utils
+      - python3-dev python3-numpy cython3 wget xz-utils python3-pip python3-setuptools
 
 stages:
   - before_install
@@ -37,6 +37,8 @@ before_install:
   - LLVM_CONFIG=${LLVM_INSTALL_PATH}/bin/llvm-config GCC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} make
   - mkdir -p ${GCC_INSTALL_PATH}/plugin/
   - sudo cp dragonegg.so ${GCC_INSTALL_PATH}/plugin/dragonegg.so
+  - sudo pip3 install --upgrade pip
+  - sudo pip3 install bigfloat
 
 install:
   - cd $TRAVIS_BUILD_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -y update && apt-get -y install --no-install-recommends \
     bash ca-certificates make git libmpfr-dev \
     gcc-${GCC_VERSION} gcc-${GCC_VERSION}-plugin-dev g++-${GCC_VERSION} gfortran-${GCC_VERSION} libgfortran-${GCC_VERSION}-dev \
     autoconf automake libedit-dev libtool libz-dev \
-    python3 python3-numpy python3-matplotlib binutils vim sudo wget xz-utils && \
+    python3 python3-numpy python3-matplotlib python3-pip python3-setuptools binutils vim sudo wget xz-utils && \
     rm -rf /var/lib/apt/lists/
 
 WORKDIR /build/
@@ -41,6 +41,10 @@ RUN git clone -b gcc-llvm-3.6 --depth=1 https://github.com/yohanchatelain/Dragon
 WORKDIR DragonEgg
 RUN LLVM_CONFIG=${LLVM_INSTALL_PATH}/bin/llvm-config GCC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} make
 ARG DRAGONEGG_PATH=/build/DragonEgg/dragonegg.so
+
+# Install bigfloat package for manipulating MPFR with Python
+RUN sudo pip3 install --upgrade pip && \
+    sudo pip3 install bigfloat
 
 # Download and configure verificarlo from git master
 WORKDIR /build/verificarlo

--- a/README.md
+++ b/README.md
@@ -352,11 +352,11 @@ The `--ftz` (**Flush-To-Zero**) flushes subnormal output to 0.
 
 ```bash
    $ VFC_BACKENDS="libinterflop_mca.so --mode=ieee" ./test
-   $ 0x0.fffffep-126 +0x1.000000p-149 = 0x1.000000p-126
+   0x0.fffffep-126 +0x1.000000p-149 = 0x1.000000p-126
    $ VFC_BACKENDS="libinterflop_mca.so --mode=ieee --daz" ./test
-   $ 0x0.fffffep-126 +0x1.000000p-149 = 0x0
+   0x0.fffffep-126 +0x1.000000p-149 = 0x0
    $ VFC_BACKENDS="libinterflop_mca.so --mode=ieee --ftz" ./test
-   $ 0x0.fffffep-126 +0x1.000000p-149 = 0x1.000000p-126
+   0x0.fffffep-126 +0x1.000000p-149 = 0x1.000000p-126
 ```
 
 The option `--seed` fixes the random generator seed. It should not generally be used
@@ -465,7 +465,7 @@ developpement.
 
 ### VPREC Backend (libinterflop_vprec.so)
 
-The VPREC backend simulates any floating-point formats that can fits into
+The VPREC backend simulates any floating-point formats that can fit into
 the IEEE-754 double precision format with a round to the nearest.
 The backend allows modifying the bit length of the exponent (range) and the
 pseudo-mantissa (precision).
@@ -508,15 +508,15 @@ the new tested format for floating-point operations in double precision
 (respectively for single precision with --range-binary32).
 It accepts an integer value that represents the magnitude of the numbers.
 
-A detailled description of the backend is given [here](https://www.researchgate.net/profile/Yohan_Chatelain/publication/335232310_Automatic_Exploration_of_Reduced_Floating-Point_Representations_in_Iterative_Methods/links/5d8e18e9a6fdcc25549f95b3/Automatic-Exploration-of-Reduced-Floating-Point-Representations-in-Iterative-Methods.pdf).
+A detailed description of the backend is given [here](https://www.researchgate.net/profile/Yohan_Chatelain/publication/335232310_Automatic_Exploration_of_Reduced_Floating-Point_Representations_in_Iterative_Methods/links/5d8e18e9a6fdcc25549f95b3/Automatic-Exploration-of-Reduced-Floating-Point-Representations-in-Iterative-Methods.pdf).
 
-The following example shows the computation with the single precision and the simulation of the `bfloat16` format with VPREC:
+The following example shows the computation with single precision and the simulation of the `bfloat16` format with VPREC:
 
 ```bash
    $ VFC_BACKENDS="libinterflop_vprec.so --precision-binary32=23 --range-binary32=8" ./a.out
-   $ (2.903225*2.903225)*16384.000000 = 138096.062500
+   (2.903225*2.903225)*16384.000000 = 138096.062500
    $ VFC_BACKENDS="libinterflop_vprec.so --precision-binary32=10 --range-binary32=5" ./a.out
-   $ (2.903225*2.903225)*16384.000000 = inf
+   (2.903225*2.903225)*16384.000000 = inf
 ```
 
 ## Verificarlo inclusion / exclusion options

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ AC_CONFIG_FILES([Makefile
                  src/backends/interflop-mca-mpfr/Makefile
                  src/backends/interflop-cancellation/Makefile
                  src/backends/interflop-bitmask/Makefile
+		 src/backends/interflop-vprec/Makefile
                  tests/Makefile
                  tests/paths.sh
                 ])

--- a/src/backends/Makefile.am
+++ b/src/backends/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS= interflop-ieee interflop-mca interflop-mca-mpfr interflop-cancellation interflop-bitmask
+SUBDIRS= interflop-ieee interflop-mca interflop-mca-mpfr interflop-cancellation interflop-bitmask interflop-vprec

--- a/src/backends/interflop-vprec/Makefile.am
+++ b/src/backends/interflop-vprec/Makefile.am
@@ -1,0 +1,9 @@
+lib_LTLIBRARIES = libinterflop_vprec.la
+libinterflop_vprec_la_SOURCES = interflop_vprec.c  ../../common/logger.c
+libinterflop_vprec_la_CFLAGS = -DBACKEND_HEADER="interflop_vprec"
+if WALL_CFLAGS
+libinterflop_vprec_la_CFLAGS += -Wall -Wextra
+endif
+libinterflop_vprec_la_LDFLAGS = -lm
+libinterflop_vprec_la_LIBADD = ../../common/libvprec_tools.la
+library_includedir =$(includedir)/

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -1,0 +1,688 @@
+/*****************************************************************************
+ *                                                                           *
+ *  This file is part of Verificarlo.                                        *
+ *                                                                           *
+ *  Copyright (c) 2015                                                       *
+ *     Universite de Versailles St-Quentin-en-Yvelines                       *
+ *     CMLA, Ecole Normale Superieure de Cachan                              *
+ *  Copyright (c) 2019-2020                                                  *
+ *     Verificarlo contributors                                              *
+ *     Universite de Versailles St-Quentin-en-Yvelines                       *
+ *                                                                           *
+ *  Verificarlo is free software: you can redistribute it and/or modify      *
+ *  it under the terms of the GNU General Public License as published by     *
+ *  the Free Software Foundation, either version 3 of the License, or        *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  Verificarlo is distributed in the hope that it will be useful,           *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU General Public License for more details.                             *
+ *                                                                           *
+ *  You should have received a copy of the GNU General Public License        *
+ *  along with Verificarlo.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ *****************************************************************************/
+
+// Changelog:
+//
+// 2018-07-7 Initial version from scratch
+//
+// 2019-11-25 Code refactoring, format conversions moved to
+// ../../common/vprec_tools.c
+//
+
+#include <argp.h>
+#include <err.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include "../../common/float_const.h"
+#include "../../common/float_struct.h"
+#include "../../common/float_utils.h"
+#include "../../common/interflop.h"
+#include "../../common/logger.h"
+#include "../../common/vprec_tools.h"
+
+typedef enum {
+  KEY_PREC_B32,
+  KEY_PREC_B64,
+  KEY_RANGE_B32,
+  KEY_RANGE_B64,
+  KEY_MODE = 'm',
+  KEY_DAZ = 'd',
+  KEY_FTZ = 'f'
+} key_args;
+
+static const char key_prec_b32_str[] = "precision-binary32";
+static const char key_prec_b64_str[] = "precision-binary64";
+static const char key_range_b32_str[] = "range-binary32";
+static const char key_range_b64_str[] = "range-binary64";
+static const char key_mode_str[] = "mode";
+static const char key_daz_str[] = "daz";
+static const char key_ftz_str[] = "ftz";
+
+typedef struct {
+  bool daz;
+  bool ftz;
+} t_context;
+
+/* define the available VPREC modes of operation */
+typedef enum {
+  vprecmode_ieee,
+  vprecmode_full,
+  vprecmode_ib,
+  vprecmode_ob,
+  _vprecmode_end_
+} vprec_mode;
+
+/* Modes' names */
+static const char *VPREC_MODE_STR[] = {"ieee", "full", "ib", "ob"};
+
+/* define the possible VPREC operation */
+typedef enum {
+  vprec_add = '+',
+  vprec_sub = '-',
+  vprec_mul = '*',
+  vprec_div = '/',
+} vprec_operation;
+
+/* define default environment variables and default parameters */
+
+/* default values of precision and range for binary32 */
+#define VPREC_PRECISION_BINARY32_MIN 1
+#define VPREC_PRECISION_BINARY32_MAX FLOAT_PMAN_SIZE
+#define VPREC_PRECISION_BINARY32_DEFAULT FLOAT_PMAN_SIZE
+#define VPREC_RANGE_BINARY32_MIN 1
+#define VPREC_RANGE_BINARY32_MAX FLOAT_EXP_SIZE
+#define VPREC_RANGE_BINARY32_DEFAULT FLOAT_EXP_SIZE
+
+/* default values of precision and range for binary64 */
+#define VPREC_PRECISION_BINARY64_MIN 1
+#define VPREC_PRECISION_BINARY64_MAX DOUBLE_PMAN_SIZE
+#define VPREC_PRECISION_BINARY64_DEFAULT DOUBLE_PMAN_SIZE
+#define VPREC_RANGE_BINARY64_MIN 1
+#define VPREC_RANGE_BINARY64_MAX DOUBLE_EXP_SIZE
+#define VPREC_RANGE_BINARY64_DEFAULT DOUBLE_EXP_SIZE
+
+/* common default values */
+#define VPREC_MODE_DEFAULT vprecmode_ob
+
+/* variables that control precision, range and mode */
+static vprec_mode VPRECLIB_MODE = VPREC_MODE_DEFAULT;
+static int VPRECLIB_BINARY32_PRECISION = VPREC_PRECISION_BINARY32_DEFAULT;
+static int VPRECLIB_BINARY64_PRECISION = VPREC_PRECISION_BINARY64_DEFAULT;
+static int VPRECLIB_BINARY32_RANGE = VPREC_RANGE_BINARY32_DEFAULT;
+static int VPRECLIB_BINARY64_RANGE = VPREC_RANGE_BINARY64_DEFAULT;
+
+static float _vprec_binary32_binary_op(float a, float b,
+                                       const vprec_operation op, void *context);
+static double _vprec_binary64_binary_op(double a, double b,
+                                        const vprec_operation op,
+                                        void *context);
+
+/******************** VPREC CONTROL FUNCTIONS *******************
+ * The following functions are used to set virtual precision and
+ * VPREC mode of operation.
+ ***************************************************************/
+
+void _set_vprec_mode(vprec_mode mode) {
+  if (mode >= _vprecmode_end_) {
+    logger_error("invalid mode provided, must be one of: "
+                 "{ieee, full, ib, ob}.");
+  } else {
+    VPRECLIB_MODE = mode;
+  }
+}
+
+void _set_vprec_precision_binary32(int precision) {
+  if (precision < VPREC_PRECISION_BINARY32_MIN) {
+    logger_error("invalid precision provided for binary32."
+                 "Must be greater than %d",
+                 VPREC_PRECISION_BINARY32_MIN);
+  } else if (VPREC_PRECISION_BINARY32_MAX < precision) {
+    logger_error("invalid precision provided, "
+                 "must be lower than (%d)",
+                 VPREC_RANGE_BINARY32_MAX);
+  } else {
+    VPRECLIB_BINARY32_PRECISION = precision;
+  }
+}
+
+void _set_vprec_range_binary32(int range) {
+  if (range < VPREC_RANGE_BINARY32_MIN) {
+    logger_error("invalid range provided for binary32."
+                 "Must be greater than %d",
+                 VPREC_RANGE_BINARY32_MIN);
+  } else if (VPREC_RANGE_BINARY32_MAX < range) {
+    logger_error("invalid range provided, "
+                 "must be lower than (%d)",
+                 VPREC_RANGE_BINARY32_MAX);
+  } else {
+    VPRECLIB_BINARY32_RANGE = range;
+  }
+}
+
+void _set_vprec_precision_binary64(int precision) {
+  if (precision < VPREC_PRECISION_BINARY64_MIN) {
+    logger_error("invalid precision provided for binary64."
+                 "Must be greater than %d",
+                 VPREC_PRECISION_BINARY64_MIN);
+  } else if (VPREC_PRECISION_BINARY64_MAX < precision) {
+    logger_error("invalid precision provided, "
+                 "must be lower than (%d)",
+                 VPREC_RANGE_BINARY64_MAX);
+  } else {
+    VPRECLIB_BINARY64_PRECISION = precision;
+  }
+}
+
+void _set_vprec_range_binary64(int range) {
+  if (range < VPREC_RANGE_BINARY64_MIN) {
+    logger_error("invalid range provided for binary64."
+                 "Must be greater than %d",
+                 VPREC_RANGE_BINARY64_MIN);
+  } else if (VPREC_RANGE_BINARY64_MAX < range) {
+    logger_error("invalid range provided, "
+                 "must be lower than (%d)",
+                 VPREC_RANGE_BINARY64_MAX);
+  } else {
+    VPRECLIB_BINARY64_RANGE = range;
+  }
+}
+
+/******************** VPREC ARITHMETIC FUNCTIONS ********************
+ * The following set of functions perform the VPREC operation. Operands
+ * are first correctly rounded to the target precison format if inbound
+ * is set, the operation is then perform using IEEE hw and
+ * correct rounding to the target precision format is done if outbound
+ * is set.
+ *******************************************************************/
+
+/* perform_bin_op: applies the binary operator (op) to (a) and (b) */
+/* and stores the result in (res) */
+#define perform_binary_op(op, res, a, b)                                       \
+  switch (op) {                                                                \
+  case vprec_add:                                                              \
+    res = (a) + (b);                                                           \
+    break;                                                                     \
+  case vprec_mul:                                                              \
+    res = (a) * (b);                                                           \
+    break;                                                                     \
+  case vprec_sub:                                                              \
+    res = (a) - (b);                                                           \
+    break;                                                                     \
+  case vprec_div:                                                              \
+    res = (a) / (b);                                                           \
+    break;                                                                     \
+  default:                                                                     \
+    logger_error("invalid operator %c", op);                                   \
+  };
+
+static inline float _vprec_binary32_binary_op(float a, float b,
+                                              const vprec_operation op,
+                                              void *context) {
+  float res = 0;
+
+  /* test if a or b are special cases */
+  if (!isfinite(a) || !isfinite(b)) {
+    perform_binary_op(op, res, a, b);
+    return res;
+  }
+
+  /* round to zero or set to infinity if underflow or overflow compare to
+   * VPRECLIB_BINARY32_RANGE */
+  int emax = (1 << (VPRECLIB_BINARY32_RANGE - 1)) - 1;
+  int emin = (emax > 1) ? 1 - emax : -1;
+
+  /* if IB or FULL, bound operand precision */
+  if ((VPRECLIB_MODE == vprecmode_full) || (VPRECLIB_MODE == vprecmode_ib)) {
+
+    /* get operand exponent */
+    binary32 aexp = {.f32 = a};
+    binary32 bexp = {.f32 = b};
+
+    aexp.s32 = ((FLOAT_GET_EXP & aexp.u32) >> FLOAT_PMAN_SIZE) - FLOAT_EXP_COMP;
+    bexp.s32 = ((FLOAT_GET_EXP & bexp.u32) >> FLOAT_PMAN_SIZE) - FLOAT_EXP_COMP;
+
+    /* check for overflow or underflow in target range */
+    bool sp_case = false;
+    if (aexp.s32 > emax) {
+      a = a * INFINITY;
+      sp_case = true;
+    }
+
+    if (bexp.s32 > emax) {
+      b = b * INFINITY;
+      sp_case = true;
+    }
+
+    /* if exp of a or b between emin and emin -target prec  (mantissa lenth) */
+    /* denormal number case require a rounding and truncation to the
+     * representable part */
+    /* if below emin-target prec */
+    /* set to correctly signed zero */
+    if (aexp.s32 <= emin) {
+      if (((t_context *)context)->daz) {
+        a = 0;
+      } else {
+        a = handle_binary32_denormal(a, emin, aexp.u32,
+                                     VPRECLIB_BINARY32_PRECISION);
+      }
+    }
+
+    if (bexp.s32 <= emin) {
+      if (((t_context *)context)->daz) {
+        b = 0;
+      } else {
+        b = handle_binary32_denormal(b, emin, bexp.u32,
+                                     VPRECLIB_BINARY32_PRECISION);
+      }
+    }
+
+    /* Specials ops must be placed after denormal handling  */
+    /* If one of the operand raises an underflow the operation */
+    /* has a different behavior. Example: x*Inf != 0*Inf */
+    if (sp_case) {
+      perform_binary_op(op, res, a, b);
+      return res;
+    }
+
+    /* else normal case, can be executed even if a or b
+       previously rounded and truncated as denormal */
+    if (VPRECLIB_BINARY32_PRECISION < FLOAT_PMAN_SIZE) {
+      a = round_binary32_normal(a, VPRECLIB_BINARY32_PRECISION);
+      b = round_binary32_normal(b, VPRECLIB_BINARY32_PRECISION);
+    }
+  };
+
+  /* perform standard floating point operation on the correctly rounded
+   * arguments */
+  perform_binary_op(op, res, a, b);
+
+  if (!isfinite(res)) {
+    return res;
+  }
+
+  /* if OB or FULL mode, bound results precision */
+  if ((VPRECLIB_MODE == vprecmode_full) || (VPRECLIB_MODE == vprecmode_ob)) {
+    binary32 resexp = {.f32 = res};
+    resexp.s32 =
+        ((FLOAT_GET_EXP & resexp.u32) >> FLOAT_PMAN_SIZE) - FLOAT_EXP_COMP;
+
+    /* check for overflow in target range */
+    if (resexp.s32 > emax) {
+      resexp.f32 = res;
+      return res * INFINITY;
+    }
+
+    /* handle underflow or denormal for res */
+    if (resexp.s32 <= emin) {
+      if (((t_context *)context)->ftz) {
+        res = 0;
+      } else {
+        res = handle_binary32_denormal(res, emin, resexp.u32,
+                                       VPRECLIB_BINARY32_PRECISION);
+      }
+    }
+
+    /* normal case for res */
+    if (VPRECLIB_BINARY32_PRECISION < FLOAT_PMAN_SIZE) {
+      res = round_binary32_normal(res, VPRECLIB_BINARY32_PRECISION);
+    }
+  }
+  return res;
+}
+
+static inline double _vprec_binary64_binary_op(double a, double b,
+                                               const vprec_operation op,
+                                               void *context) {
+  double res = 0;
+
+  /* test if a or b are special cases */
+  if (!isfinite(a) || !isfinite(b)) {
+    perform_binary_op(op, res, a, b);
+    return res;
+  }
+
+  /* round to zero or set to infinity if underflow or overflow compare to
+   * VPRECLIB_BINARY64_RANGE */
+  int emax = (1 << (VPRECLIB_BINARY64_RANGE - 1)) - 1;
+  int emin = (emax > 1) ? 1 - emax : -1;
+
+  /* if IB or FULL, bound operand precision */
+  if ((VPRECLIB_MODE == vprecmode_full) || (VPRECLIB_MODE == vprecmode_ib)) {
+
+    /* get operand exponent */
+    binary64 aexp = {.f64 = a};
+    binary64 bexp = {.f64 = b};
+
+    aexp.s64 =
+        ((DOUBLE_GET_EXP & aexp.u64) >> DOUBLE_PMAN_SIZE) - DOUBLE_EXP_COMP;
+    bexp.s64 =
+        ((DOUBLE_GET_EXP & bexp.u64) >> DOUBLE_PMAN_SIZE) - DOUBLE_EXP_COMP;
+
+    /* check for overflow or underflow in target range */
+    bool sp_case = false;
+    if (aexp.s64 > emax) {
+      a = a * INFINITY;
+      sp_case = true;
+    }
+
+    if (bexp.s64 > emax) {
+      b = b * INFINITY;
+      sp_case = true;
+    }
+
+    /* if exp of a or b between emin and emin -target prec  (mantissa lenth) */
+    /* denormal number case require a roundin and truncation to the
+     * representable part */
+    /* if below emin-target prec */
+    /* set to correctly signed zero */
+    if (aexp.s64 <= emin) {
+      if (((t_context *)context)->daz) {
+        a = 0;
+      } else {
+        a = handle_binary64_denormal(a, emin, aexp.u64,
+                                     VPRECLIB_BINARY64_PRECISION);
+      }
+    }
+
+    if (bexp.s64 <= emin) {
+      if (((t_context *)context)->daz) {
+        b = 0;
+      } else {
+        b = handle_binary64_denormal(b, emin, bexp.u64,
+                                     VPRECLIB_BINARY64_PRECISION);
+      }
+    }
+
+    /* Specials ops must be placed after denormal handling  */
+    /* If one of the operand raises an underflow the operation */
+    /* has a different behavior. Example: x*Inf != 0*Inf */
+    if (sp_case) {
+      perform_binary_op(op, res, a, b);
+      return res;
+    }
+
+    /* else normal case, can be executed even if a or b previously rounded and
+     * truncated as denormal */
+    if (VPRECLIB_BINARY64_PRECISION < DOUBLE_PMAN_SIZE) {
+      a = round_binary64_normal(a, VPRECLIB_BINARY64_PRECISION);
+      b = round_binary64_normal(b, VPRECLIB_BINARY64_PRECISION);
+    }
+  }
+
+  /* perform standard floating point operation on the correctly rounded
+   * arguments */
+  perform_binary_op(op, res, a, b);
+
+  if (!isfinite(res)) {
+    return res;
+  }
+
+  /* if OB or FULL mode, bound results precision */
+  if ((VPRECLIB_MODE == vprecmode_full) || (VPRECLIB_MODE == vprecmode_ob)) {
+    binary64 resexp = {.f64 = res};
+    resexp.s64 =
+        ((DOUBLE_GET_EXP & resexp.u64) >> DOUBLE_PMAN_SIZE) - DOUBLE_EXP_COMP;
+
+    /* check for overflow in target range */
+    if (resexp.s64 > emax) {
+      return res * INFINITY;
+    }
+
+    /* handle underflow or denormal for res */
+    if (resexp.s64 <= emin) {
+      if (((t_context *)context)->ftz) {
+        res = 0;
+      } else {
+        res = handle_binary64_denormal(res, emin, resexp.u64,
+                                       VPRECLIB_BINARY64_PRECISION);
+      }
+    }
+
+    /* normal case for res */
+    if (VPRECLIB_BINARY64_PRECISION < DOUBLE_PMAN_SIZE) {
+      res = round_binary64_normal(res, VPRECLIB_BINARY64_PRECISION);
+    }
+  };
+
+  return res;
+}
+
+/************************* FPHOOKS FUNCTIONS *************************
+ * These functions correspond to those inserted into the source code
+ * during source to source compilation and are replacement to floating
+ * point operators
+ **********************************************************************/
+
+static void _interflop_add_float(float a, float b, float *c, void *context) {
+  *c = _vprec_binary32_binary_op(a, b, vprec_add, context);
+}
+
+static void _interflop_sub_float(float a, float b, float *c, void *context) {
+  *c = _vprec_binary32_binary_op(a, b, vprec_sub, context);
+}
+
+static void _interflop_mul_float(float a, float b, float *c, void *context) {
+  *c = _vprec_binary32_binary_op(a, b, vprec_mul, context);
+}
+
+static void _interflop_div_float(float a, float b, float *c, void *context) {
+  *c = _vprec_binary32_binary_op(a, b, vprec_div, context);
+}
+
+static void _interflop_add_double(double a, double b, double *c,
+                                  void *context) {
+  *c = _vprec_binary64_binary_op(a, b, vprec_add, context);
+}
+
+static void _interflop_sub_double(double a, double b, double *c,
+                                  void *context) {
+  *c = _vprec_binary64_binary_op(a, b, vprec_sub, context);
+}
+
+static void _interflop_mul_double(double a, double b, double *c,
+                                  void *context) {
+  *c = _vprec_binary64_binary_op(a, b, vprec_mul, context);
+}
+
+static void _interflop_div_double(double a, double b, double *c,
+                                  void *context) {
+  *c = _vprec_binary64_binary_op(a, b, vprec_div, context);
+}
+
+static struct argp_option options[] = {
+    /* --debug, sets the variable debug = true */
+    {key_prec_b32_str, KEY_PREC_B32, "PRECISION", 0,
+     "select precision for binary32 (PRECISION >= 0)"},
+    {key_prec_b64_str, KEY_PREC_B64, "PRECISION", 0,
+     "select precision for binary64 (PRECISION >= 0)"},
+    {key_range_b32_str, KEY_RANGE_B32, "RANGE", 0,
+     "select range for binary32 (0 < RANGE && RANGE <= 11)"},
+    {key_range_b64_str, KEY_RANGE_B64, "RANGE", 0,
+     "select range for binary64 (0 < RANGE && RANGE <= 11)"},
+    {key_mode_str, KEY_MODE, "MODE", 0,
+     "select VPREC mode among {ieee, full, ib, ob}"},
+    {key_daz_str, KEY_DAZ, 0, 0,
+     "denormals-are-zero: sets denormals inputs to zero"},
+    {key_ftz_str, KEY_FTZ, 0, 0, "flush-to-zero: sets denormal output to zero"},
+    {0}};
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+  t_context *ctx = (t_context *)state->input;
+  char *endptr;
+  int val = -1;
+  switch (key) {
+  case KEY_PREC_B32:
+    /* precision */
+    errno = 0;
+    val = strtol(arg, &endptr, 10);
+    if (errno != 0 || val < VPREC_PRECISION_BINARY32_MIN) {
+      logger_error("--%s invalid value provided, must be a "
+                   "positive integer.",
+                   key_prec_b32_str);
+    } else if (val > VPREC_PRECISION_BINARY32_MAX) {
+      logger_error("--%s invalid value provided, "
+                   "must lower than IEEE binary32 precision (%d)",
+                   key_prec_b32_str, VPREC_PRECISION_BINARY32_MAX);
+    } else {
+      _set_vprec_precision_binary32(val);
+    }
+    break;
+  case KEY_PREC_B64:
+    /* precision */
+    errno = 0;
+    val = strtol(arg, &endptr, 10);
+    if (errno != 0 || val < VPREC_PRECISION_BINARY64_MIN) {
+      logger_error("--%s invalid value provided, must be a "
+                   "positive integer.",
+                   key_prec_b64_str);
+    } else if (val > VPREC_PRECISION_BINARY64_MAX) {
+      logger_error("--%s invalid value provided, "
+                   "must be lower than IEEE binary64 precision (%d)",
+                   key_prec_b64_str, VPREC_PRECISION_BINARY64_MAX);
+    } else {
+      _set_vprec_precision_binary64(val);
+    }
+    break;
+  case KEY_RANGE_B32:
+    /* precision */
+    errno = 0;
+    val = strtol(arg, &endptr, 10);
+    if (errno != 0 || val < VPREC_RANGE_BINARY32_MIN) {
+      logger_error("--%s invalid value provided, must be a "
+                   "positive integer.",
+                   key_range_b32_str);
+    } else if (val > VPREC_RANGE_BINARY32_MAX) {
+      logger_error("--%s invalid value provided, "
+                   "must be lower than IEEE binary32 range size (%d)",
+                   key_range_b32_str, VPREC_RANGE_BINARY32_MAX);
+    } else {
+      _set_vprec_range_binary32(val);
+    }
+    break;
+  case KEY_RANGE_B64:
+    /* precision */
+    errno = 0;
+    val = strtol(arg, &endptr, 10);
+    if (errno != 0 || val < VPREC_RANGE_BINARY64_MIN) {
+      logger_error("--%s invalid value provided, must be a "
+                   "positive integer.",
+                   key_range_b64_str);
+    } else if (val > VPREC_RANGE_BINARY64_MAX) {
+      logger_error("--%s invalid value provided, "
+                   "must be lower than IEEE binary64 range size (%d)",
+                   key_range_b64_str, VPREC_RANGE_BINARY64_MAX);
+    } else {
+      _set_vprec_range_binary64(val);
+    }
+    break;
+  case KEY_MODE:
+    /* mode */
+    if (strcasecmp(VPREC_MODE_STR[vprecmode_ieee], arg) == 0) {
+      _set_vprec_mode(vprecmode_ieee);
+    } else if (strcasecmp(VPREC_MODE_STR[vprecmode_full], arg) == 0) {
+      _set_vprec_mode(vprecmode_full);
+    } else if (strcasecmp(VPREC_MODE_STR[vprecmode_ib], arg) == 0) {
+      _set_vprec_mode(vprecmode_ib);
+    } else if (strcasecmp(VPREC_MODE_STR[vprecmode_ob], arg) == 0) {
+      _set_vprec_mode(vprecmode_ob);
+    } else {
+      logger_error("--%s invalid value provided, must be one of: "
+                   "{ieee, full, ib, ob}.",
+                   key_mode_str);
+    }
+    break;
+  case KEY_DAZ:
+    /* denormals-are-zero */
+    ctx->daz = true;
+    break;
+  case KEY_FTZ:
+    /* flush-to-zero */
+    ctx->ftz = true;
+    break;
+  default:
+    return ARGP_ERR_UNKNOWN;
+  }
+  return 0;
+}
+
+static struct argp argp = {options, parse_opt, "", ""};
+
+void init_context(t_context *ctx) {
+  ctx->daz = false;
+  ctx->ftz = false;
+}
+
+void print_information_header(void *context) {
+  /* Environnement variable to disable loading message */
+  char *silent_load_env = getenv("VFC_BACKENDS_SILENT_LOAD");
+  bool silent_load =
+      ((silent_load_env == NULL) || (strcasecmp(silent_load_env, "True") != 0))
+          ? false
+          : true;
+
+  if (silent_load)
+    return;
+
+  t_context *ctx = (t_context *)context;
+
+  logger_info(
+      "load backend with "
+      "%s = %d, "
+      "%s = %d, "
+      "%s = %d, "
+      "%s = %d, "
+      "%s = %s, "
+      "%s = %s and "
+      "%s = %s"
+      "\n",
+      key_prec_b32_str, VPRECLIB_BINARY32_PRECISION, key_range_b32_str,
+      VPRECLIB_BINARY32_RANGE, key_prec_b64_str, VPRECLIB_BINARY64_PRECISION,
+      key_range_b64_str, VPRECLIB_BINARY64_RANGE, key_mode_str,
+      VPREC_MODE_STR[VPRECLIB_MODE], key_daz_str, ctx->daz ? "true" : "false",
+      key_ftz_str, ctx->ftz ? "true" : "false");
+}
+
+struct interflop_backend_interface_t interflop_init(int argc, char **argv,
+                                                    void **context) {
+
+  /* Initialize the logger */
+  logger_init();
+
+  /* Setting to default values */
+  _set_vprec_precision_binary32(VPREC_PRECISION_BINARY32_DEFAULT);
+  _set_vprec_precision_binary64(VPREC_PRECISION_BINARY64_DEFAULT);
+  _set_vprec_range_binary32(VPREC_RANGE_BINARY32_DEFAULT);
+  _set_vprec_range_binary64(VPREC_RANGE_BINARY64_DEFAULT);
+  _set_vprec_mode(VPREC_MODE_DEFAULT);
+
+  t_context *ctx = malloc(sizeof(t_context));
+  *context = ctx;
+  init_context(ctx);
+
+  /* parse backend arguments */
+  argp_parse(&argp, argc, argv, 0, 0, ctx);
+
+  print_information_header(ctx);
+
+  struct interflop_backend_interface_t interflop_backend_vprec = {
+      _interflop_add_float,
+      _interflop_sub_float,
+      _interflop_mul_float,
+      _interflop_div_float,
+      NULL,
+      _interflop_add_double,
+      _interflop_sub_double,
+      _interflop_mul_double,
+      _interflop_div_double,
+      NULL};
+
+  return interflop_backend_vprec;
+}

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,5 +1,12 @@
-noinst_LTLIBRARIES = libtinymt64.la
+noinst_LTLIBRARIES = libtinymt64.la libvprec_tools.la
+
 libtinymt64_la_CFLAGS = -fPIC -static
 libtinymt64_la_SOURCES = \
 	tinymt64.h \
 	tinymt64.c
+
+libvprec_tools_la_CFLAGS = -fPIC -static
+libvprec_tools_la_SOURCES = \
+	vprec_tools.h \
+	vprec_tools.c
+library_includedir =$(includedir)/

--- a/src/common/vprec_tools.c
+++ b/src/common/vprec_tools.c
@@ -1,0 +1,150 @@
+/*****************************************************************************
+ *                                                                           *
+ *  This file is part of Verificarlo.                                        *
+ *                                                                           *
+ *  Copyright (c) 2015                                                       *
+ *     Universite de Versailles St-Quentin-en-Yvelines                       *
+ *     CMLA, Ecole Normale Superieure de Cachan                              *
+ *  Copyright (c) 2019                                                       *
+ *     Universite de Versailles St-Quentin-en-Yvelines                       *
+ *                                                                           *
+ *  Verificarlo is free software: you can redistribute it and/or modify      *
+ *  it under the terms of the GNU General Public License as published by     *
+ *  the Free Software Foundation, either version 3 of the License, or        *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  Verificarlo is distributed in the hope that it will be useful,           *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU General Public License for more details.                             *
+ *                                                                           *
+ *  You should have received a copy of the GNU General Public License        *
+ *  along with Verificarlo.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ *****************************************************************************/
+
+#include "vprec_tools.h"
+#include "float_const.h"
+#include "float_struct.h"
+
+inline float round_binary32_denormal(float x, int emin, int xexp,
+                                     int precision) {
+
+  /* build 1/2 ulp and add it  before truncation for faithfull rounding */
+
+  /* position to the end of the target prec-1 */
+  const uint32_t target_position = FLOAT_PMAN_SIZE - precision - 1;
+
+  /*precision loss due to denormalizqation*/
+  const uint32_t precision_loss = emin - xexp;
+
+  /* truncate the trailing bits */
+  const uint32_t mask_denormal =
+      0xFFFFFFFF << (FLOAT_PMAN_SIZE - precision + precision_loss);
+
+  binary32 b32_x = {.f32 = x};
+  b32_x.ieee.mantissa = 0;
+  binary32 half_ulp = {.f32 = x};
+  half_ulp.ieee.mantissa = 1 << (target_position + precision_loss);
+
+  b32_x.f32 = x + (half_ulp.f32 - b32_x.f32);
+  b32_x.u32 &= mask_denormal;
+
+  return b32_x.f32;
+}
+
+inline float round_binary32_normal(float x, int precision) {
+
+  /* build 1/2 ulp and add it  before truncation for faithfull rounding */
+
+  /* generate a mask to erase the last 23-VPRECLIB_PREC bits, in other word,
+     it remains VPRECLIB_PREC bit in the mantissa */
+  const uint32_t mask = 0xFFFFFFFF << (FLOAT_PMAN_SIZE - precision);
+
+  /* position to the end of the target prec-1 */
+  const uint32_t target_position = FLOAT_PMAN_SIZE - precision - 1;
+
+  binary32 b32x = {.f32 = x};
+  b32x.ieee.mantissa = 0;
+  binary32 half_ulp = {.f32 = x};
+  half_ulp.ieee.mantissa = (1 << target_position);
+
+  b32x.f32 = x + (half_ulp.f32 - b32x.f32);
+  b32x.u32 &= mask;
+
+  return b32x.f32;
+}
+
+inline double round_binary64_denormal(double x, int emin, int xexp,
+                                      int precision) {
+
+  /* build 1/2 ulp and add it before truncation for faithfull rounding */
+
+  /* position to the end of the target prec-1 */
+  const uint64_t target_position = DOUBLE_PMAN_SIZE - precision - 1;
+
+  /*precision loss due to denormalization*/
+  const uint64_t precision_loss = emin - xexp;
+
+  /* truncate the trailing bits */
+  const uint64_t mask_denormal =
+      0xFFFFFFFFFFFFFFFF << (DOUBLE_PMAN_SIZE - precision + precision_loss);
+
+  binary64 b64x = {.f64 = x};
+  b64x.ieee.mantissa = 0;
+  binary64 half_ulp = {.f64 = x};
+  half_ulp.ieee.mantissa = 1ULL << (target_position + precision_loss);
+
+  b64x.f64 = x + (half_ulp.f64 - b64x.f64);
+  b64x.u64 &= mask_denormal;
+
+  return b64x.f64;
+}
+
+inline double round_binary64_normal(double x, int precision) {
+
+  /* build 1/2 ulp and add it  before truncation for faithfull rounding */
+
+  /* generate a mask to erase the last 52-VPRECLIB_PREC bits, in other word,
+     it remains VPRECLIB_PREC bit in the mantissa */
+  const uint64_t mask = 0xFFFFFFFFFFFFFFFF << (DOUBLE_PMAN_SIZE - precision);
+
+  /* position to the end of the target prec-1 */
+  const uint64_t target_position = DOUBLE_PMAN_SIZE - precision - 1;
+
+  binary64 b64x = {.f64 = x};
+  b64x.ieee.mantissa = 0;
+  binary64 half_ulp = {.f64 = x};
+  half_ulp.ieee.mantissa = 1ULL << target_position;
+
+  b64x.f64 = x + (half_ulp.f64 - b64x.f64);
+  b64x.u64 &= mask;
+
+  return b64x.f64;
+}
+
+inline float handle_binary32_denormal(float x, int emin, int xexp,
+                                      int precision) {
+  /* underflow */
+  if (xexp < (emin - precision)) {
+    /* multiply by 0 a to keep the sign */
+    return x * 0;
+  }
+  /* denormal */
+  else if (precision <= FLOAT_PMAN_SIZE) {
+    return round_binary32_denormal(x, emin, xexp, precision);
+  }
+}
+
+inline double handle_binary64_denormal(double x, int emin, int xexp,
+                                       int precision) {
+  /* underflow */
+  if (xexp < (emin - precision)) {
+    /* multiply by a 0 to keep the sign */
+    return x * 0;
+  }
+  /* denormal */
+  else if (precision <= DOUBLE_PMAN_SIZE) {
+    return round_binary64_denormal(x, emin, xexp, precision);
+  }
+}

--- a/src/common/vprec_tools.h
+++ b/src/common/vprec_tools.h
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ *                                                                           *
+ *  This file is part of Verificarlo.                                        *
+ *                                                                           *
+ *  Copyright (c) 2015                                                       *
+ *     Universite de Versailles St-Quentin-en-Yvelines                       *
+ *     CMLA, Ecole Normale Superieure de Cachan                              *
+ *  Copyright (c) 2019-2020                                                  *
+ *     Verificarlo contributors                                              *
+ *     Universite de Versailles St-Quentin-en-Yvelines                       *
+ *                                                                           *
+ *  Verificarlo is free software: you can redistribute it and/or modify      *
+ *  it under the terms of the GNU General Public License as published by     *
+ *  the Free Software Foundation, either version 3 of the License, or        *
+ *  (at your option) any later version.                                      *
+ *                                                                           *
+ *  Verificarlo is distributed in the hope that it will be useful,           *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *  GNU General Public License for more details.                             *
+ *                                                                           *
+ *  You should have received a copy of the GNU General Public License        *
+ *  along with Verificarlo.  If not, see <http://www.gnu.org/licenses/>.     *
+ *                                                                           *
+ *****************************************************************************/
+
+#ifndef __VPREC_TOOLS_H__
+#define __VPREC_TOOLS_H__
+
+/******************** VPREC ARITHMETIC FUNCTIONS ********************
+ * The following set of functions perform the VPREC operation. Operands
+ * are first correctly rounded to the target precison format if inbound
+ * is set, the operation is then perform using IEEE hw and
+ * correct rounding to the target precision format is done if outbound
+ * is set.
+ *******************************************************************/
+
+float round_binary32_denormal(float x, int emin, int xexp, int precision);
+float round_binary32_normal(float x, int precision);
+float handle_binary32_denormal(float x, int emin, int xexp, int precision);
+
+double round_binary64_normal(double x, int precision);
+double round_binary64_denormal(double x, int emin, int xexp, int precision);
+double handle_binary64_denormal(double x, int emin, int xexp, int precision);
+
+#endif /* __VPREC_TOOLS_H__ */

--- a/tests/test_vprec_backend/check_output.py
+++ b/tests/test_vprec_backend/check_output.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+
+import os
+import math
+import sys
+
+exit_at_error = False
+
+PRECISION="VERIFICARLO_PRECISION"
+mpfr_file="mpfr.txt"
+vprec_file="vprec.txt"
+
+def get_var_env_int(env):
+
+    varenv = os.getenv(env)
+    if varenv and varenv.isdigit():
+        return int(varenv)
+    else:
+        print("Bad {env} {varenv}".format(env=env, varenv=varenv))
+        exit(1)
+
+def parse_file(filename):
+    fi = open(filename, "r")
+    fp_list = []
+    return [float.fromhex(line) for line in fi]
+
+def get_relative_error(mpfr, vprec):
+
+    if math.isnan(mpfr) != math.isnan(vprec):
+        print("Error NaN")
+        exit(1)
+    elif math.isinf(mpfr) != math.isinf(vprec):
+        print("Error Inf")
+        exit(1)
+    elif math.isnan(mpfr) and math.isnan(vprec):
+        return -1
+    elif mpfr == vprec:
+        return -1
+    elif mpfr == 0.0:
+        return abs(vprec)
+    elif vprec == 0.0:
+        return abs(mpfr)
+    else:
+        return abs((mpfr-vprec)/mpfr)
+
+def get_significant_digits(relative_error):
+    # Special case when mpfr == vprec
+    # return high significance
+    if relative_error == -1:
+        return 100
+    else:
+        return abs(math.log(relative_error,2))
+
+def are_equal(mpfr, vprec):
+    if math.isnan(mpfr) and math.isnan(vprec):
+        return True
+    else:
+        return mpfr == vprec
+
+def compute_err(precision, mpfr_list, vprec_list):
+    for mpfr,vprec in zip(mpfr_list,vprec_list):
+        print("Compare MPFR,VPREC:{mpfr} {vprec}".format(mpfr=mpfr,vprec=vprec))
+        relative_error = get_relative_error(mpfr, vprec)
+        s = get_significant_digits(relative_error)
+        if math.ceil(s) < precision:
+            float_type=os.getenv('VERIFICARLO_VPREC_TYPE')
+            vprec_range=os.getenv('VERIFICARLO_VPREC_RANGE')
+            vprec_precision=os.getenv('VERIFICARLO_PRECISION')
+            vprec_mode=os.getenv('VERIFICARLO_VPREC_MODE')
+            op=os.getenv('VERIFICARLO_OP')
+            sys.stderr.write("{t}: MODE={m} RANGE={r} PRECISION={p} OP={op}\n".format(
+                t=float_type,
+                m=vprec_mode,
+                r=vprec_range,
+                p=vprec_precision,
+                op=op))
+
+            sys.stderr.write("Relative error too high: mpfr={mpfr} vprec={vprec} error={err} ({el} b=2)\n".format(
+                mpfr=mpfr,
+                vprec=vprec,
+                err=relative_error,
+                el=s))
+
+            sys.stderr.flush()
+            if exit_at_error:
+                exit(1)
+
+if "__main__" == __name__:
+
+    precision = get_var_env_int(PRECISION)
+    mpfr_list = parse_file(mpfr_file)
+    vprec_list = parse_file(vprec_file)
+
+    compute_err(precision, mpfr_list, vprec_list)
+
+    exit(0)

--- a/tests/test_vprec_backend/comparison.sh
+++ b/tests/test_vprec_backend/comparison.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+print_usage() {
+    echo "Usage: <float> <float> <operation> <type>"
+    echo "       <float>: floating point value in hex c99 format"
+    echo "       <operation>: {+,-,/,x}"
+    echo "       <type>: {float,double}"
+}
+
+check_float() {
+    case $1 in
+	float|double) ;;
+	*) print_usage; exit 1;;
+    esac
+}
+
+check_op() {
+    case $op in
+	+|-|/|x) ;;
+	*) print_usage; exit 1;;
+    esac
+}
+
+print_context() {
+    echo "VFC_BACKENDS=${VFC_BACKENDS}"
+}
+
+if [[ $# != 4 ]]; then
+    print_usage
+    exit 1
+else
+    x=$1
+    y=$2
+    op=$3
+    float_type=$4    
+fi
+
+print_context
+
+verificarlo compute_vprec_rounding.c -DREAL="${float_type}" -o compute_vprec_rounding
+
+./compute_mpfr_rounding.py $x $y $op $float_type
+./compute_vprec_rounding $x $y $op 

--- a/tests/test_vprec_backend/compute_mpfr_rounding.py
+++ b/tests/test_vprec_backend/compute_mpfr_rounding.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python3
+
+from bigfloat import *
+import sys
+import os
+import math
+import functools
+
+verbose_mode=False
+VERBOSE_MODE="VERBOSE_MODE"
+
+op_list = ["+","-","x","/"]
+op2bfOp = { "+" : add,
+            "-" : sub,
+            "x" : mul,
+            "/" : div  }
+
+VPREC_RANGE="VERIFICARLO_VPREC_RANGE"
+PRECISION  ="VERIFICARLO_PRECISION"
+VPREC_MODE="VERIFICARLO_VPREC_MODE"
+
+mode_ieee = "IEEE"
+mode_pb   = "IB"
+mode_ob   = "OB"
+mode_full = "FULL"
+
+def parse_file(filename):
+    fi = open(filename, "r")
+    return [BigFloat(fp.strip()) for fp in fi]
+
+def check_op(op):
+    if op in op_list:
+        return op2bfOp[op]
+    else:
+        print("Bad op {op}".format(op=op))
+        exit(1)
+
+def get_var_env_int(env):
+
+    varenv = os.getenv(env)
+    if varenv and varenv.isdigit():
+        return int(varenv)
+    else:
+        print("Bad {env} {varenv}".format(env=env, varenv=varenv))
+        exit(1)
+
+def get_var_env(env):
+
+    varenv = os.getenv(env)
+    if varenv:
+        return varenv
+    else:
+        print("Bad {env} {varenv}".format(env=env, varenv=varenv))
+        exit(1)
+
+def set_custom_context(vrange, prec):
+    emax = 2**(vrange-1)
+    emin = -2**(vrange-1) - prec + 4
+
+    context = Context(precision=prec,
+                      emin=emin,
+                      emax=emax,
+                      subnormalize=True,
+                      rounding=ROUND_TIES_TO_EVEN)
+
+    setcontext(context)
+    return context
+
+def get_context_type(float_type):
+    if float_type == "float":
+        return single_precision
+    elif float_type == "double":
+        return double_precision
+    else:
+        print("Unknown type {t}".format(t=float_type))
+        exit(1)
+
+# 0x0.xp+e
+def hex_normalize(flt):
+    if math.isinf(flt) or math.isnan(flt) or flt==0.0:
+        return str(flt)
+
+    hex_str = flt.hex()
+    s = functools.reduce(lambda s,f : s.replace(f,'.'), ['0x', '.', 'p'], hex_str)
+    s = s.split('.')
+
+    try:
+        sign = '+'
+        [first, frac, exp] = filter(lambda x : x != '', s)
+    except ValueError:
+        [sign, first, frac, exp] = filter(lambda x : x != '', s)
+    except Exception as e:
+        print(e)
+        print(flt,s)
+        exit(1)
+
+    mantissa = str(hex(int(frac,16) << 1))
+    mantissa = mantissa.replace('1','1.',1)
+    exp = int(exp)-1
+    signe_exp = '+' if exp >= 0 else ''
+    hex_normalize = "{sign}{mant}p{signe_exp}{exp}".format(sign=sign,
+                                                           mant=mantissa,
+                                                           signe_exp=signe_exp,
+                                                           exp=exp)
+    return hex_normalize
+
+def print_mpfr_hex(name, mpfr_x, msg=''):
+    if verbose_mode:
+        res = hex_normalize(mpfr_x)
+        fmt = "[MPFR] {msg} {name}={r}\n".format(name=name, r=res, msg=msg)
+        sys.stderr.write(fmt)
+
+def check_verbose_mode():
+    global verbose_mode
+    verbose_env = os.getenv(VERBOSE_MODE)
+    if verbose_env:
+        verbose_mode=True
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 5:
+        print("4 arguments expected: a b op context")
+        exit(1)
+
+    check_verbose_mode()
+
+    a = sys.argv[1]
+    b = sys.argv[2]
+    op = check_op(sys.argv[3])
+    context_type = get_context_type(sys.argv[4])
+    setcontext(context_type)
+
+    vrange = get_var_env_int(VPREC_RANGE)
+    prec = get_var_env_int(PRECISION)+1
+    mode = get_var_env(VPREC_MODE)
+
+    # DEBUG
+    mpfr_a = BigFloat.fromhex(a)
+    mpfr_b = BigFloat.fromhex(b)
+    print_mpfr_hex('a', mpfr_a, '(before rounding)')
+    print_mpfr_hex('b', mpfr_b, '(before rounding)')
+
+    if mode == mode_pb or mode == mode_full:
+        set_custom_context(vrange, prec)
+    else:
+        setcontext(context_type)
+
+    mpfr_a = BigFloat.fromhex(a)
+    mpfr_b = BigFloat.fromhex(b)
+
+    if mode == mode_ob or mode == mode_full:
+        set_custom_context(vrange, prec)
+    else:
+        setcontext(context_type)
+
+    res = op(mpfr_a, mpfr_b)
+
+    print_mpfr_hex('a', mpfr_a)
+    print_mpfr_hex('b', mpfr_b)
+    print_mpfr_hex('res', res)
+
+    print(hex_normalize(res))

--- a/tests/test_vprec_backend/compute_vprec_rounding.c
+++ b/tests/test_vprec_backend/compute_vprec_rounding.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+REAL perform_bin_op(REAL a, REAL b, char op) {
+  switch(op){
+  case '+':
+    return (a) + (b);
+  case '-':
+    return (a) - (b);
+  case 'x':
+    return (a) * (b);
+  case '/':
+    return (a) / (b);
+  default:
+    fprintf(stderr, "Bad op %c\n",op);
+    exit(EXIT_FAILURE);
+  }
+}
+
+int main(int argc, char * argv[]) {
+
+  if (argc != 4) {
+    fprintf(stderr, "3 arguments expected: a b op\n");
+    exit(EXIT_FAILURE);
+  }
+
+  REAL a = strtod(argv[1], NULL);
+  REAL b = strtod(argv[2], NULL);
+  char op = argv[3][0];
+
+  REAL c = perform_bin_op(a,b,op);
+
+  printf("%a\n",c);
+
+  return 0;
+}

--- a/tests/test_vprec_backend/generate_input.py
+++ b/tests/test_vprec_backend/generate_input.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+import numpy as np
+import sys
+
+output_filename = "input.txt"
+
+def print_random_fp(n, r, output_filename):
+
+    emax = 2**(r-1)-1
+    rand_fp_array_1 = np.random.normal(loc=0, scale=2**emax, size=n)
+    rand_fp_array_2 = np.random.normal(loc=0, scale=2**emax, size=n)
+
+    fo = open(output_filename, "w")
+
+    for fp1,fp2 in zip(rand_fp_array_1,rand_fp_array_2):
+        fo.write("{f1} {f2}\n".format(f1=fp1.hex(), f2=fp2.hex()))
+
+    fo.close()
+
+if "__main__" == __name__:
+
+    n = int(sys.argv[1])
+    r = int(sys.argv[1])
+
+    print_random_fp(n, r, output_filename)

--- a/tests/test_vprec_backend/generic_test.sh
+++ b/tests/test_vprec_backend/generic_test.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+if [[ $# != 4 ]]; then
+    echo "expected 4 arguments, $# given"
+    echo "range_min range_step precision_min precision_step"
+    exit 1
+else
+    RANGE_MIN=$1
+    RANGE_STEP=$2
+    PRECISION_MIN=$3
+    PRECISION_STEP=$4
+    echo "RANGE_MIN=${RANGE_MIN}"
+    echo "RANGE_STEP=${RANGE_STEP}"
+    echo "PRECISION_MIN=${PRECISION_MIN}"
+    echo "PRECISION_STEP=${PRECISION_STEP}"
+fi
+
+export VERIFICARLO_BACKEND=VPREC
+
+# Operation parameters
+operation_list=("+" "-" "/" "x")
+
+# Floating type list
+float_type_list=("float" "double")
+
+# Modes list
+modes_list=("IB" "OB" "FULL")
+
+# Range parameters
+declare -A range_max
+range_max["float"]=8
+range_max["double"]=11
+declare -A range_option
+range_option["float"]=--range-binary32
+range_option["double"]=--range-binary64
+
+# Precision parameters
+declare -A precision_max
+precision_max["float"]=23
+precision_max["double"]=52
+declare -A precision_option
+precision_option["float"]=--precision-binary32
+precision_option["double"]=--precision-binary64
+
+rm -f log.error
+
+print_sep() {
+    LENGTH=$(expr length "$1")
+    printf '#%.0s' `seq ${LENGTH}`
+    printf "\n"
+}
+
+compute_op() {
+    rm mpfr.txt
+    rm vprec.txt
+    while read a b; do
+	./compute_mpfr_rounding.py $a $b $1 $2 >> mpfr.txt
+	./compute_vprec_rounding $a $b $1 >> vprec.txt
+    done < input.txt
+}
+
+check_output() {
+    echo "Check output"
+    ./check_output.py 2>> log.error
+
+    if [[ $? != 0 ]]; then			
+	msg="Type: ${TYPE} Mode: ${MODE} Range: ${RANGE} OP: ${OP} Precision: ${PRECISION}"
+	print_sep "${msg}"       
+	echo "${msg}"
+	print_sep "${msg}"
+	./print_error.py input.txt mpfr.txt vprec.txt >> log.error
+    fi
+}
+
+for TYPE in "${float_type_list[@]}"; do
+    echo $LD_LIBRARY_PATH
+
+    echo "TYPE: ${TYPE}"
+    export VERIFICARLO_VPREC_TYPE=$TYPE
+    
+    verificarlo compute_vprec_rounding.c -DREAL=$TYPE -o compute_vprec_rounding --verbose
+
+    for MODE in "${modes_list[@]}"; do
+	echo "MODE: ${MODE}"
+	export VERIFICARLO_VPREC_MODE=$MODE
+
+	for RANGE  in `seq ${RANGE_MIN} ${RANGE_STEP} ${range_max[$TYPE]}`; do
+	    echo "Range: ${RANGE}"
+	    export VERIFICARLO_VPREC_RANGE=$RANGE
+
+	    ./generate_input.py 5 $RANGE
+
+	    for OP in "${operation_list[@]}"; do 
+		echo "OP: ${OP}"
+
+		for PRECISION in `seq ${PRECISION_MIN} ${PRECISION_STEP} ${precision_max[$TYPE]}`; do
+		    echo "Precision: ${PRECISION}"
+		    export VERIFICARLO_PRECISION=$PRECISION
+		    export VERIFICARLO_OP=$OP
+		    export VFC_BACKENDS="libinterflop_vprec.so ${precision_option[$TYPE]}=${PRECISION} ${range_option[$TYPE]}=${RANGE} --mode=${MODE}"
+		    compute_op $OP $TYPE
+		    check_output		    
+		done
+	    done
+	done
+    done
+done

--- a/tests/test_vprec_backend/generic_test.sh
+++ b/tests/test_vprec_backend/generic_test.sh
@@ -105,3 +105,5 @@ for TYPE in "${float_type_list[@]}"; do
 	done
     done
 done
+
+cat log.error

--- a/tests/test_vprec_backend/print_error.py
+++ b/tests/test_vprec_backend/print_error.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+import sys
+
+if '__main__' == __name__:
+
+    inputs_filename = sys.argv[1]
+    mpfr_filename   = sys.argv[2]
+    vprec_filename  = sys.argv[3]
+
+    inputs_values = [fi.strip() for fi in open(inputs_filename)]
+    mpfr_values   = [fi.strip() for fi in open(mpfr_filename)]
+    vprec_values  = [fi.strip() for fi in open(vprec_filename)]
+    
+    nb_values = len(inputs_values)
+    
+    for i in range(nb_values):
+        x,y = map(float.fromhex, inputs_values[i].split())
+        print inputs_values[i],mpfr_values[i],vprec_values[i]," # Double result ",float(x*y).hex()
+
+        

--- a/tests/test_vprec_backend/test.sh
+++ b/tests/test_vprec_backend/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [[ $# == 1 ]]; then
+    usecase=$1
+    echo $usecase
+fi
+
+case $usecase in
+    small)	
+	RANGE_MIN=2
+	RANGE_STEP=4
+	PRECISION_MIN=3
+	PRECISION_STEP=20
+	;;
+    medium)
+	RANGE_MIN=2
+	RANGE_STEP=2
+	PRECISION_MIN=3
+	PRECISION_STEP=10
+	;;
+    full)
+	RANGE_MIN=1
+	RANGE_STEP=1
+	PRECISION_MIN=1
+	PRECISION_STEP=1
+	;;
+    cmp) ./comparison.sh $1 $2 $3; exit 0 ;;
+    *)
+	RANGE_MIN=2
+	RANGE_STEP=4
+	PRECISION_MIN=3
+	PRECISION_STEP=20
+esac
+
+    echo "RANGE_MIN=${RANGE_MIN}"
+    echo "RANGE_STEP=${RANGE_STEP}"
+    echo "PRECISION_MIN=${PRECISION_MIN}"
+    echo "PRECISION_STEP=${PRECISION_STEP}"
+
+
+./generic_test.sh ${RANGE_MIN} ${RANGE_STEP} ${PRECISION_MIN} ${PRECISION_STEP}
+  


### PR DESCRIPTION
- Add VPREC backend that allows simulating any floating-point formats that fit into the IEEE-754 double precision format
- Two options for setting the precision and the range:
  * --precision-binary{32,64}
  * --range-binary{32,64}        
- Add test_vprec_backend for testing against MPFR. 
  * This test does not fail but reports failures in log.error