### PR TITLE
adding pre-configured setting in vprec backend

### DIFF
--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -60,12 +60,12 @@ typedef enum {
   KEY_INPUT_FILE,
   KEY_OUTPUT_FILE,
   KEY_LOG_FILE,
+  KEY_PRESET,
   KEY_MODE = 'm',
   KEY_ERR_MODE = 'e',
   KEY_INSTRUMENT = 'i',
   KEY_DAZ = 'd',
-  KEY_FTZ = 'f',
-  KEY_PRESET,
+  KEY_FTZ = 'f'
 } key_args;
 
 static const char key_prec_b32_str[] = "precision-binary32";
@@ -75,13 +75,13 @@ static const char key_range_b64_str[] = "range-binary64";
 static const char key_input_file_str[] = "prec-input-file";
 static const char key_output_file_str[] = "prec-output-file";
 static const char key_log_file_str[] = "prec-log-file";
+static const char key_preset_str[] = "preset";
 static const char key_mode_str[] = "mode";
 static const char key_err_mode_str[] = "error-mode";
 static const char key_err_exp_str[] = "max-abs-error-exponent";
 static const char key_instrument_str[] = "instrument";
 static const char key_daz_str[] = "daz";
 static const char key_ftz_str[] = "ftz";
-static const char key_preset_str[] = "preset";
 
 typedef struct {
   bool relErr;
@@ -1300,6 +1300,18 @@ static struct argp_option options[] = {
      "output file where the precision profile is written", 0},
     {key_log_file_str, KEY_LOG_FILE, "LOG", 0,
      "log file where input/output informations are written", 0},
+    {key_preset_str, KEY_PRESET, "PRESET", 0,
+     "select a default PRESET setting among {binary16, binary32, binary64, "
+     "bfloat16, tensorfloat, fp24, PXR24}\n"
+     "Format (range, precision)\n"
+     "binary16    ( 5, 10)\n"
+     "binary32    ( 8, 23)\n"
+     "binary64    (11, 52)\n"
+     "bfloat16    ( 8,  7)\n"
+     "tensorfloat ( 8, 10)\n"
+     "fp24        ( 7, 16)\n"
+     "PXR24       ( 8, 15)",
+     0},
     {key_mode_str, KEY_MODE, "MODE", 0,
      "select VPREC mode among {ieee, full, ib, ob}", 0},
     {key_err_mode_str, KEY_ERR_MODE, "ERROR_MODE", 0,
@@ -1312,10 +1324,6 @@ static struct argp_option options[] = {
     {key_daz_str, KEY_DAZ, 0, 0,
      "denormals-are-zero: sets denormals inputs to zero", 0},
     {key_ftz_str, KEY_FTZ, 0, 0, "flush-to-zero: sets denormal output to zero",
-     0},
-    {key_preset_str, KEY_PRESET, "PRESET", 0,
-     "select a default PRESET setting among {binary16, binary32, binary64, "
-     "bfloat16, tensorfloat, fp24, PXR24}",
      0},
     {0}};
 

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -131,7 +131,7 @@ typedef enum {
   preset_PXR24
 } vprec_preset;
 
-static const char *VPREC_PRESET_STR[] = {"binary16", "binary32", "binary64",
+static const char *VPREC_PRESET_STR[] = {"binary16", "binary32",    "binary64",
                                          "bfloat16", "tensorfloat", "fp24",
                                          "PXR24"};
 
@@ -1295,7 +1295,8 @@ static struct argp_option options[] = {
      0},
     {key_preset_str, KEY_PRESET, "PRESET", 0,
      "select a default PRESET setting among {binary16, binary32, binary64, "
-     "bfloat16, tensorfloat, fp24, PXR24}", 0},
+     "bfloat16, tensorfloat, fp24, PXR24}",
+     0},
     {0}};
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -131,15 +131,9 @@ typedef enum {
   preset_PXR24
 } vprec_preset;
 
-static const char *VPREC_PRESET_STR[] = {
-  "binary16",
-  "binary32",
-  "binary64",
-  "bfloat16",
-  "tensorfloat",
-  "fp24",
-  "PXR24"
-};
+static const char *VPREC_PRESET_STR[] = {"binary16", "binary32", "binary64",
+                                         "bfloat16", "tensorfloat", "fp24",
+                                         "PXR24"};
 
 /* define default environment variables and default parameters */
 
@@ -1271,38 +1265,38 @@ static void _interflop_div_double(double a, double b, double *c,
 }
 
 static struct argp_option options[] = {
-  /* --debug, sets the variable debug = true */
-  {key_prec_b32_str, KEY_PREC_B32, "PRECISION", 0,
-   "select precision for binary32 (PRECISION >= 0)", 0},
-  {key_prec_b64_str, KEY_PREC_B64, "PRECISION", 0,
-   "select precision for binary64 (PRECISION >= 0)", 0},
-  {key_range_b32_str, KEY_RANGE_B32, "RANGE", 0,
-   "select range for binary32 (0 < RANGE && RANGE <= 8)", 0},
-  {key_range_b64_str, KEY_RANGE_B64, "RANGE", 0,
-   "select range for binary64 (0 < RANGE && RANGE <= 11)", 0},
-  {key_input_file_str, KEY_INPUT_FILE, "INPUT", 0,
-   "input file with the precision configuration to use", 0},
-  {key_output_file_str, KEY_OUTPUT_FILE, "OUTPUT", 0,
-   "output file where the precision profile is written", 0},
-  {key_log_file_str, KEY_LOG_FILE, "LOG", 0,
-   "log file where input/output informations are written", 0},
-  {key_mode_str, KEY_MODE, "MODE", 0,
-   "select VPREC mode among {ieee, full, ib, ob}", 0},
-  {key_err_mode_str, KEY_ERR_MODE, "ERROR_MODE", 0,
-   "select error mode among {rel, abs, all}", 0},
-  {key_err_exp_str, KEY_ERR_EXP, "MAX_ABS_ERROR_EXPONENT", 0,
-   "select magnitude of the maximum absolute error", 0},
-  {key_instrument_str, KEY_INSTRUMENT, "INSTRUMENTATION", 0,
-   "select VPREC instrumentation mode among {arguments, operations, full}",
-   0},
-  {key_daz_str, KEY_DAZ, 0, 0,
-   "denormals-are-zero: sets denormals inputs to zero", 0},
-  {key_ftz_str, KEY_FTZ, 0, 0, "flush-to-zero: sets denormal output to zero",
-   0},
-  {key_preset_str, KEY_PRESET, "PRESET", 0,
-   "select a default PRESET setting among {binary16, binary32, binary64, "
-   "bfloat16, tensorfloat, fp24, PXR24}", 0},
-  {0}};
+    /* --debug, sets the variable debug = true */
+    {key_prec_b32_str, KEY_PREC_B32, "PRECISION", 0,
+     "select precision for binary32 (PRECISION >= 0)", 0},
+    {key_prec_b64_str, KEY_PREC_B64, "PRECISION", 0,
+     "select precision for binary64 (PRECISION >= 0)", 0},
+    {key_range_b32_str, KEY_RANGE_B32, "RANGE", 0,
+     "select range for binary32 (0 < RANGE && RANGE <= 8)", 0},
+    {key_range_b64_str, KEY_RANGE_B64, "RANGE", 0,
+     "select range for binary64 (0 < RANGE && RANGE <= 11)", 0},
+    {key_input_file_str, KEY_INPUT_FILE, "INPUT", 0,
+     "input file with the precision configuration to use", 0},
+    {key_output_file_str, KEY_OUTPUT_FILE, "OUTPUT", 0,
+     "output file where the precision profile is written", 0},
+    {key_log_file_str, KEY_LOG_FILE, "LOG", 0,
+     "log file where input/output informations are written", 0},
+    {key_mode_str, KEY_MODE, "MODE", 0,
+     "select VPREC mode among {ieee, full, ib, ob}", 0},
+    {key_err_mode_str, KEY_ERR_MODE, "ERROR_MODE", 0,
+     "select error mode among {rel, abs, all}", 0},
+    {key_err_exp_str, KEY_ERR_EXP, "MAX_ABS_ERROR_EXPONENT", 0,
+     "select magnitude of the maximum absolute error", 0},
+    {key_instrument_str, KEY_INSTRUMENT, "INSTRUMENTATION", 0,
+     "select VPREC instrumentation mode among {arguments, operations, full}",
+     0},
+    {key_daz_str, KEY_DAZ, 0, 0,
+     "denormals-are-zero: sets denormals inputs to zero", 0},
+    {key_ftz_str, KEY_FTZ, 0, 0, "flush-to-zero: sets denormal output to zero",
+     0},
+    {key_preset_str, KEY_PRESET, "PRESET", 0,
+     "select a default PRESET setting among {binary16, binary32, binary64, "
+     "bfloat16, tensorfloat, fp24, PXR24}", 0},
+    {0}};
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   t_context *ctx = (t_context *)state->input;
@@ -1492,7 +1486,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     /* set range */
     _set_vprec_range_binary32(range);
     _set_vprec_range_binary64(range);
