### PR TITLE
removing the clean of tests/paths.sh file

### DIFF
--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -16,4 +16,4 @@ for t in $tests ; do
     fi
 done
 
-rm -Rf *~ testplan.log testplan.trs test-suite.log
+rm -Rf *~ paths.sh testplan.log testplan.trs test-suite.log

--- a/tests/clean.sh
+++ b/tests/clean.sh
@@ -16,4 +16,4 @@ for t in $tests ; do
     fi
 done
 
-rm -Rf *~ paths.sh testplan.log testplan.trs test-suite.log
+rm -Rf *~ testplan.log testplan.trs test-suite.log

--- a/tests/paths.sh
+++ b/tests/paths.sh
@@ -1,1 +1,0 @@
-LLVM_BINDIR=/usr/lib/llvm-7/bin


### PR DESCRIPTION
This file was generated by the configuration script before. But now it
have a default setting.