### PR TITLE
Do not instrument unsupported types, such as function pointers.

### DIFF
--- a/src/libvfcfuncinstrument/libVFCFuncInstrument.cpp
+++ b/src/libvfcfuncinstrument/libVFCFuncInstrument.cpp
@@ -540,7 +540,7 @@ struct VfclibFunc : public ModulePass {
 
                   // If the called function is an intrinsic function that does
                   // not use float or double, do not instrument it.
-                  if (is_intrinsic && !(use_float || use_double)) {
+                  if (!(use_float || use_double) || is_intrinsic) {
                     continue;
                   }
 


### PR DESCRIPTION
Otherwise, vfc_enter_function gets invoked during program execution, and an entry not created will cause the program to crash. 