-    
+
     break;
   default:
     return ARGP_ERR_UNKNOWN;

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -131,6 +131,26 @@ typedef enum {
   preset_PXR24
 } vprec_preset;
 
+typedef enum {
+  preset_precision_binary16 = 10,
+  preset_precision_binary32 = 23,
+  preset_precision_binary64 = 52,
+  preset_precision_bfloat16 = 7,
+  preset_precision_tensorfloat = 10,
+  preset_precision_fp24 = 16,
+  preset_precision_PXR24 = 15
+} vprec_preset_precision;
+
+typedef enum {
+  preset_range_binary16 = 5,
+  preset_range_binary32 = 8,
+  preset_range_binary64 = 11,
+  preset_range_bfloat16 = 8,
+  preset_range_tensorfloat = 8,
+  preset_range_fp24 = 7,
+  preset_range_PXR24 = 8
+} vprec_preset_range;
+
 static const char *VPREC_PRESET_STR[] = {"binary16", "binary32",    "binary64",
                                          "bfloat16", "tensorfloat", "fp24",
                                          "PXR24"};
@@ -1452,26 +1472,26 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   case KEY_PRESET:
     /* preset */
     if (strcmp(VPREC_PRESET_STR[preset_binary16], arg) == 0) {
-      precision = 10;
-      range = 5;
+      precision = preset_precision_binary16;
+      range = preset_range_binary16;
     } else if (strcmp(VPREC_PRESET_STR[preset_binary32], arg) == 0) {
-      precision = 23;
-      range = 8;
+      precision = preset_precision_binary32;
+      range = preset_range_binary32;
     } else if (strcmp(VPREC_PRESET_STR[preset_binary64], arg) == 0) {
-      precision = 52;
-      range = 11;
+      precision = preset_precision_binary64;
+      range = preset_range_binary64;
     } else if (strcmp(VPREC_PRESET_STR[preset_bfloat16], arg) == 0) {
-      precision = 7;
-      range = 8;
+      precision = preset_precision_bfloat16;
+      range = preset_range_bfloat16;
     } else if (strcmp(VPREC_PRESET_STR[preset_tensorfloat], arg) == 0) {
-      precision = 10;
-      range = 8;
+      precision = preset_precision_tensorfloat;
+      range = preset_range_tensorfloat;
     } else if (strcmp(VPREC_PRESET_STR[preset_fp24], arg) == 0) {
-      precision = 16;
-      range = 7;
+      precision = preset_precision_fp24;
+      range = preset_range_fp24;
     } else if (strcmp(VPREC_PRESET_STR[preset_PXR24], arg) == 0) {
-      precision = 15;
-      range = 8;
+      precision = preset_precision_PXR24;
+      range = preset_range_PXR24;
     } else {
       logger_error("--%s invalid preset provided, must be one of: "
                    "{binary16, binary32, binary64, bfloat16, tensorfloat, "

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -1303,14 +1303,11 @@ static struct argp_option options[] = {
     {key_preset_str, KEY_PRESET, "PRESET", 0,
      "select a default PRESET setting among {binary16, binary32, binary64, "
      "bfloat16, tensorfloat, fp24, PXR24}\n"
-     "Format (range, precision)\n"
-     "binary16    ( 5, 10)\n"
-     "binary32    ( 8, 23)\n"
-     "binary64    (11, 52)\n"
-     "bfloat16    ( 8,  7)\n"
-     "tensorfloat ( 8, 10)\n"
-     "fp24        ( 7, 16)\n"
-     "PXR24       ( 8, 15)",
+     "Format (range, precision) : "
+     "binary16 (5, 10), binary32 (8, 23), "
+     "binary64 (11, 52), bfloat16 (8, 7), "
+     "tensorfloat (8, 10), fp24 (7, 16), "
+     "PXR24 (8, 15)",
      0},
     {key_mode_str, KEY_MODE, "MODE", 0,
      "select VPREC mode among {ieee, full, ib, ob}", 0},

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -64,7 +64,8 @@ typedef enum {
   KEY_ERR_MODE = 'e',
   KEY_INSTRUMENT = 'i',
   KEY_DAZ = 'd',
-  KEY_FTZ = 'f'
+  KEY_FTZ = 'f',
+  KEY_PRESET,
 } key_args;
 
 static const char key_prec_b32_str[] = "precision-binary32";
@@ -80,6 +81,7 @@ static const char key_err_exp_str[] = "max-abs-error-exponent";
 static const char key_instrument_str[] = "instrument";
 static const char key_daz_str[] = "daz";
 static const char key_ftz_str[] = "ftz";
+static const char key_preset_str[] = "preset";
 
 typedef struct {
   bool relErr;
@@ -117,6 +119,27 @@ typedef enum {
   vprec_mul = '*',
   vprec_div = '/',
 } vprec_operation;
+
+/* define the possible VPREC preset */
+typedef enum {
+  preset_binary16,
+  preset_binary32,
+  preset_binary64,
+  preset_bfloat16,
+  preset_tensorfloat,
+  preset_fp24,
+  preset_PXR24
+} vprec_preset;
+
+static const char *VPREC_PRESET_STR[] = {
+  "binary16",
+  "binary32",
+  "binary64",
+  "bfloat16",
+  "tensorfloat",
+  "fp24",
+  "PXR24"
+};
 
 /* define default environment variables and default parameters */
 
@@ -1248,40 +1271,46 @@ static void _interflop_div_double(double a, double b, double *c,
 }
 
 static struct argp_option options[] = {
-    /* --debug, sets the variable debug = true */
-    {key_prec_b32_str, KEY_PREC_B32, "PRECISION", 0,
-     "select precision for binary32 (PRECISION >= 0)", 0},
-    {key_prec_b64_str, KEY_PREC_B64, "PRECISION", 0,
-     "select precision for binary64 (PRECISION >= 0)", 0},
-    {key_range_b32_str, KEY_RANGE_B32, "RANGE", 0,
-     "select range for binary32 (0 < RANGE && RANGE <= 8)", 0},
-    {key_range_b64_str, KEY_RANGE_B64, "RANGE", 0,
-     "select range for binary64 (0 < RANGE && RANGE <= 11)", 0},
-    {key_input_file_str, KEY_INPUT_FILE, "INPUT", 0,
-     "input file with the precision configuration to use", 0},
-    {key_output_file_str, KEY_OUTPUT_FILE, "OUTPUT", 0,
-     "output file where the precision profile is written", 0},
-    {key_log_file_str, KEY_LOG_FILE, "LOG", 0,
-     "log file where input/output informations are written", 0},
-    {key_mode_str, KEY_MODE, "MODE", 0,
-     "select VPREC mode among {ieee, full, ib, ob}", 0},
-    {key_err_mode_str, KEY_ERR_MODE, "ERROR_MODE", 0,
-     "select error mode among {rel, abs, all}", 0},
-    {key_err_exp_str, KEY_ERR_EXP, "MAX_ABS_ERROR_EXPONENT", 0,
-     "select magnitude of the maximum absolute error", 0},
-    {key_instrument_str, KEY_INSTRUMENT, "INSTRUMENTATION", 0,
-     "select VPREC instrumentation mode among {arguments, operations, full}",
-     0},
-    {key_daz_str, KEY_DAZ, 0, 0,
-     "denormals-are-zero: sets denormals inputs to zero", 0},
-    {key_ftz_str, KEY_FTZ, 0, 0, "flush-to-zero: sets denormal output to zero",
-     0},
-    {0}};
+  /* --debug, sets the variable debug = true */
+  {key_prec_b32_str, KEY_PREC_B32, "PRECISION", 0,
+   "select precision for binary32 (PRECISION >= 0)", 0},
+  {key_prec_b64_str, KEY_PREC_B64, "PRECISION", 0,
+   "select precision for binary64 (PRECISION >= 0)", 0},
+  {key_range_b32_str, KEY_RANGE_B32, "RANGE", 0,
+   "select range for binary32 (0 < RANGE && RANGE <= 8)", 0},
+  {key_range_b64_str, KEY_RANGE_B64, "RANGE", 0,
+   "select range for binary64 (0 < RANGE && RANGE <= 11)", 0},
+  {key_input_file_str, KEY_INPUT_FILE, "INPUT", 0,
+   "input file with the precision configuration to use", 0},
+  {key_output_file_str, KEY_OUTPUT_FILE, "OUTPUT", 0,
+   "output file where the precision profile is written", 0},
+  {key_log_file_str, KEY_LOG_FILE, "LOG", 0,
+   "log file where input/output informations are written", 0},
+  {key_mode_str, KEY_MODE, "MODE", 0,
+   "select VPREC mode among {ieee, full, ib, ob}", 0},
+  {key_err_mode_str, KEY_ERR_MODE, "ERROR_MODE", 0,
+   "select error mode among {rel, abs, all}", 0},
+  {key_err_exp_str, KEY_ERR_EXP, "MAX_ABS_ERROR_EXPONENT", 0,
+   "select magnitude of the maximum absolute error", 0},
+  {key_instrument_str, KEY_INSTRUMENT, "INSTRUMENTATION", 0,
+   "select VPREC instrumentation mode among {arguments, operations, full}",
+   0},
+  {key_daz_str, KEY_DAZ, 0, 0,
+   "denormals-are-zero: sets denormals inputs to zero", 0},
+  {key_ftz_str, KEY_FTZ, 0, 0, "flush-to-zero: sets denormal output to zero",
+   0},
+  {key_preset_str, KEY_PRESET, "PRESET", 0,
+   "select a default PRESET setting among {binary16, binary32, binary64, "
+   "bfloat16, tensorfloat, fp24, PXR24}", 0},
+  {0}};
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   t_context *ctx = (t_context *)state->input;
   char *endptr;
   int val = -1;
+  int precision = 0;
+  int range = 0;
+
   switch (key) {
   case KEY_PREC_B32:
     /* precision */
@@ -1424,6 +1453,46 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
   case KEY_FTZ:
     /* flush-to-zero */
     ctx->ftz = true;
+    break;
+  case KEY_PRESET:
+    /* preset */
+    if (strcmp(VPREC_PRESET_STR[preset_binary16], arg) == 0) {
+      precision = 10;
+      range = 5;
+    } else if (strcmp(VPREC_PRESET_STR[preset_binary32], arg) == 0) {
+      precision = 23;
+      range = 8;
+    } else if (strcmp(VPREC_PRESET_STR[preset_binary64], arg) == 0) {
+      precision = 52;
+      range = 11;
+    } else if (strcmp(VPREC_PRESET_STR[preset_bfloat16], arg) == 0) {
+      precision = 7;
+      range = 8;
+    } else if (strcmp(VPREC_PRESET_STR[preset_tensorfloat], arg) == 0) {
+      precision = 10;
+      range = 8;
+    } else if (strcmp(VPREC_PRESET_STR[preset_fp24], arg) == 0) {
+      precision = 16;
+      range = 7;
+    } else if (strcmp(VPREC_PRESET_STR[preset_PXR24], arg) == 0) {
+      precision = 15;
+      range = 8;
+    } else {
+      logger_error("--%s invalid preset provided, must be one of: "
+                   "{binary16, binary32, binary64, bfloat16, tensorfloat, "
+                   "fp24, PXR24}",
+                   key_preset_str);
+      break;
+    }
+
+    /* set precision */
+    _set_vprec_precision_binary32(precision);
+    _set_vprec_precision_binary64(precision);
+
+    /* set range */
+    _set_vprec_range_binary32(range);
+    _set_vprec_range_binary64(range);
+    
     break;
   default:
     return ARGP_ERR_UNKNOWN;


### PR DESCRIPTION
Hi,

This pull request attempt to adding pre-configured settings in vprec like:
binary16, binary32, binary64, bfloat16, tensorfloat, fp24, PXR24

Related issue #184.