### PR TITLE
Zero + Zero fix for vprec backend

### DIFF
--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -295,15 +295,15 @@ static float _vprec_round_binary32(float a, char is_input, void *context,
   if (aexp.s32 < emin) {
     if ((((t_context *)context)->daz && is_input) ||
         (((t_context *)context)->ftz && !is_input)) {
-      a = 0;
+      return a * 0; // preserve sign
+    } else if (FP_ZERO == fpclassify(a)) {
+      return a;
     } else {
-      a = handle_binary32_denormal(a, emin, binary32_precision);
+      return handle_binary32_denormal(a, emin, binary32_precision);
     }
   } else {
-    a = round_binary32_normal(a, binary32_precision);
+    return round_binary32_normal(a, binary32_precision);
   }
-
-  return a;
 }
 
 // Round the double with the given precision
@@ -334,15 +334,15 @@ static double _vprec_round_binary64(double a, char is_input, void *context,
   if (aexp.s64 < emin) {
     if ((((t_context *)context)->daz && is_input) ||
         (((t_context *)context)->ftz && !is_input)) {
-      a = 0;
+      return a * 0; // preserve sign
+    } else if (FP_ZERO == fpclassify(a)) {
+      return a;
     } else {
-      a = handle_binary64_denormal(a, emin, binary64_precision);
+      return handle_binary64_denormal(a, emin, binary64_precision);
     }
   } else {
-    a = round_binary64_normal(a, binary64_precision);
+    return round_binary64_normal(a, binary64_precision);
   }
-
-  return a;
 }
 
 static inline float _vprec_binary32_binary_op(float a, float b,

--- a/tests/test_vprec_zero/test.c
+++ b/tests/test_vprec_zero/test.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#define bit(A, i) ((A >> i) & 1)
+
+typedef unsigned long long int u_64;
+typedef unsigned int u_32;
+
+static void print_double(double d) {
+  u_64 a = *((u_64 *)&d);
+
+  for (int i = 63; i >= 0; i--)
+    (i == 63 || i == 52) ? printf("%lld ", bit(a, i))
+                         : printf("%lld", bit(a, i));
+
+  printf("\n");
+}
+
+int main(int argc, char const *argv[])
+{
+	double zero = 0.0;
+
+	double a = zero + zero;
+
+  print_double(zero);
+  printf("\t\t\t\t + \t\t\t\t\n");
+  print_double(zero);
+  printf("\t\t\t\t = \t\t\t\t\n");
+	print_double(a);
+
+	printf("\n%la + %la = %la\n", zero, zero, a);
+
+	return 0;
+}

--- a/tests/test_vprec_zero/test.sh
+++ b/tests/test_vprec_zero/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+rm -f test.o test output
+
+verificarlo-c test.c -o test
+
+export VFC_BACKENDS="libinterflop_vprec.so --mode=ib --precision-binary64=23"
+
+./test > output
+
+if grep "= 0x0p+0" output; then
+  exit 0
+else
+  echo "zero + zero is not zero: test failed"
+  exit 1
+fi
+


### PR DESCRIPTION
Thanks to @Avaquet for reporting a bug with vprec, where 0 + 0 is not 0. We fix this by not handling Zero as a denormal.