### PR TITLE
Pre release v0.4.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 Verificarlo CHANGELOG
 
-# [Unreleased]
+# [v0.4.2] 2021/02/15
 
 ## Added
+  * Support for LLVM up to 11.0.1
   * Mechanism for reading VFC_BACKENDS from file through VFC_BACKENDS_FROM_FILE
   * Absolute error option for MCA and VPREC backends
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 FROM ubuntu:20.04
-LABEL maintainner="verificarlo contributors <verificarlo@googlegroups.com>"
+LABEL maintainer="verificarlo contributors <verificarlo@googlegroups.com>"
 
 ARG PYTHON_VERSION=3.8
 ARG LLVM_VERSION=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 FROM ubuntu:20.04
-MAINTAINER Verificarlo contributors <verificarlo@googlegroups.com>
+LABEL maintainner="verificarlo contributors <verificarlo@googlegroups.com>"
 
 ARG PYTHON_VERSION=3.8
 ARG LLVM_VERSION=7
@@ -22,7 +22,8 @@ RUN apt-get -y install --no-install-recommends \
     clang-${LLVM_VERSION} llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
     gcc-${GCC_VERSION} g++-${GCC_VERSION} \
     gfortran-${GCC_VERSION} libgfortran-${GCC_VERSION}-dev flang \
-    python3 python3-pip python3-numpy python3-matplotlib python3-dev cython3
+    python3 python3-pip python3-numpy python3-matplotlib python3-dev cython3 && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build/
 
@@ -38,7 +39,7 @@ COPY . /build/verificarlo/
 WORKDIR /build/verificarlo
 RUN ./autogen.sh && \
     ./configure --with-llvm=$(llvm-config-${LLVM_VERSION} --prefix) \
-    		--with-flang CC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} \
+    --with-flang CC=gcc-${GCC_VERSION} CXX=g++-${GCC_VERSION} \
     || cat config.log
 
 # Build verificarlo

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![verificarlo logo](https://avatars1.githubusercontent.com/u/12033642)
 
-## Verificarlo v0.4.1
+## Verificarlo v0.4.2
 
 ![Build Status](https://github.com/verificarlo/verificarlo/workflows/test-docker/badge.svg?branch=master)
 [![DOI](https://zenodo.org/badge/34260221.svg)](https://zenodo.org/badge/latestdoi/34260221)
@@ -66,7 +66,7 @@ $ docker run -v "$PWD":/workdir -e VFC_BACKENDS="libinterflop_mca.so" \
 Please ensure that Verificarlo's dependencies are installed on your system:
 
   * GNU mpfr library http://www.mpfr.org/
-  * LLVM, clang and opt from 4.0 up to 10.0.1, http://clang.llvm.org/
+  * LLVM, clang and opt from 4.0 up to 11.0.1, http://clang.llvm.org/
   * gcc from 4.9
   * flang for Fortran support
   * python3 with numpy and bigfloat packages


### PR DESCRIPTION
# Added
  * Support for LLVM up to 11.0.1
  * Mechanism for reading VFC_BACKENDS from file through VFC_BACKENDS_FROM_FILE
  * Absolute error option for MCA and VPREC backends

Closes #203 