### PR TITLE
Fix test that requires --save-temps

### DIFF
--- a/tests/test_ieee_backend/test.sh
+++ b/tests/test_ieee_backend/test.sh
@@ -4,7 +4,7 @@ verificarlo-c --save-temps -O0 test.c -o test
 
 # Check that all the operations have been instrumented
 for op in fadd fsub fmul fdiv; do
-  if grep $op test.2.ll; then
+  if grep $op test*.2.ll; then
     echo "Some $op have not been instrumented"
     exit 1
   fi

--- a/tests/test_ieee_backend/test.sh
+++ b/tests/test_ieee_backend/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-verificarlo-c -O0 test.c -o test
+verificarlo-c --save-temps -O0 test.c -o test
 
 # Check that all the operations have been instrumented
 for op in fadd fsub fmul fdiv; do


### PR DESCRIPTION
- test_ieee_backend requires ```--save-temps``` since it inspects .ll files.