### PR TITLE
Makefile correction from verificarlo/verificarlo#253

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -27,6 +27,5 @@ if BUILD_FLANG
 lib_LIBRARIES = libvfc_probes_f.a
 libvfc_probes_f_a_SOURCES = vfc_probes_f.f90
 library_includedir =$(includedir)/
-endif
-
 include_HEADERS = vfc_probes_f.mod
+endif

--- a/src/tools/ci/test.py
+++ b/src/tools/ci/test.py
@@ -180,7 +180,7 @@ def run_tests(config):
 
             os.putenv("VFC_BACKENDS", backend["name"])
 
-            command = "./" + executable["executable"] + parameters
+            command = "./" + executable["executable"] + " " + parameters
 
             repetitions = 1
             if "repetitions" in backend:
@@ -192,7 +192,7 @@ def run_tests(config):
                 os.putenv("VFC_PROBES_OUTPUT", temp.name)
 
                 print(command)
-                p = subprocess.Popen(command)
+                p = subprocess.Popen(command.split())
                 try:
                     p.wait(timeout)
                 except subprocess.TimeoutExpired:


### PR DESCRIPTION
Correctly ignores the rules for the Fortran interface when flang support
is disabled.

Also add a small correction to the code of the vfc_ci test command to
make it easier to correctly pass arguments to the test executables.