### PR TITLE
Fix dockerhub issue:

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 autoreconf -is
 
-git submodule init
-git submodule update
+rm -rf src/tools/sigdigits/
+git submodule update --init --recursive


### PR DESCRIPTION
    - Dockerhub failed to init submodule
    - Fix it by removing the submodule before calling submodule update,
      suggested by http://tech.yipp.ca/git/needed-single-revision-unable-find-current-revision-submodule-path/

Fix #257 