### PR TITLE
Fix error with .ll path during compilation

### DIFF
--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -166,7 +166,9 @@ def compile_only(sources, options, output, args):
         output=output))
 
 def get_tmp_filename(prefix, suffix, args):
-    abs_prefix = os.path.abspath(prefix) + '.'
+    filename_ext = os.path.basename(prefix)
+    basename = os.path.splitext(filename_ext)[0]
+    abs_prefix = os.getcwd() + os.sep + basename + "."
     tmp = tempfile.NamedTemporaryFile(mode='w+b',
                                       prefix=abs_prefix,
                                       suffix=suffix,


### PR DESCRIPTION
- Previous version uses the absolute path of the source file to generate 
  intermediate files (.ll). But this path can be not accessible to the 
  user (read-only). We use the current directory instead.