### PR TITLE
Fix vfc_probes error when compiling with Fortran:

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ else
    AC_DEFINE_UNQUOTED([FLANG_PATH], ["$FLANG"], [The flang path])
    AC_SUBST(FLANG_PATH, $FLANG)
 
-   AC_PROG_FC=$FLANG
+   AC_SUBST(FC, $FLANG)
 fi
 
 AC_CHECK_LIB([c], [exit], , AC_MSG_ERROR([Could not find c library]))
@@ -206,7 +206,5 @@ AC_CONFIG_FILES([Makefile
                  tests/paths.sh
                 ])
 
-AC_CONFIG_FILES([verificarlo.in \
-    tests/test_fortran_vfc_probes/test.sh],
-		[chmod +x tests/test_fortran_vfc_probes/test.sh])
+AC_CONFIG_FILES([verificarlo.in])
 AC_OUTPUT

--- a/src/common/vfc_probes.c
+++ b/src/common/vfc_probes.c
@@ -96,7 +96,7 @@ void vfc_free_probes(vfc_probes *probes) {
 
   // Before freeing the map, iterate manually over all items to free the keys
   vfc_probe_node *probe = NULL;
-  for (int i = 0; i < probes->map->capacity; i++) {
+  for (size_t i = 0; i < probes->map->capacity; i++) {
     probe = (vfc_probe_node *)get_value_at(probes->map->items, i);
 
     // Comparing with 1 is also necessary since it will be the value of deleted
@@ -213,7 +213,7 @@ int vfc_dump_probes(vfc_probes *probes) {
 
   // Iterate over all table elements
   vfc_probe_node *probe = NULL;
-  for (int i = 0; i < probes->map->capacity; i++) {
+  for (size_t i = 0; i < probes->map->capacity; i++) {
     probe = (vfc_probe_node *)get_value_at(probes->map->items, i);
     if (probe != NULL) {
       fprintf(fp, "%s,%a\n", probe->key, probe->value);

--- a/src/common/vfc_probes_f.f90
+++ b/src/common/vfc_probes_f.f90
@@ -30,7 +30,7 @@ module vfc_probes_f
     interface
 
         type(vfc_probes) function vfc_init_probes() bind(C, name = "vfc_init_probes")
-
+        import
         end function vfc_init_probes
 
         function vfc_free_probes(probes) bind(C, name = "vfc_free_probes")

--- a/src/tools/ci/test_data_processing.py
+++ b/src/tools/ci/test_data_processing.py
@@ -105,7 +105,8 @@ def apply_data_pocessing(data):
     # Get empirical average, standard deviation and p-value
     data["mu"] = np.average(data["values"])
     data["sigma"] = np.std(data["values"])
-    data["pvalue"] = scipy.stats.shapiro(data["values"]).pvalue
+    # Shapiro returns (statistic, p_value)
+    data["pvalue"] = scipy.stats.shapiro(data["values"])[1]
 
     # Quantiles
     data["min"] = np.min(data["values"])

--- a/tests/test_fortran_vfc_probes/clean.sh
+++ b/tests/test_fortran_vfc_probes/clean.sh
@@ -1,3 +1,3 @@
-:#!/bin/sh
+#!/bin/sh
 
 rm -f test_fortran *.o *.csv

--- a/tests/test_fortran_vfc_probes/test.sh
+++ b/tests/test_fortran_vfc_probes/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+source ../paths.sh
+
+if [ -z "${FLANG}" ]; then
+    echo "this test is not run when not using --with-flang"
+    exit 0
+fi
+
+verificarlo-f -c vfc_probes_test.f90 --show-cmd
+verificarlo-f vfc_probes_test.o -lvfc_probes -lvfc_probes_f -o test_fortran
+
+VFC_BACKENDS="libinterflop_ieee.so" VFC_PROBES_OUTPUT="tmp.csv" ./test_fortran
+
+if ls *.csv; then
+    echo "CSV file found, SUCCESS"
+    exit 0
+else
+    echo "CSV file not found, FAILURE"
+    exit 1
+fi

--- a/tests/test_vfc_ci/test.c
+++ b/tests/test_vfc_ci/test.c
@@ -1,7 +1,7 @@
 // Dummy test to make sure that the vfc_probes system works properly
 
 #include <stdio.h>
-#include <vfc_probes.h>
+#include "vfc_probes.h"
 
 int main(void) {
 

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -192,6 +192,7 @@ def compiler_mode(sources, options, output, args):
         ins = get_tmp_filename(basename, '.2.ll', args)
 
         compiler = linkers[args.linker]
+        include = f" -I {mcalib_includes} "
 
         debug = '-g' if args.inst_func else ''
 
@@ -204,7 +205,8 @@ def compiler_mode(sources, options, output, args):
             continue
 
         # Compile to ir (fortran uses flang, c uses clang)
-        shell(f'{compiler} -c -S {debug} {source} -emit-llvm {options} -o {ir.name}')
+        shell(
+            f'{compiler} -c -S {debug} {source} {include} -emit-llvm {options} -o {ir.name}')
 
         selectfunction = ""
         if args.function:


### PR DESCRIPTION
    - Fix module incompability when we compile libvfc_probes_f.a
      with gfortran and compiling codes with flang
    - Force flang to be used to compile libvfc_probes_f
    - Pass include path during compilation in verificarlo.in.in
    - Make src/tools/ci/test_data_processing.py retro compatible
      with older scipy version that don't use namedtuple for returned
      value
Fix #257 