### PR TITLE
Fix llvm version error

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please ensure that Verificarlo's dependencies are installed on your system:
   * LLVM, clang and opt from 4.0 up to 11.0.1, http://clang.llvm.org/
   * gcc from 4.9
   * flang for Fortran support
-  * python3 with numpy and bigfloat packages
+  * python3 with numpy, bigfloat and pandas packages
   * autotools (automake, autoconf)
 
 Then run the following command inside verificarlo directory:
@@ -92,7 +92,7 @@ install procedure:
 ```bash
    $ sudo apt-get install libmpfr-dev clang-7 flang-7 llvm-7-dev \
        gcc-7 autoconf automake build-essential python3 python3-numpy python3-pip
-   $ sudo pip3 install bigfloat
+   $ sudo pip3 install bigfloat pandas
    $ cd verificarlo/
    $ ./autogen.sh
    $ ./configure --with-flang CC=gcc-7 CXX=g++-7

--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -77,7 +77,7 @@ AC_DEFUN([AX_LLVM],
     [],
     [
       AC_MSG_ERROR(
-        [LLVM version up to $2 is supported])
+        [LLVM version up to $2 is not supported])
     ])
 
   LLVM_BINDIR=`$LLVM_CONFIG --bindir`


### PR DESCRIPTION
Hello,

When I tried to use Verificarlo with llvm version 11.1.0 I see this message:
```
LLVM version up to 11.1.0 is supported
```
I think it is just one forgets.

I also add **pandas** dependency on README.

**UPDATE:**
The message is not:
```
LLVM version up to 11.1.0 is supported
```
But it is:
```
LLVM version up to 11.0.1 is supported
```