### PR TITLE
Deterministic backends and asserts system for vfc_ci

### DIFF
--- a/doc/06-Postprocessing.md
+++ b/doc/06-Postprocessing.md
@@ -121,11 +121,19 @@ Below is a list of the different functions you may use to manipulate the
 `vfc_probes` structure :
 
 ```
-// Add a new probe. If a duplicate test/variable name combination is detected,
-// an error will be thrown.
-int vfc_probe(vfc_probes *probes, char *testName, char *varName,
-                  double val);
+// Add a new probe. If an issue with the key is detected (forbidden characters
+// or a duplicate key), an error will be thrown. (no assert)
+int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 
+// Similar to vfc_probe, but with an optional accuracy threshold (absolute
+// assert).
+int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+                     double val, double accuracyThreshold);
+
+// Similar to vfc_probe, but with an optional accuracy threshold (absolute
+// assert).
+int vfc_probe_assert_relative(vfc_probes *probes, char *testName, char *varName,
+                              double val, double accuracyThreshold);
 // Free all probes
 void vfc_free_probes(vfc_probes *probes);
 
@@ -141,10 +149,35 @@ To export your variables to a file, `vfc_probes` relies on the
 your code through a Verificarlo CI test run, so you usually won't have to care
 about it,  but if you were to manually execute a program that calls the
 `vfc_dump_probes` function without this variable, you would be notified by a
-runtime warning explaining that your probes canno tbe exported.
+runtime warning explaining that your probes cannot be exported.
+
+Finally, probes can be used with an optional "assert". Asserts are accuracy
+targets that we want to reach on test variables. If a probe is created with an
+assert, the tool will estimate its error and compare it to the specified
+accuracy target. However, the definition of this error can vary depending on the
+backend and the assert types. Backends are separated in two categories, non-
+deterministic (such as the MCA backend) and deterministic (such as the VPREC backend),
+and asserts precision can be absolute (by default) or relative. This results in four
+different conditions to validate the probe, which are summed up in the following
+table :
+
+| |Absolute|Relative|
+--- | --- | ---
+|Non-deterministic|Standard deviation < Target | Standard deviation / Empirical average < Target
+|Deterministic|IEEE value -  Backend value < Target|(IEEE value -  Backend value) / IEEE value < Target
+
+By default, the standard deviation is used to estimate the error, and must be
+inderior to the accuracy threshold for the probe to pass (or inferior to the
+std. dev. / avg. quotient in the case of a relative assert).
+But in the case of a deterministic backend, it is impossible to compute the standard
+deviation and the average of the probe to estimate the error. Instead , the  
+probe is computed in IEEE standard arithmetic, and this value is used as a
+reference to compute the error introduced by the deterministic backend. The
+status of a probe (passing/failing) can then be consulted in the report (see
+the ["Visualize your test results"](#visualize-your-test-results) part).
 
 **Fortran specific** : `vfc_probes` also comes with a Fortran interface. In
-order to use it, import the`vfc_probes_f` module, as well as
+order to use it, import the `vfc_probes_f` module, as well as
 [ISO_C_BINDING](https://gcc.gnu.org/onlinedocs/gfortran/ISO_005fC_005fBINDING.html).
 The functions are exactly the same, except that values stored inside probes should be
 of type `REAL(kind=C_DOUBLE)`. Moreover, since Fortran passes all functions arguments
@@ -180,13 +213,19 @@ project. Here is an example showcasing the expected structure of this file :
 ```
 
 The `parameters` field is optional and will default to an empty string when not
- specified. Each executable can be run with different backends, which have
- themselves different numbers of repetitions.
+specified. Each executable can be run with different backends, which have
+themselves different numbers of repetitions.
+
+Moreover, the `repetitions` field can also be omitted. However, the backend will
+then be considered as deterministic, which will result in a different data
+processing pipeline being used. For this reason, you should only omit this
+parameter when using backends that are actually deterministic (such as VPREC),
+and specify it in any other case.
 
 Note that :
 
 - Specifying a high enough number of repetitions is important to obtain reliable
- metrics in the report.
+ metrics in the report (with non-deterministic backends).
 - The path to the executable should be relative to the root of the project.
 
 Once this step is complete, you are ready to execute your first test run. This
@@ -213,7 +252,7 @@ Verificarlo CI takes advantage of
 [GitHub Actions](https://github.com/features/actions) and
 [GitLab CI/CD](https://docs.gitlab.com/ee/ci/) to lauch test runs and save
 their results everytime you push to your repository. The run files are stored
-on a dedicated orphan branch named wit the `vfc_ci_` prefix : if you were to
+on a dedicated orphan branch named with the `vfc_ci_` prefix : if you were to
 integrate Verificarlo CI into a `dev` branch, you could access your run files
 on the `vfc_ci_dev` branch.
 
@@ -259,15 +298,25 @@ custom logo to the report, etc... For more details :
 vfc_ci serve --help
 ```
 
-The report is split into two main functionnalities :
+The report is split into a few main views :
 
 - **Compare runs :** lets you select a test/variable/backend combination, and
 compare the evolution of the corresponding variable over the different runs
-(significant digits, distribution, average, standard deviation).
+(significant digits, distribution, average, standard deviation). Moreover, if
+some probes are associated to an assert, fails will appear in red on the
+plots. This view is itself separated into two parts, one for the non-deterministic
+backends, and one for the deterministic backends (which only has a plot to show the
+probe's values).
 - **Inspect runs :** lets you select a specific run. From there you can select
 one factor to group by and one factor to filter by your data (between test,
-variable and backend). For each group, this will create new distribution for
-significants digits, standard deviation, and compute aggregated averages.
+variable and backend). For each group, this will create new distributions for
+significants digits, standard deviation, and compute aggregated averages. This
+view only works for non-deterministic backends.
+- **Asserts table :** lets you see which probes are associated to an assert, and
+which ones are failing. This view is itself separated into two parts, one for the
+non-deterministic backends, and one for the deterministic backends. Depending
+on the backend type, data used for the probe validation will also be shown in
+the table.
 
  > :warning: In the "Inspect runs" mode, you have 6 different selection
 possibilities. Depending on your test setup, all of these combinations might

--- a/doc/06-Postprocessing.md
+++ b/doc/06-Postprocessing.md
@@ -130,7 +130,7 @@ int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold);
 
-// Similar to vfc_probe, but with an optional accuracy threshold (absolute
+// Similar to vfc_probe, but with an optional accuracy threshold (relative
 // check).
 int vfc_probe_check_relative(vfc_probes *probes, char *testName, char *varName,
                               double val, double accuracyThreshold);
@@ -167,13 +167,12 @@ table :
 |Deterministic|\|IEEE value\| -  \|Backend value\| < Target|(\|IEEE value\| -  \|Backend value\|) / \|IEEE value\| < Target
 
 By default, the standard deviation is used to estimate the error, and must be
-inderior to the accuracy threshold for the probe to pass (or inferior to the
+inferior to the accuracy threshold for the probe to pass (or inferior to the
 std. dev. / avg. quotient in the case of a relative check).
-But in the case of a deterministic backend, it is impossible to compute the standard
-deviation and the average of the probe to estimate the error. Instead , the  
-probe is computed in IEEE standard arithmetic, and this value is used as a
-reference to compute the error introduced by the deterministic backend. The
-status of a probe (passing/failing) can then be consulted in the report (see
+But in the case of a deterministic backend, the standard deviation is undefined.
+Instead, the probe is computed in IEEE standard arithmetic, and this value is
+used as a reference to compute the error introduced by the deterministic backend.
+The status of a probe (passing/failing) can then be consulted in the report (see
 the ["Visualize your test results"](#visualize-your-test-results) part).
 
 **Fortran specific** : `vfc_probes` also comes with a Fortran interface. In

--- a/doc/06-Postprocessing.md
+++ b/doc/06-Postprocessing.md
@@ -122,17 +122,17 @@ Below is a list of the different functions you may use to manipulate the
 
 ```
 // Add a new probe. If an issue with the key is detected (forbidden characters
-// or a duplicate key), an error will be thrown. (no assert)
+// or a duplicate key), an error will be thrown. (no check)
 int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
-// assert).
-int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+// check).
+int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold);
 
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
-// assert).
-int vfc_probe_assert_relative(vfc_probes *probes, char *testName, char *varName,
+// check).
+int vfc_probe_check_relative(vfc_probes *probes, char *testName, char *varName,
                               double val, double accuracyThreshold);
 // Free all probes
 void vfc_free_probes(vfc_probes *probes);
@@ -151,24 +151,24 @@ about it,  but if you were to manually execute a program that calls the
 `vfc_dump_probes` function without this variable, you would be notified by a
 runtime warning explaining that your probes cannot be exported.
 
-Finally, probes can be used with an optional "assert". Asserts are accuracy
-targets that we want to reach on test variables. If a probe is created with an
-assert, the tool will estimate its error and compare it to the specified
+Finally, probes can be used with an optional "check". Checks are accuracy
+targets that we want to reach on test variables. If a probe is created with a
+check, the tool will estimate its error and compare it to the specified
 accuracy target. However, the definition of this error can vary depending on the
-backend and the assert types. Backends are separated in two categories, non-
+backend and the check types. Backends are separated in two categories, non-
 deterministic (such as the MCA backend) and deterministic (such as the VPREC backend),
-and asserts precision can be absolute (by default) or relative. This results in four
+and checks precision can be absolute (by default) or relative. This results in four
 different conditions to validate the probe, which are summed up in the following
 table :
 
 | |Absolute|Relative|
 --- | --- | ---
-|Non-deterministic|Standard deviation < Target | Standard deviation / Empirical average < Target
-|Deterministic|IEEE value -  Backend value < Target|(IEEE value -  Backend value) / IEEE value < Target
+|Non-deterministic|\|Standard deviation\| < Target | \|Standard deviation\| / \|Empirical average\| < Target
+|Deterministic|\|IEEE value\| -  \|Backend value\| < Target|(\|IEEE value\| -  \|Backend value\|) / \|IEEE value\| < Target
 
 By default, the standard deviation is used to estimate the error, and must be
 inderior to the accuracy threshold for the probe to pass (or inferior to the
-std. dev. / avg. quotient in the case of a relative assert).
+std. dev. / avg. quotient in the case of a relative check).
 But in the case of a deterministic backend, it is impossible to compute the standard
 deviation and the average of the probe to estimate the error. Instead , the  
 probe is computed in IEEE standard arithmetic, and this value is used as a
@@ -303,7 +303,7 @@ The report is split into a few main views :
 - **Compare runs :** lets you select a test/variable/backend combination, and
 compare the evolution of the corresponding variable over the different runs
 (significant digits, distribution, average, standard deviation). Moreover, if
-some probes are associated to an assert, fails will appear in red on the
+some probes are associated to a check, fails will appear in red on the
 plots. This view is itself separated into two parts, one for the non-deterministic
 backends, and one for the deterministic backends (which only has a plot to show the
 probe's values).
@@ -312,7 +312,7 @@ one factor to group by and one factor to filter by your data (between test,
 variable and backend). For each group, this will create new distributions for
 significants digits, standard deviation, and compute aggregated averages. This
 view only works for non-deterministic backends.
-- **Asserts table :** lets you see which probes are associated to an assert, and
+- **checks table :** lets you see which probes are associated to a check, and
 which ones are failing. This view is itself separated into two parts, one for the
 non-deterministic backends, and one for the deterministic backends. Depending
 on the backend type, data used for the probe validation will also be shown in

--- a/src/common/vfc_probes.c
+++ b/src/common/vfc_probes.c
@@ -77,7 +77,7 @@ int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 
 // Similar to vfc_probe, but with an optional accuracy threshold.
 int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
-                     double val, double accuracyThreshold);
+                    double val, double accuracyThreshold);
 
 // Return the number of probes stored in the hashmap
 unsigned int vfc_num_probes(vfc_probes *probes);
@@ -200,7 +200,7 @@ int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val) {
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
 // check).
 int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
-                     double val, double accuracyThreshold) {
+                    double val, double accuracyThreshold) {
   return vfc_probe_kernel(probes, testName, varName, val, accuracyThreshold,
                           "absolute");
 }
@@ -208,7 +208,7 @@ int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
 // Similar to vfc_probe, but with an optional accuracy threshold (relative
 // check).
 int vfc_probe_check_relative(vfc_probes *probes, char *testName, char *varName,
-                              double val, double accuracyThreshold) {
+                             double val, double accuracyThreshold) {
   return vfc_probe_kernel(probes, testName, varName, val, accuracyThreshold,
                           "relative");
 }
@@ -276,13 +276,13 @@ int vfc_probe_f(vfc_probes *probes, char *testName, char *varName,
 }
 
 int vfc_probe_check_f(vfc_probes *probes, char *testName, char *varName,
-                       double *val, double *accuracyThreshold) {
+                      double *val, double *accuracyThreshold) {
   return vfc_probe_check(probes, testName, varName, *val, *accuracyThreshold);
 }
 
 int vfc_probe_check_relative_f(vfc_probes *probes, char *testName,
-                                char *varName, double *val,
-                                double *accuracyThreshold) {
+                               char *varName, double *val,
+                               double *accuracyThreshold) {
   return vfc_probe_check_relative(probes, testName, varName, *val,
-                                   *accuracyThreshold);
+                                  *accuracyThreshold);
 }

--- a/src/common/vfc_probes.c
+++ b/src/common/vfc_probes.c
@@ -246,7 +246,7 @@ int vfc_dump_probes(vfc_probes *probes) {
   }
 
   // First line gives the column names
-  fprintf(fp, "test,variable,value,accuracy_threshold,mode\n");
+  fprintf(fp, "test,variable,value,accuracy_threshold,assert_mode\n");
 
   // Iterate over all table elements
   vfc_probe_node *probe = NULL;

--- a/src/common/vfc_probes.c
+++ b/src/common/vfc_probes.c
@@ -76,7 +76,7 @@ void validate_probe_key(char *str);
 int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 
 // Similar to vfc_probe, but with an optional accuracy threshold.
-int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold);
 
 // Return the number of probes stored in the hashmap
@@ -145,7 +145,7 @@ void validate_probe_key(char *str) {
   }
 }
 
-// Probe kernel function that supports asserts and use any mode (relative /
+// Probe kernel function that supports checks and use any mode (relative /
 // absolute). This probably won't be called directly by the user.
 int vfc_probe_kernel(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold, char *mode) {
@@ -192,22 +192,22 @@ int vfc_probe_kernel(vfc_probes *probes, char *testName, char *varName,
 // Add a new probe. If an issue with the key is detected (forbidden characters
 // or a duplicate key), an error will be thrown.
 int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val) {
-  // Creating a probe without assert is equivalent to setting the accuracy
+  // Creating a probe without check is equivalent to setting the accuracy
   // threshold to 0.
   return vfc_probe_kernel(probes, testName, varName, val, 0, "none");
 }
 
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
-// assert).
-int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+// check).
+int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold) {
   return vfc_probe_kernel(probes, testName, varName, val, accuracyThreshold,
                           "absolute");
 }
 
 // Similar to vfc_probe, but with an optional accuracy threshold (relative
-// assert).
-int vfc_probe_assert_relative(vfc_probes *probes, char *testName, char *varName,
+// check).
+int vfc_probe_check_relative(vfc_probes *probes, char *testName, char *varName,
                               double val, double accuracyThreshold) {
   return vfc_probe_kernel(probes, testName, varName, val, accuracyThreshold,
                           "relative");
@@ -246,7 +246,7 @@ int vfc_dump_probes(vfc_probes *probes) {
   }
 
   // First line gives the column names
-  fprintf(fp, "test,variable,value,accuracy_threshold,assert_mode\n");
+  fprintf(fp, "test,variable,value,accuracy_threshold,check_mode\n");
 
   // Iterate over all table elements
   vfc_probe_node *probe = NULL;
@@ -275,14 +275,14 @@ int vfc_probe_f(vfc_probes *probes, char *testName, char *varName,
   return vfc_probe(probes, testName, varName, *val);
 }
 
-int vfc_probe_assert_f(vfc_probes *probes, char *testName, char *varName,
+int vfc_probe_check_f(vfc_probes *probes, char *testName, char *varName,
                        double *val, double *accuracyThreshold) {
-  return vfc_probe_assert(probes, testName, varName, *val, *accuracyThreshold);
+  return vfc_probe_check(probes, testName, varName, *val, *accuracyThreshold);
 }
 
-int vfc_probe_assert_relative_f(vfc_probes *probes, char *testName,
+int vfc_probe_check_relative_f(vfc_probes *probes, char *testName,
                                 char *varName, double *val,
                                 double *accuracyThreshold) {
-  return vfc_probe_assert_relative(probes, testName, varName, *val,
+  return vfc_probe_check_relative(probes, testName, varName, *val,
                                    *accuracyThreshold);
 }

--- a/src/common/vfc_probes.c
+++ b/src/common/vfc_probes.c
@@ -40,10 +40,14 @@
 #endif
 
 // A probe containing a double value as well as its key, which is needed when
-// dumping the probes
+// dumping the probes. Optionally, an accuracy threshold can be defined : it
+// will be re-used in the preprocessing to (un)validate the probe.
 struct vfc_probe_node {
   char *key;
   double value;
+
+  double accuracyThreshold;
+  char *mode;
 };
 
 typedef struct vfc_probe_node vfc_probe_node;
@@ -71,6 +75,10 @@ void validate_probe_key(char *str);
 // or a duplicate key), an error will be thrown.
 int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 
+// Similar to vfc_probe, but with an optional accuracy threshold.
+int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+                     double val, double accuracyThreshold);
+
 // Return the number of probes stored in the hashmap
 unsigned int vfc_num_probes(vfc_probes *probes);
 
@@ -96,7 +104,7 @@ void vfc_free_probes(vfc_probes *probes) {
 
   // Before freeing the map, iterate manually over all items to free the keys
   vfc_probe_node *probe = NULL;
-  for (size_t i = 0; i < probes->map->capacity; i++) {
+  for (int i = 0; i < probes->map->capacity; i++) {
     probe = (vfc_probe_node *)get_value_at(probes->map->items, i);
 
     // Comparing with 1 is also necessary since it will be the value of deleted
@@ -104,6 +112,7 @@ void vfc_free_probes(vfc_probes *probes) {
     if (probe != NULL && probe != (vfc_probe_node *)1) {
       if (probe->key != NULL) {
         free(probe->key);
+        free(probe->mode);
       }
     }
   }
@@ -136,9 +145,10 @@ void validate_probe_key(char *str) {
   }
 }
 
-// Add a new probe. If an issue with the key is detected (forbidden characters
-// or a duplicate key), an error will be thrown.
-int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val) {
+// Probe kernel function that supports asserts and use any mode (relative /
+// absolute). This probably won't be called directly by the user.
+int vfc_probe_kernel(vfc_probes *probes, char *testName, char *varName,
+                     double val, double accuracyThreshold, char *mode) {
 
   if (probes == NULL) {
     return 1;
@@ -170,10 +180,37 @@ int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val) {
   vfc_probe_node *newProbe = (vfc_probe_node *)malloc(sizeof(vfc_probe_node));
   newProbe->key = key;
   newProbe->value = val;
+  newProbe->accuracyThreshold = accuracyThreshold;
+  newProbe->mode = malloc(sizeof(char) * strlen(mode));
+  strcpy(newProbe->mode, mode);
 
   vfc_hashmap_insert(probes->map, vfc_hashmap_str_function(key), newProbe);
 
   return 0;
+}
+
+// Add a new probe. If an issue with the key is detected (forbidden characters
+// or a duplicate key), an error will be thrown.
+int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val) {
+  // Creating a probe without assert is equivalent to setting the accuracy
+  // threshold to 0.
+  return vfc_probe_kernel(probes, testName, varName, val, 0, "none");
+}
+
+// Similar to vfc_probe, but with an optional accuracy threshold (absolute
+// assert).
+int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+                     double val, double accuracyThreshold) {
+  return vfc_probe_kernel(probes, testName, varName, val, accuracyThreshold,
+                          "absolute");
+}
+
+// Similar to vfc_probe, but with an optional accuracy threshold (relative
+// assert).
+int vfc_probe_assert_relative(vfc_probes *probes, char *testName, char *varName,
+                              double val, double accuracyThreshold) {
+  return vfc_probe_kernel(probes, testName, varName, val, accuracyThreshold,
+                          "relative");
 }
 
 // Return the number of probes stored in the hashmap
@@ -209,14 +246,15 @@ int vfc_dump_probes(vfc_probes *probes) {
   }
 
   // First line gives the column names
-  fprintf(fp, "test,variable,value\n");
+  fprintf(fp, "test,variable,value,accuracy_threshold,mode\n");
 
   // Iterate over all table elements
   vfc_probe_node *probe = NULL;
-  for (size_t i = 0; i < probes->map->capacity; i++) {
+  for (int i = 0; i < probes->map->capacity; i++) {
     probe = (vfc_probe_node *)get_value_at(probes->map->items, i);
     if (probe != NULL) {
-      fprintf(fp, "%s,%a\n", probe->key, probe->value);
+      fprintf(fp, "%s,%a,%a,%s\n", probe->key, probe->value,
+              probe->accuracyThreshold, probe->mode);
     }
   }
 
@@ -230,11 +268,21 @@ int vfc_dump_probes(vfc_probes *probes) {
 /*
  * Fortran wrappers : since Fortran arguments are all passed by address, these
  * versions only take pointers as arguments and only call the base fuctions.
- * (as of now, only the vfc_probe function needs its own wrapper, since other
- * functions already use pointers as their arguments).
  */
 
 int vfc_probe_f(vfc_probes *probes, char *testName, char *varName,
                 double *val) {
   return vfc_probe(probes, testName, varName, *val);
+}
+
+int vfc_probe_assert_f(vfc_probes *probes, char *testName, char *varName,
+                       double *val, double *accuracyThreshold) {
+  return vfc_probe_assert(probes, testName, varName, *val, *accuracyThreshold);
+}
+
+int vfc_probe_assert_relative_f(vfc_probes *probes, char *testName,
+                                char *varName, double *val,
+                                double *accuracyThreshold) {
+  return vfc_probe_assert_relative(probes, testName, varName, *val,
+                                   *accuracyThreshold);
 }

--- a/src/common/vfc_probes.h
+++ b/src/common/vfc_probes.h
@@ -86,12 +86,12 @@ int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
 // check).
 int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
-                     double val, double accuracyThreshold);
+                    double val, double accuracyThreshold);
 
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
 // check).
 int vfc_probe_check_relative(vfc_probes *probes, char *testName, char *varName,
-                              double val, double accuracyThreshold);
+                             double val, double accuracyThreshold);
 
 // Return the number of probes stored in the hashmap
 unsigned int vfc_num_probes(vfc_probes *probes);
@@ -105,8 +105,8 @@ int vfc_dump_probes(vfc_probes *probes);
 int vfc_probe_f(vfc_probes *probes, char *testName, char *varName, double *val);
 
 int vfc_probe_check_f(vfc_probes *probes, char *testName, char *varName,
-                       double *val, double *accuracyThreshold);
+                      double *val, double *accuracyThreshold);
 
 int vfc_probe_check_relative_f(vfc_probes *probes, char *testName,
-                                char *varName, double *val,
-                                double *accuracyThreshold);
+                               char *varName, double *val,
+                               double *accuracyThreshold);

--- a/src/common/vfc_probes.h
+++ b/src/common/vfc_probes.h
@@ -74,23 +74,23 @@ char *gen_probe_key(char *testName, char *varName);
 // Helper function to detect forbidden character ',' in the keys
 void validate_probe_key(char *str);
 
-// Probe kernel function that supports asserts and use any mode (relative /
+// Probe kernel function that supports checks and use any mode (relative /
 // absolute). This probably won't be called directly by the user.
 int vfc_probe_kernel(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold, char *mode);
 
 // Add a new probe. If an issue with the key is detected (forbidden characters
-// or a duplicate key), an error will be thrown. (no assert)
+// or a duplicate key), an error will be thrown. (no check)
 int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
 
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
-// assert).
-int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+// check).
+int vfc_probe_check(vfc_probes *probes, char *testName, char *varName,
                      double val, double accuracyThreshold);
 
 // Similar to vfc_probe, but with an optional accuracy threshold (absolute
-// assert).
-int vfc_probe_assert_relative(vfc_probes *probes, char *testName, char *varName,
+// check).
+int vfc_probe_check_relative(vfc_probes *probes, char *testName, char *varName,
                               double val, double accuracyThreshold);
 
 // Return the number of probes stored in the hashmap
@@ -104,9 +104,9 @@ int vfc_dump_probes(vfc_probes *probes);
 
 int vfc_probe_f(vfc_probes *probes, char *testName, char *varName, double *val);
 
-int vfc_probe_assert_f(vfc_probes *probes, char *testName, char *varName,
+int vfc_probe_check_f(vfc_probes *probes, char *testName, char *varName,
                        double *val, double *accuracyThreshold);
 
-int vfc_probe_assert_relative_f(vfc_probes *probes, char *testName,
+int vfc_probe_check_relative_f(vfc_probes *probes, char *testName,
                                 char *varName, double *val,
                                 double *accuracyThreshold);

--- a/src/common/vfc_probes.h
+++ b/src/common/vfc_probes.h
@@ -31,6 +31,7 @@
 
 #pragma once
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,10 +43,14 @@
 #endif
 
 // A probe containing a double value as well as its key, which is needed when
-// dumping the probes
+// dumping the probes. Optionally, an accuracy threshold can be defined : it
+// will be re-used in the preprocessing to (un)validate the probe.
 struct vfc_probe_node {
   char *key;
   double value;
+
+  double accuracyThreshold;
+  char *mode;
 };
 
 typedef struct vfc_probe_node vfc_probe_node;
@@ -69,9 +74,24 @@ char *gen_probe_key(char *testName, char *varName);
 // Helper function to detect forbidden character ',' in the keys
 void validate_probe_key(char *str);
 
+// Probe kernel function that supports asserts and use any mode (relative /
+// absolute). This probably won't be called directly by the user.
+int vfc_probe_kernel(vfc_probes *probes, char *testName, char *varName,
+                     double val, double accuracyThreshold, char *mode);
+
 // Add a new probe. If an issue with the key is detected (forbidden characters
-// or a duplicate key), an error will be thrown.
+// or a duplicate key), an error will be thrown. (no assert)
 int vfc_probe(vfc_probes *probes, char *testName, char *varName, double val);
+
+// Similar to vfc_probe, but with an optional accuracy threshold (absolute
+// assert).
+int vfc_probe_assert(vfc_probes *probes, char *testName, char *varName,
+                     double val, double accuracyThreshold);
+
+// Similar to vfc_probe, but with an optional accuracy threshold (absolute
+// assert).
+int vfc_probe_assert_relative(vfc_probes *probes, char *testName, char *varName,
+                              double val, double accuracyThreshold);
 
 // Return the number of probes stored in the hashmap
 unsigned int vfc_num_probes(vfc_probes *probes);
@@ -80,5 +100,13 @@ unsigned int vfc_num_probes(vfc_probes *probes);
 // free it.
 int vfc_dump_probes(vfc_probes *probes);
 
-// Fortran wrapper
+// Fortran wrappers
+
 int vfc_probe_f(vfc_probes *probes, char *testName, char *varName, double *val);
+
+int vfc_probe_assert_f(vfc_probes *probes, char *testName, char *varName,
+                       double *val, double *accuracyThreshold);
+
+int vfc_probe_assert_relative_f(vfc_probes *probes, char *testName,
+                                char *varName, double *val,
+                                double *accuracyThreshold);

--- a/src/tools/ci/serve.py
+++ b/src/tools/ci/serve.py
@@ -56,6 +56,7 @@ def run(
     # re-write the Tornado server, which means setting up public directories,
     # generating the Jinja template, etc... => This is an option for a future
     # commit.
+
     command = "bokeh serve %s/vfc_ci_report %s --allow-websocket-origin=%s:%s --port %s --args %s %s %s %s" \
         % (dirname, show, allow_origin, port, port, directory, logo, max_files, ignore_recent)
     command = os.path.normpath(command)

--- a/src/tools/ci/test.py
+++ b/src/tools/ci/test.py
@@ -102,10 +102,10 @@ def read_probes_csv(filepath, warnings, execution_data):
 
     # Extract accuracy thresholds data
     checks_data = results[["test",
-                            "variable",
-                            "vfc_backend",
-                            "accuracy_threshold",
-                            "check_mode"]].copy()
+                           "variable",
+                           "vfc_backend",
+                           "accuracy_threshold",
+                           "check_mode"]].copy()
 
     del results["accuracy_threshold"]
     del results["check_mode"]

--- a/src/tools/ci/test.py
+++ b/src/tools/ci/test.py
@@ -101,11 +101,14 @@ def read_probes_csv(filepath, warnings, execution_data):
     results["vfc_backend"] = execution_data["backend"]
 
     # Extract accuracy thresholds data
-    asserts_data = results[["test", "variable",
-                            "vfc_backend", "accuracy_threshold", "mode"]].copy()
+    asserts_data = results[["test",
+                            "variable",
+                            "vfc_backend",
+                            "accuracy_threshold",
+                            "assert_mode"]].copy()
 
     del results["accuracy_threshold"]
-    del results["mode"]
+    del results["assert_mode"]
 
     return results, asserts_data
 
@@ -252,7 +255,7 @@ def run_deterministic(
 
     run_data.rename(columns={"values": "value"}, inplace=True)
     run_data["accuracy_threshold"] = run_asserts_data["accuracy_threshold"]
-    run_data["mode"] = run_asserts_data["mode"]
+    run_data["assert_mode"] = run_asserts_data["assert_mode"]
 
     # If asserts are detected, do a reference run (with IEEE backend)
     if run_data["accuracy_threshold"].sum() != 0:
@@ -385,7 +388,7 @@ def run_tests(config):
 
         # Copy informations about accuracy thresholds to the main dataframe
         data["accuracy_threshold"] = asserts_data["accuracy_threshold"]
-        data["mode"] = asserts_data["mode"]
+        data["assert_mode"] = asserts_data["assert_mode"]
 
     else:
         data = pd.DataFrame()

--- a/src/tools/ci/test.py
+++ b/src/tools/ci/test.py
@@ -25,7 +25,7 @@
 # This script reads the vfc_tests_config.json file and executes tests accordingly
 # It will also generate a ... .vfcrunh5 file with the results of the run
 
-from .test_data_processing import data_processing
+from .test_data_processing import data_processing, validate_deterministic_probe
 import pandas as pd
 import os
 import subprocess
@@ -49,7 +49,7 @@ timeout = 600   # For commands execution
 
 # Helper functions
 
-def read_probes_csv(filepath, backend, warnings, execution_data):
+def read_probes_csv(filepath, warnings, execution_data):
     '''Read a CSV file outputted by vfc_probe as a Pandas dataframe'''
 
     try:
@@ -63,8 +63,12 @@ def read_probes_csv(filepath, backend, warnings, execution_data):
         )
         warnings.append(execution_data)
         return pd.DataFrame(
-            columns=["test", "variable", "values", "vfc_backend"]
-        )
+            columns=[
+                "test",
+                "variable",
+                "values",
+                "accuracy_threshold",
+                "vfc_backend"])
 
     except Exception:
         print(
@@ -73,8 +77,12 @@ def read_probes_csv(filepath, backend, warnings, execution_data):
         )
         warnings.append(execution_data)
         return pd.DataFrame(
-            columns=["test", "variable", "values", "vfc_backend"]
-        )
+            columns=[
+                "test",
+                "variable",
+                "values",
+                "accuracy_threshold",
+                "vfc_backend"])
 
     if len(results) == 0:
         print(
@@ -87,9 +95,19 @@ def read_probes_csv(filepath, backend, warnings, execution_data):
     results["value"] = results["value"].apply(lambda x: float.fromhex(x))
     results.rename(columns={"value": "values"}, inplace=True)
 
-    results["vfc_backend"] = backend
+    results["accuracy_threshold"] = results["accuracy_threshold"].apply(
+        lambda x: float.fromhex(x))
 
-    return results
+    results["vfc_backend"] = execution_data["backend"]
+
+    # Extract accuracy thresholds data
+    asserts_data = results[["test", "variable",
+                            "vfc_backend", "accuracy_threshold", "mode"]].copy()
+
+    del results["accuracy_threshold"]
+    del results["mode"]
+
+    return results, asserts_data
 
 
 ##########################################################################
@@ -150,6 +168,136 @@ def generate_metadata(is_git_commit):
     return metadata
 
 
+def run_non_deterministic(
+        command,
+        repetitions,
+        executable,
+        backend,
+        data,
+        asserts_data,
+        warnings):
+    '''
+    Loop execution for non-deterministic backends. This will also export asserts
+    so they can be merged later with the data (after the likely duplicates have
+    been removed).
+    '''
+
+    # Run test repetitions and save results
+    for i in range(repetitions):
+        temp = tempfile.NamedTemporaryFile()
+        os.putenv("VFC_PROBES_OUTPUT", temp.name)
+
+        p = subprocess.Popen(command.split())
+        try:
+            p.wait(timeout)
+        except subprocess.TimeoutExpired:
+            print(
+                "Warning [vfc_ci]: execution was timed out",
+                file=sys.stderr)
+            p.kill()
+
+        execution_data = {
+            "executable": executable,
+            "backend": backend,
+            "repetition": i + 1
+        }
+
+        run_data, run_assert_data = read_probes_csv(
+            temp.name,
+            warnings,
+            execution_data
+        )
+
+        data.append(run_data)
+        asserts_data.append(run_assert_data)
+
+        temp.close()
+
+
+def run_deterministic(
+        command,
+        executable,
+        backend,
+        deterministic_data,
+        warnings):
+    '''
+    Single execution for deterministic test. If some probes are associated to an
+    assert, an IEEE run will also be executed as a reference. The assert will be
+    checked directly, since it doesn't really require any data processing.
+    '''
+
+    temp = tempfile.NamedTemporaryFile()
+    os.putenv("VFC_PROBES_OUTPUT", temp.name)
+
+    p = subprocess.Popen(command.split())
+    try:
+        p.wait(timeout)
+    except subprocess.TimeoutExpired:
+        print(
+            "Warning [vfc_ci]: execution was timed out",
+            file=sys.stderr)
+        p.kill()
+
+    execution_data = {
+        "executable": executable,
+        "backend": backend,
+        "repetition": 1
+    }
+
+    run_data, run_asserts_data = read_probes_csv(
+        temp.name,
+        warnings,
+        execution_data
+    )
+
+    run_data.rename(columns={"values": "value"}, inplace=True)
+    run_data["accuracy_threshold"] = run_asserts_data["accuracy_threshold"]
+    run_data["mode"] = run_asserts_data["mode"]
+
+    # If asserts are detected, do a reference run (with IEEE backend)
+    if run_data["accuracy_threshold"].sum() != 0:
+
+        temp.close()
+
+        os.putenv("VFC_BACKENDS", "libinterflop_ieee.so")
+        temp = tempfile.NamedTemporaryFile()
+        os.putenv("VFC_PROBES_OUTPUT", temp.name)
+
+        p = subprocess.Popen(command.split())
+        try:
+            p.wait(timeout)
+        except subprocess.TimeoutExpired:
+            print(
+                "Warning [vfc_ci]: reference execution was timed out",
+                file=sys.stderr)
+            p.kill()
+
+        execution_data = {
+            "executable": executable,
+            "backend": "libinterflop_ieee.so (reference run)",
+            "repetition": 1
+        }
+
+        reference_run_data = read_probes_csv(
+            temp.name,
+            warnings,
+            execution_data
+        )[0]
+
+        run_data["reference_value"] = reference_run_data["values"]
+        run_data["assert"] = run_data.apply(
+            lambda x: validate_deterministic_probe(x), axis=1
+        )
+
+    else:
+        run_data["reference_value"] = 0
+        run_data["assert"] = True
+
+    deterministic_data.append(run_data)
+
+    temp.close()
+
+
 def run_tests(config):
     '''
     Execute tests and collect results in a Pandas dataframe
@@ -159,15 +307,19 @@ def run_tests(config):
     print("Info [vfc_ci]: Building tests...")
     os.system(config["make_command"])
 
-    # This is an array of Pandas dataframes for now
+    # These are arrays of Pandas dataframes for now
     data = []
+    deterministic_data = []
+
+    # Only for non-deterministic data. Stored separately for now since it is
+    # easier to add this to data after the groupby.
+    asserts_data = []
 
     # This will contain all executables/repetition numbers from which we could
     # not get any data
     warnings = []
 
-    # Tests execution loops
-
+    # Executables iteration
     for executable in config["executables"]:
         print("Info [vfc_ci]: Running executable :",
               executable["executable"], "...")
@@ -176,58 +328,79 @@ def run_tests(config):
         if "parameters" in executable:
             parameters = executable["parameters"]
 
+        # Backends iteration
         for backend in executable["vfc_backends"]:
 
             os.putenv("VFC_BACKENDS", backend["name"])
 
             command = "./" + executable["executable"] + " " + parameters
 
-            repetitions = 1
+            # By default, we expect to have a number of repetitions specified
+            # to run the tests in "non-deterministic" mode.
             if "repetitions" in backend:
                 repetitions = backend["repetitions"]
 
-            # Run test repetitions and save results
-            for i in range(repetitions):
-                temp = tempfile.NamedTemporaryFile()
-                os.putenv("VFC_PROBES_OUTPUT", temp.name)
-
-                print(command)
-                p = subprocess.Popen(command.split())
-                try:
-                    p.wait(timeout)
-                except subprocess.TimeoutExpired:
-                    print(
-                        "Warning [vfc_ci]: execution was timed out",
-                        file=sys.stderr)
-                    p.kill()
-
-                # This will only be used if we need to append this exec to the
-                # warnings list
-                execution_data = {
-                    "executable": executable["executable"],
-                    "backend": backend["name"],
-                    "repetition": i + 1
-                }
-
-                data.append(read_probes_csv(
-                    temp.name,
+                run_non_deterministic(
+                    command,
+                    repetitions,
+                    executable["executable"],
                     backend["name"],
-                    warnings,
-                    execution_data
-                ))
+                    data,
+                    asserts_data,
+                    warnings)
 
-                temp.close()
-
-    # Combine all separate executions in one dataframe
-    data = pd.concat(data, sort=False, ignore_index=True)
-    data = data.groupby(["test", "vfc_backend", "variable"])\
-        .values.apply(list).reset_index()
+            # However, if it is not specified, we'll assume a deterministic
+            # backend and fall back to this mode (so as to avoid the same data
+            # processing phase used for non-deterministic mode).
+            else:
+                # The run is executed in this helper function
+                run_deterministic(
+                    command,
+                    executable["executable"],
+                    backend["name"],
+                    deterministic_data,
+                    warnings)
 
     # Make sure we have some data to work on
-    assert(len(data) != 0), "Error [vfc_ci]: No data have been generated " \
+    assert(len(data) != 0 or len(deterministic_data) != 0), "Error [vfc_ci]: No data have been generated " \
         "by your tests executions, aborting run without writing results file"
 
-    return data, warnings
+    # Combine all separate executions in one dataframe
+    if len(data) > 0:
+        data = pd.concat(data, sort=False, ignore_index=True)
+        data = data.groupby(["test", "variable", "vfc_backend"]
+                            ).values.apply(list).reset_index()
+
+        data = data.set_index(
+            ["test", "variable", "vfc_backend"]).sort_index()
+        asserts_data = pd.concat(
+            asserts_data,
+            sort=False,
+            ignore_index=True)
+        asserts_data = asserts_data.drop_duplicates()
+        asserts_data = asserts_data.reset_index()
+        del asserts_data["index"]
+        asserts_data = asserts_data.set_index(
+            ["test", "variable", "vfc_backend"]).sort_index()
+
+        # Copy informations about accuracy thresholds to the main dataframe
+        data["accuracy_threshold"] = asserts_data["accuracy_threshold"]
+        data["mode"] = asserts_data["mode"]
+
+    else:
+        data = pd.DataFrame()
+
+        # Combine all serparate executions of deterministic backends in one DF
+    if len(deterministic_data) != 0:
+        deterministic_data = pd.concat(
+            deterministic_data,
+            sort=False,
+            ignore_index=True)
+
+    else:
+        deterministic_data = pd.DataFrame()
+
+    return data, deterministic_data, warnings
 
 
 def show_warnings(warnings):
@@ -269,16 +442,20 @@ def run(is_git_commit, export_raw_values, dry_run):
     print("Info [vfc_ci]: Generating run metadata...")
     metadata = generate_metadata(is_git_commit)
 
-    data, warnings = run_tests(config)
+    data, deterministic_data, warnings = run_tests(config)
     show_warnings(warnings)
 
     # Data processing
-    data = data_processing(data)
+    if not data.empty:
+        data = data_processing(data)
 
-    # Prepare data for export (by creating a proper index and linking run
-    # timestamp)
-    data = data.set_index(["test", "variable", "vfc_backend"]).sort_index()
-    data["timestamp"] = metadata["timestamp"]
+        # Link run timestamp
+        data["timestamp"] = metadata["timestamp"]
+
+    if not deterministic_data.empty:
+        deterministic_data = deterministic_data.set_index(
+            ["test", "variable", "vfc_backend"]).sort_index()
+        deterministic_data["timestamp"] = metadata["timestamp"]
 
     filename = metadata["hash"] if is_git_commit else str(
         metadata["timestamp"])
@@ -290,16 +467,27 @@ def run(is_git_commit, export_raw_values, dry_run):
     # WARNING : Exporting to HDF5 implicitly requires to install "tables" on the
     # system
 
-    # Export raw data if needed
-    if export_raw_values and not dry_run:
-        data.to_hdf(filename + ".vfcraw.h5", key="data")
-        metadata.to_hdf(filename + ".vfcraw.h5", key="metadata")
-
-    # Export data
-    del data["values"]
     if not dry_run:
-        data.to_hdf(filename + ".vfcrun.h5", key="data")
+        # Export raw if needed
+        if export_raw_values:
+            data.to_hdf(filename + ".vfcraw.h5", key="data")
+            metadata.to_hdf(filename + ".vfcraw.h5", key="metadata")
+            deterministic_data.to_hdf(
+                filename + ".vfcraw.h5",
+                key="deterministic_data")
+
+        # Export metadata
         metadata.to_hdf(filename + ".vfcrun.h5", key="metadata")
+
+        # Export data
+        if not data.empty:
+            del data["values"]
+        data.to_hdf(filename + ".vfcrun.h5", key="data")
+
+        # Export deterministic data
+        deterministic_data.to_hdf(
+            filename + ".vfcrun.h5",
+            key="deterministic_data")
 
     # Print termination messages
     print(

--- a/src/tools/ci/test_data_processing.py
+++ b/src/tools/ci/test_data_processing.py
@@ -120,7 +120,7 @@ def apply_data_pocessing(data):
     data["quantile75"] = np.quantile(data["values"], 0.75)
     data["max"] = np.max(data["values"])
 
-    #Check validation
+    # Check validation
 
     if data["check_mode"] == "absolute":
         data["check"] = True if data["sigma"] < abs(

--- a/src/tools/ci/test_data_processing.py
+++ b/src/tools/ci/test_data_processing.py
@@ -38,6 +38,9 @@ confidence = 0.95
 def significant_digits(x):
     '''First wrapper to sd.significant_digits (returns results in base 2)'''
 
+    if x.mu == 0:
+        return 53
+
     # If the null hypothesis is rejected, call sigdigits with the General
     # formula:
     if x.pvalue < min_pvalue:
@@ -76,6 +79,9 @@ def significant_digits_lower_bound(x):
     # If the null hypothesis is rejected, no lower bound
     if x.pvalue < min_pvalue:
         return x.s2
+
+    elif x.mu == 0:
+        return 53
 
     # Else, the lower bound will be computed with p= .9 alpha-1=.95
     else:
@@ -116,11 +122,11 @@ def apply_data_pocessing(data):
 
     # Assert validation
 
-    if data["mode"] == "absolute":
+    if data["assert_mode"] == "absolute":
         data["assert"] = True if data["sigma"] < abs(
             data["accuracy_threshold"]) else False
 
-    elif data["mode"] == "relative":
+    elif data["assert_mode"] == "relative":
         data["assert"] = True if abs(
             data["sigma"] /
             data["mu"]) < abs(data["accuracy_threshold"]) else False
@@ -162,12 +168,12 @@ def validate_deterministic_probe(x):
     backends to validate probes depending on if they are absolute or relative
     '''
 
-    if x["mode"] == "absolute":
+    if x["assert_mode"] == "absolute":
         return True if abs(
             x["value"] -
             x["reference_value"]) < abs(x["accuracy_threshold"]) else False
 
-    if x["mode"] == "relative":
+    if x["assert_mode"] == "relative":
         return True if abs(x["value"] - x["reference_value"]) / \
             abs(x["reference_value"]) < abs(x["accuracy_threshold"]) else False
 

--- a/src/tools/ci/test_data_processing.py
+++ b/src/tools/ci/test_data_processing.py
@@ -120,19 +120,19 @@ def apply_data_pocessing(data):
     data["quantile75"] = np.quantile(data["values"], 0.75)
     data["max"] = np.max(data["values"])
 
-    # Assert validation
+    #Check validation
 
-    if data["assert_mode"] == "absolute":
-        data["assert"] = True if data["sigma"] < abs(
+    if data["check_mode"] == "absolute":
+        data["check"] = True if data["sigma"] < abs(
             data["accuracy_threshold"]) else False
 
-    elif data["assert_mode"] == "relative":
-        data["assert"] = True if abs(
+    elif data["check_mode"] == "relative":
+        data["check"] = True if abs(
             data["sigma"] /
             data["mu"]) < abs(data["accuracy_threshold"]) else False
 
     else:
-        data["assert"] = True
+        data["check"] = True
 
     return data
 
@@ -168,12 +168,12 @@ def validate_deterministic_probe(x):
     backends to validate probes depending on if they are absolute or relative
     '''
 
-    if x["assert_mode"] == "absolute":
+    if x["check_mode"] == "absolute":
         return True if abs(
             x["value"] -
             x["reference_value"]) < abs(x["accuracy_threshold"]) else False
 
-    if x["assert_mode"] == "relative":
+    if x["check_mode"] == "relative":
         return True if abs(x["value"] - x["reference_value"]) / \
             abs(x["reference_value"]) < abs(x["accuracy_threshold"]) else False
 

--- a/src/tools/ci/test_data_processing.py
+++ b/src/tools/ci/test_data_processing.py
@@ -43,7 +43,7 @@ def significant_digits(x):
     if x.pvalue < min_pvalue:
         # In a pandas DF, "values" actually refers to the array of columns, and
         # not the column named "values"
-        distribution = x.values[3]
+        distribution = x.values[0]
         distribution = distribution.reshape(len(distribution), 1)
 
         # The distribution's empirical average will be used as the reference
@@ -64,7 +64,7 @@ def significant_digits(x):
 
     # Else, manually compute sMCA (Stott-Parker formula)
     else:
-        return -np.log2(np.absolute(x.sigma / x.mu))
+        return min(-np.log2(np.absolute(x.sigma / x.mu)), 53)
 
 
 def significant_digits_lower_bound(x):
@@ -79,7 +79,7 @@ def significant_digits_lower_bound(x):
 
     # Else, the lower bound will be computed with p= .9 alpha-1=.95
     else:
-        distribution = x.values[3]
+        distribution = x.values[0]
         distribution = distribution.reshape(len(distribution), 1)
 
         mu = np.array([x.mu])
@@ -105,8 +105,7 @@ def apply_data_pocessing(data):
     # Get empirical average, standard deviation and p-value
     data["mu"] = np.average(data["values"])
     data["sigma"] = np.std(data["values"])
-    # Shapiro returns (statistic, p_value)
-    data["pvalue"] = scipy.stats.shapiro(data["values"])[1]
+    data["pvalue"] = scipy.stats.shapiro(data["values"]).pvalue
 
     # Quantiles
     data["min"] = np.min(data["values"])
@@ -114,6 +113,20 @@ def apply_data_pocessing(data):
     data["quantile50"] = np.quantile(data["values"], 0.50)
     data["quantile75"] = np.quantile(data["values"], 0.75)
     data["max"] = np.max(data["values"])
+
+    # Assert validation
+
+    if data["mode"] == "absolute":
+        data["assert"] = True if data["sigma"] < abs(
+            data["accuracy_threshold"]) else False
+
+    elif data["mode"] == "relative":
+        data["assert"] = True if abs(
+            data["sigma"] /
+            data["mu"]) < abs(data["accuracy_threshold"]) else False
+
+    else:
+        data["assert"] = True
 
     return data
 
@@ -141,3 +154,21 @@ def data_processing(data):
     data["nsamples"] = data["values"].apply(len)
 
     return data
+
+
+def validate_deterministic_probe(x):
+    '''
+    This function will be applied to results dataframes of deterministic
+    backends to validate probes depending on if they are absolute or relative
+    '''
+
+    if x["mode"] == "absolute":
+        return True if abs(
+            x["value"] -
+            x["reference_value"]) < abs(x["accuracy_threshold"]) else False
+
+    if x["mode"] == "relative":
+        return True if abs(x["value"] - x["reference_value"]) / \
+            abs(x["reference_value"]) < abs(x["accuracy_threshold"]) else False
+
+    return True

--- a/src/tools/ci/vfc_ci_report/Makefile.am
+++ b/src/tools/ci/vfc_ci_report/Makefile.am
@@ -1,4 +1,4 @@
 SUBDIRS = templates static
 
 pkgpythondir = $(pythondir)/verificarlo/ci/vfc_ci_report
-pkgpython_PYTHON = asserts.py compare_runs.py deterministic_compare.py helper.py inspect_runs.py main.py plot.py
+pkgpython_PYTHON = checks.py compare_runs.py deterministic_compare.py helper.py inspect_runs.py main.py plot.py

--- a/src/tools/ci/vfc_ci_report/Makefile.am
+++ b/src/tools/ci/vfc_ci_report/Makefile.am
@@ -1,4 +1,4 @@
 SUBDIRS = templates static
 
 pkgpythondir = $(pythondir)/verificarlo/ci/vfc_ci_report
-pkgpython_PYTHON = compare_runs.py helper.py inspect_runs.py main.py plot.py
+pkgpython_PYTHON = asserts.py compare_runs.py deterministic_compare.py helper.py inspect_runs.py main.py plot.py

--- a/src/tools/ci/vfc_ci_report/asserts.py
+++ b/src/tools/ci/vfc_ci_report/asserts.py
@@ -56,15 +56,15 @@ class Asserts:
 
         # Only keep interesting columns
         self.run_data = self.run_data[[
-            "assert", "accuracy_threshold", "mode",
+            "assert", "accuracy_threshold", "assert_mode",
             "mu", "sigma",
         ]]
 
         # Only keep probes that have an assert
         self.run_data = self.run_data[self.run_data.accuracy_threshold != 0]
 
-        # Uppercase first letter of "mode" for display
-        self.run_data["mode"] = self.run_data["mode"].apply(
+        # Uppercase first letter of "assert_mode" for display
+        self.run_data["assert_mode"] = self.run_data["assert_mode"].apply(
             lambda x: x.capitalize())
 
         # Generate the data source object
@@ -83,7 +83,7 @@ class Asserts:
 
         # Only keep interesting columns
         self.deterministic_run_data = self.deterministic_run_data[[
-            "assert", "accuracy_threshold", "mode",
+            "assert", "accuracy_threshold", "assert_mode",
             "value", "reference_value",
         ]]
 
@@ -92,8 +92,8 @@ class Asserts:
             self.deterministic_run_data.accuracy_threshold != 0
         ]
 
-        # Uppercase first letter of "mode" for display
-        self.deterministic_run_data["mode"] = self.deterministic_run_data["mode"].apply(
+        # Uppercase first letter of "assert_mode" for display
+        self.deterministic_run_data["assert_mode"] = self.deterministic_run_data["assert_mode"].apply(
             lambda x: x.capitalize())
 
         # Generate the data source object
@@ -127,12 +127,12 @@ class Asserts:
 
         # Only keep interesting columns
         self.run_data = self.run_data[[
-            "assert", "accuracy_threshold", "mode",
+            "assert", "accuracy_threshold", "assert_mode",
             "mu", "sigma",
         ]]
 
         self.deterministic_run_data = self.deterministic_run_data[[
-            "assert", "accuracy_threshold", "mode",
+            "assert", "accuracy_threshold", "assert_mode",
             "value", "reference_value",
         ]]
 
@@ -143,10 +143,10 @@ class Asserts:
             self.deterministic_run_data.accuracy_threshold != 0
         ]
 
-        # Uppercase first letter of "mode" for display
-        self.run_data["mode"] = self.run_data["mode"].apply(
+        # Uppercase first letter of "assert_mode" for display
+        self.run_data["assert_mode"] = self.run_data["assert_mode"].apply(
             lambda x: x.capitalize())
-        self.deterministic_run_data["mode"] = self.deterministic_run_data["mode"].apply(
+        self.deterministic_run_data["assert_mode"] = self.deterministic_run_data["assert_mode"].apply(
             lambda x: x.capitalize())
 
         # Generate the data source objects
@@ -198,7 +198,7 @@ class Asserts:
             TableColumn(field="variable", title="Variable"),
             TableColumn(field="vfc_backend", title="Backend"),
             TableColumn(field="accuracy_threshold", title="Target precision"),
-            TableColumn(field="mode", title="Assert mode"),
+            TableColumn(field="assert_mode", title="Assert mode"),
             TableColumn(field="mu", title="Emp. avg. μ"),
             TableColumn(field="sigma", title="Std. dev. σ"),
             TableColumn(field="assert", title="Passed")
@@ -218,7 +218,7 @@ class Asserts:
             TableColumn(field="variable", title="Variable"),
             TableColumn(field="vfc_backend", title="Backend"),
             TableColumn(field="accuracy_threshold", title="Target precision"),
-            TableColumn(field="mode", title="Assert mode"),
+            TableColumn(field="assert_mode", title="Assert mode"),
             TableColumn(field="value", title="Backend value"),
             TableColumn(field="reference_value", title="IEEE value"),
             TableColumn(field="assert", title="Passed")
@@ -319,5 +319,19 @@ class Asserts:
         # show the data for the first time
         self.run_data.reset_index(inplace=True)
         self.deterministic_run_data.reset_index(inplace=True)
-        self.sources["non_deterministic"].data = self.run_data
-        self.sources["deterministic"].data = self.deterministic_run_data
+
+        if not self.run_data.empty:
+            self.sources["non_deterministic"].data = self.run_data
+        else:
+            self.sources["non_deterministic"].data = {
+                "assert": [], "accuracy_threshold": [], "assert_mode": [],
+                "mu": [], "sigma": []
+            }
+
+        if not self.deterministic_run_data.empty:
+            self.sources["deterministic"].data = self.deterministic_run_data
+        else:
+            self.sources["deterministic"].data = {
+                "assert": [], "accuracy_threshold": [], "assert_mode": [],
+                "value": [], "reference_value": []
+            }

--- a/src/tools/ci/vfc_ci_report/asserts.py
+++ b/src/tools/ci/vfc_ci_report/asserts.py
@@ -1,0 +1,323 @@
+#############################################################################
+#                                                                           #
+#  This file is part of Verificarlo.                                        #
+#                                                                           #
+#  Copyright (c) 2015-2021                                                  #
+#     Verificarlo contributors                                              #
+#     Universite de Versailles St-Quentin-en-Yvelines                       #
+#     CMLA, Ecole Normale Superieure de Cachan                              #
+#                                                                           #
+#  Verificarlo is free software: you can redistribute it and/or modify      #
+#  it under the terms of the GNU General Public License as published by     #
+#  the Free Software Foundation, either version 3 of the License, or        #
+#  (at your option) any later version.                                      #
+#                                                                           #
+#  Verificarlo is distributed in the hope that it will be useful,           #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#  GNU General Public License for more details.                             #
+#                                                                           #
+#  You should have received a copy of the GNU General Public License        #
+#  along with Verificarlo.  If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                           #
+#############################################################################
+
+# Manage the view comparing the asserts by run.
+# At its creation, a Asserts object will create all the needed Bokeh widgets,
+# setup the callback functions (either server side or client side),
+# initialize widgets selection, and from this selection generate the first plots.
+# Then, when callback functions are triggered, widgets selections are updated,
+# and re-generated with the newly selected data.
+# This manages both deterministic and non-deterministic views in the report !
+
+import pandas as pd
+
+from bokeh.embed import components
+from bokeh.models import Select, ColumnDataSource, DataTable, TableColumn, \
+    CustomJS
+
+import helper
+
+##########################################################################
+
+
+class Asserts:
+
+    # Widgets' callback functions
+
+    def update_non_deterministic_run(self, attrname, old, new):
+
+        # Update run selection (by using dict mapping)
+        self.current_non_deterministic_run = self.runs_dict[new]
+
+        # Update run data
+        self.run_data = self.data[self.data["timestamp"]
+                                  == self.current_non_deterministic_run]
+
+        # Only keep interesting columns
+        self.run_data = self.run_data[[
+            "assert", "accuracy_threshold", "mode",
+            "mu", "sigma",
+        ]]
+
+        # Only keep probes that have an assert
+        self.run_data = self.run_data[self.run_data.accuracy_threshold != 0]
+
+        # Uppercase first letter of "mode" for display
+        self.run_data["mode"] = self.run_data["mode"].apply(
+            lambda x: x.capitalize())
+
+        # Generate the data source object
+        self.run_data.reset_index(inplace=True)
+        self.sources["non_deterministic"].data = self.run_data
+
+    def update_deterministic_run(self, attrname, old, new):
+
+        # Update run selection (by using dict mapping)
+        self.current_deterministic_run = self.runs_dict[new]
+
+        # Update run data
+        self.deterministic_run_data = self.deterministic_data[
+            self.deterministic_data["timestamp"] == self.current_run
+        ]
+
+        # Only keep interesting columns
+        self.deterministic_run_data = self.deterministic_run_data[[
+            "assert", "accuracy_threshold", "mode",
+            "value", "reference_value",
+        ]]
+
+        # Only keep probes that have an assert*
+        self.deterministic_run_data = self.deterministic_run_data[
+            self.deterministic_run_data.accuracy_threshold != 0
+        ]
+
+        # Uppercase first letter of "mode" for display
+        self.deterministic_run_data["mode"] = self.deterministic_run_data["mode"].apply(
+            lambda x: x.capitalize())
+
+        # Generate the data source object
+        self.deterministic_run_data.reset_index(inplace=True)
+        self.sources["deterministic"].data = self.deterministic_run_data
+
+        # Bokeh setup functions
+
+    def setup_widgets(self):
+
+        # Run selection
+
+        # Dict contains all inspectable runs (maps display strings to timestamps)
+        # The dict structure allows to get the timestamp from the display string
+        # in O(1)
+        self.runs_dict = helper.gen_runs_selection(self.metadata)
+
+        # Contains all options strings
+        runs_display = list(self.runs_dict.keys())
+        # Will be used when updating plots (contains actual number)
+        self.current_run = self.runs_dict[runs_display[-1]]
+        self.current_deterministic_run = self.runs_dict[runs_display[-1]]
+
+        # Contains the selected option string, used to update current_n_runs
+        current_run_display = runs_display[-1]
+
+        # This contains only entries matching the run
+        self.run_data = self.data[self.data["timestamp"] == self.current_run]
+        self.deterministic_run_data = self.deterministic_data[
+            self.deterministic_data["timestamp"] == self.current_deterministic_run]
+
+        # Only keep interesting columns
+        self.run_data = self.run_data[[
+            "assert", "accuracy_threshold", "mode",
+            "mu", "sigma",
+        ]]
+
+        self.deterministic_run_data = self.deterministic_run_data[[
+            "assert", "accuracy_threshold", "mode",
+            "value", "reference_value",
+        ]]
+
+        # Only keep probes that have an assert
+        self.run_data = self.run_data[self.run_data.accuracy_threshold != 0]
+
+        self.deterministic_run_data = self.deterministic_run_data[
+            self.deterministic_run_data.accuracy_threshold != 0
+        ]
+
+        # Uppercase first letter of "mode" for display
+        self.run_data["mode"] = self.run_data["mode"].apply(
+            lambda x: x.capitalize())
+        self.deterministic_run_data["mode"] = self.deterministic_run_data["mode"].apply(
+            lambda x: x.capitalize())
+
+        # Generate the data source objects
+        self.run_data.reset_index(inplace=True)
+        self.deterministic_run_data.reset_index(inplace=True)
+        self.sources["non_deterministic"].data = self.run_data
+        self.sources["deterministic"].data = self.deterministic_run_data
+
+        # Non-deterministic run selector
+        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"non-deterministic-asserts-\");"
+
+        self.widgets["select_assert_run_non_deterministic"] = Select(
+            name="select_assert_run_non_deterministic", title="Run :",
+            value=current_run_display, options=runs_display
+        )
+        self.doc.add_root(self.widgets["select_assert_run_non_deterministic"])
+        self.widgets["select_assert_run_non_deterministic"].on_change(
+            "value", self.update_non_deterministic_run)
+        self.widgets["select_assert_run_non_deterministic"].js_on_change(
+            "value", CustomJS(
+                code=change_run_callback_js, args=(
+                    dict(
+                        metadata=helper.metadata_to_dict(
+                            helper.get_metadata(
+                                self.metadata, self.current_run))))))
+
+        # Deterministic run selector
+        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"deterministic-asserts-\");"
+
+        self.widgets["select_assert_run_deterministic"] = Select(
+            name="select_assert_run_deterministic", title="Run :",
+            value=current_run_display, options=runs_display
+        )
+        self.doc.add_root(self.widgets["select_assert_run_deterministic"])
+        self.widgets["select_assert_run_deterministic"].on_change(
+            "value", self.update_deterministic_run)
+        self.widgets["select_assert_run_deterministic"].js_on_change(
+            "value", CustomJS(
+                code=change_run_callback_js, args=(
+                    dict(
+                        metadata=helper.metadata_to_dict(
+                            helper.get_metadata(
+                                self.metadata, self.current_deterministic_run))))))
+
+        # Non-deterministic asserts table:
+
+        non_deterministic_olumns = [
+            TableColumn(field="test", title="Test"),
+            TableColumn(field="variable", title="Variable"),
+            TableColumn(field="vfc_backend", title="Backend"),
+            TableColumn(field="accuracy_threshold", title="Target precision"),
+            TableColumn(field="mode", title="Assert mode"),
+            TableColumn(field="mu", title="Emp. avg. μ"),
+            TableColumn(field="sigma", title="Std. dev. σ"),
+            TableColumn(field="assert", title="Passed")
+        ]
+
+        self.widgets["non_deterministic_asserts_table"] = DataTable(
+            name="non_deterministic_asserts_table",
+            source=self.sources["non_deterministic"],
+            columns=non_deterministic_olumns,
+            width=895, sizing_mode="scale_width")
+        self.doc.add_root(self.widgets["non_deterministic_asserts_table"])
+
+        # Deterministic asserts table:
+
+        deterministic_columns = [
+            TableColumn(field="test", title="Test"),
+            TableColumn(field="variable", title="Variable"),
+            TableColumn(field="vfc_backend", title="Backend"),
+            TableColumn(field="accuracy_threshold", title="Target precision"),
+            TableColumn(field="mode", title="Assert mode"),
+            TableColumn(field="value", title="Backend value"),
+            TableColumn(field="reference_value", title="IEEE value"),
+            TableColumn(field="assert", title="Passed")
+        ]
+
+        self.widgets["deterministic_asserts_table"] = DataTable(
+            name="deterministic_asserts_table",
+            source=self.sources["deterministic"],
+            columns=deterministic_columns,
+            width=895, sizing_mode="scale_width")
+        self.doc.add_root(self.widgets["deterministic_asserts_table"])
+
+        # Communication methods
+        # (to send/receive messages to/from master)
+
+    def change_repo(self, new_data, new_deterministic_data, new_metadata):
+        '''
+        When received, update data and metadata with the new repo, and update
+        everything
+        '''
+
+        self.data = new_data
+        self.deterministic_data = new_deterministic_data
+        self.metadata = new_metadata
+
+        self.runs_dict = helper.gen_runs_selection(self.metadata)
+
+        # Contains all options strings
+        runs_display = list(self.runs_dict.keys())
+        # Will be used when updating plots (contains actual number)
+        self.current_run = self.runs_dict[runs_display[-1]]
+        self.current_deterministic_run = self.runs_dict[runs_display[-1]]
+
+        # Update run selection (this will automatically trigger the callback)
+
+        self.widgets["select_assert_run_non_deterministic"].options = runs_display
+        self.widgets["select_assert_run_deterministic"].options = runs_display
+
+        # If the run name happens to be the same, the callback has to be
+        # triggered manually
+        if runs_display[-1] == self.widgets["select_assert_run_non_deterministic"].value:
+            update_non_deterministic_run(
+                "value", runs_display[-1], runs_display[-1])
+        # In any other case, updating the value is enough to trigger the
+        # callback
+        else:
+            self.widgets["select_assert_run_non_deterministic"].value = runs_display[-1]
+
+        if runs_display[-1] == self.widgets["select_assert_run_deterministic"].value:
+            update_deterministic_run(
+                "value", runs_display[-1], runs_display[-1])
+        else:
+            self.widgets["select_assert_run_deterministic"].value = runs_display[-1]
+
+    def switch_view(self, run_name):
+        '''When received, switch selected run to run_name'''
+
+        # This will trigger the widget's callback
+        self.widgets["select_assert_run"].value = run_name
+
+        # Constructor
+
+    def __init__(self, master, doc, data, deterministic_data, metadata):
+        '''
+        Here are the most important attributes of the CompareRuns class
+
+        master : reference to the ViewMaster class
+        doc : an object provided by Bokeh to add elements to the HTML document
+        data : pandas dataframe containing tests data (non-deterministic
+        backends only)
+        deterministic_data : pandas dataframe containing tests data (deterministic
+        backends only)
+        metadata : pandas dataframe containing all the tests metadata
+
+        sources : ColumnDataSource object provided by Bokeh, contains current
+        data (inside the .data attribute)
+        widgets : dictionary of Bokeh widgets (no plots for this view)
+        '''
+
+        self.master = master
+
+        self.doc = doc
+        self.data = data
+        self.deterministic_data = deterministic_data
+        self.metadata = metadata
+
+        self.sources = {
+            "deterministic": ColumnDataSource({}),
+            "non_deterministic": ColumnDataSource({})
+        }
+
+        self.widgets = {}
+
+        # Setup Bokeh objects
+        self.setup_widgets()
+
+        # At this point, everything should have been initialized, so we can
+        # show the data for the first time
+        self.run_data.reset_index(inplace=True)
+        self.deterministic_run_data.reset_index(inplace=True)
+        self.sources["non_deterministic"].data = self.run_data
+        self.sources["deterministic"].data = self.deterministic_run_data

--- a/src/tools/ci/vfc_ci_report/checks.py
+++ b/src/tools/ci/vfc_ci_report/checks.py
@@ -22,8 +22,8 @@
 #                                                                           #
 #############################################################################
 
-# Manage the view comparing the asserts by run.
-# At its creation, a Asserts object will create all the needed Bokeh widgets,
+# Manage the view comparing the checks by run.
+# At its creation, a Checks object will create all the needed Bokeh widgets,
 # setup the callback functions (either server side or client side),
 # initialize widgets selection, and from this selection generate the first plots.
 # Then, when callback functions are triggered, widgets selections are updated,
@@ -41,7 +41,7 @@ import helper
 ##########################################################################
 
 
-class Asserts:
+class Checks:
 
     # Widgets' callback functions
 
@@ -56,15 +56,15 @@ class Asserts:
 
         # Only keep interesting columns
         self.run_data = self.run_data[[
-            "assert", "accuracy_threshold", "assert_mode",
+            "check", "accuracy_threshold", "check_mode",
             "mu", "sigma",
         ]]
 
-        # Only keep probes that have an assert
+        # Only keep probes that have an check
         self.run_data = self.run_data[self.run_data.accuracy_threshold != 0]
 
-        # Uppercase first letter of "assert_mode" for display
-        self.run_data["assert_mode"] = self.run_data["assert_mode"].apply(
+        # Uppercase first letter of "check_mode" for display
+        self.run_data["check_mode"] = self.run_data["check_mode"].apply(
             lambda x: x.capitalize())
 
         # Generate the data source object
@@ -83,17 +83,17 @@ class Asserts:
 
         # Only keep interesting columns
         self.deterministic_run_data = self.deterministic_run_data[[
-            "assert", "accuracy_threshold", "assert_mode",
+            "check", "accuracy_threshold", "check_mode",
             "value", "reference_value",
         ]]
 
-        # Only keep probes that have an assert*
+        # Only keep probes that have an check
         self.deterministic_run_data = self.deterministic_run_data[
             self.deterministic_run_data.accuracy_threshold != 0
         ]
 
-        # Uppercase first letter of "assert_mode" for display
-        self.deterministic_run_data["assert_mode"] = self.deterministic_run_data["assert_mode"].apply(
+        # Uppercase first letter of "check_mode" for display
+        self.deterministic_run_data["check_mode"] = self.deterministic_run_data["check_mode"].apply(
             lambda x: x.capitalize())
 
         # Generate the data source object
@@ -127,26 +127,26 @@ class Asserts:
 
         # Only keep interesting columns
         self.run_data = self.run_data[[
-            "assert", "accuracy_threshold", "assert_mode",
+            "check", "accuracy_threshold", "check_mode",
             "mu", "sigma",
         ]]
 
         self.deterministic_run_data = self.deterministic_run_data[[
-            "assert", "accuracy_threshold", "assert_mode",
+            "check", "accuracy_threshold", "check_mode",
             "value", "reference_value",
         ]]
 
-        # Only keep probes that have an assert
+        # Only keep probes that have an check
         self.run_data = self.run_data[self.run_data.accuracy_threshold != 0]
 
         self.deterministic_run_data = self.deterministic_run_data[
             self.deterministic_run_data.accuracy_threshold != 0
         ]
 
-        # Uppercase first letter of "assert_mode" for display
-        self.run_data["assert_mode"] = self.run_data["assert_mode"].apply(
+        # Uppercase first letter of "check_mode" for display
+        self.run_data["check_mode"] = self.run_data["check_mode"].apply(
             lambda x: x.capitalize())
-        self.deterministic_run_data["assert_mode"] = self.deterministic_run_data["assert_mode"].apply(
+        self.deterministic_run_data["check_mode"] = self.deterministic_run_data["check_mode"].apply(
             lambda x: x.capitalize())
 
         # Generate the data source objects
@@ -156,16 +156,16 @@ class Asserts:
         self.sources["deterministic"].data = self.deterministic_run_data
 
         # Non-deterministic run selector
-        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"non-deterministic-asserts-\");"
+        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"non-deterministic-checks-\");"
 
-        self.widgets["select_assert_run_non_deterministic"] = Select(
-            name="select_assert_run_non_deterministic", title="Run :",
+        self.widgets["select_check_run_non_deterministic"] = Select(
+            name="select_check_run_non_deterministic", title="Run :",
             value=current_run_display, options=runs_display
         )
-        self.doc.add_root(self.widgets["select_assert_run_non_deterministic"])
-        self.widgets["select_assert_run_non_deterministic"].on_change(
+        self.doc.add_root(self.widgets["select_check_run_non_deterministic"])
+        self.widgets["select_check_run_non_deterministic"].on_change(
             "value", self.update_non_deterministic_run)
-        self.widgets["select_assert_run_non_deterministic"].js_on_change(
+        self.widgets["select_check_run_non_deterministic"].js_on_change(
             "value", CustomJS(
                 code=change_run_callback_js, args=(
                     dict(
@@ -174,16 +174,16 @@ class Asserts:
                                 self.metadata, self.current_run))))))
 
         # Deterministic run selector
-        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"deterministic-asserts-\");"
+        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"deterministic-checks-\");"
 
-        self.widgets["select_assert_run_deterministic"] = Select(
-            name="select_assert_run_deterministic", title="Run :",
+        self.widgets["select_check_run_deterministic"] = Select(
+            name="select_check_run_deterministic", title="Run :",
             value=current_run_display, options=runs_display
         )
-        self.doc.add_root(self.widgets["select_assert_run_deterministic"])
-        self.widgets["select_assert_run_deterministic"].on_change(
+        self.doc.add_root(self.widgets["select_check_run_deterministic"])
+        self.widgets["select_check_run_deterministic"].on_change(
             "value", self.update_deterministic_run)
-        self.widgets["select_assert_run_deterministic"].js_on_change(
+        self.widgets["select_check_run_deterministic"].js_on_change(
             "value", CustomJS(
                 code=change_run_callback_js, args=(
                     dict(
@@ -191,45 +191,45 @@ class Asserts:
                             helper.get_metadata(
                                 self.metadata, self.current_deterministic_run))))))
 
-        # Non-deterministic asserts table:
+        # Non-deterministic checks table:
 
         non_deterministic_olumns = [
             TableColumn(field="test", title="Test"),
             TableColumn(field="variable", title="Variable"),
             TableColumn(field="vfc_backend", title="Backend"),
             TableColumn(field="accuracy_threshold", title="Target precision"),
-            TableColumn(field="assert_mode", title="Assert mode"),
+            TableColumn(field="check_mode", title="Check mode"),
             TableColumn(field="mu", title="Emp. avg. μ"),
             TableColumn(field="sigma", title="Std. dev. σ"),
-            TableColumn(field="assert", title="Passed")
+            TableColumn(field="check", title="Passed")
         ]
 
-        self.widgets["non_deterministic_asserts_table"] = DataTable(
-            name="non_deterministic_asserts_table",
+        self.widgets["non_deterministic_checks_table"] = DataTable(
+            name="non_deterministic_checks_table",
             source=self.sources["non_deterministic"],
             columns=non_deterministic_olumns,
             width=895, sizing_mode="scale_width")
-        self.doc.add_root(self.widgets["non_deterministic_asserts_table"])
+        self.doc.add_root(self.widgets["non_deterministic_checks_table"])
 
-        # Deterministic asserts table:
+        # Deterministic checks table:
 
         deterministic_columns = [
             TableColumn(field="test", title="Test"),
             TableColumn(field="variable", title="Variable"),
             TableColumn(field="vfc_backend", title="Backend"),
             TableColumn(field="accuracy_threshold", title="Target precision"),
-            TableColumn(field="assert_mode", title="Assert mode"),
+            TableColumn(field="check_mode", title="Check mode"),
             TableColumn(field="value", title="Backend value"),
             TableColumn(field="reference_value", title="IEEE value"),
-            TableColumn(field="assert", title="Passed")
+            TableColumn(field="check", title="Passed")
         ]
 
-        self.widgets["deterministic_asserts_table"] = DataTable(
-            name="deterministic_asserts_table",
+        self.widgets["deterministic_checks_table"] = DataTable(
+            name="deterministic_checks_table",
             source=self.sources["deterministic"],
             columns=deterministic_columns,
             width=895, sizing_mode="scale_width")
-        self.doc.add_root(self.widgets["deterministic_asserts_table"])
+        self.doc.add_root(self.widgets["deterministic_checks_table"])
 
         # Communication methods
         # (to send/receive messages to/from master)
@@ -254,30 +254,30 @@ class Asserts:
 
         # Update run selection (this will automatically trigger the callback)
 
-        self.widgets["select_assert_run_non_deterministic"].options = runs_display
-        self.widgets["select_assert_run_deterministic"].options = runs_display
+        self.widgets["select_check_run_non_deterministic"].options = runs_display
+        self.widgets["select_check_run_deterministic"].options = runs_display
 
         # If the run name happens to be the same, the callback has to be
         # triggered manually
-        if runs_display[-1] == self.widgets["select_assert_run_non_deterministic"].value:
+        if runs_display[-1] == self.widgets["select_check_run_non_deterministic"].value:
             update_non_deterministic_run(
                 "value", runs_display[-1], runs_display[-1])
         # In any other case, updating the value is enough to trigger the
         # callback
         else:
-            self.widgets["select_assert_run_non_deterministic"].value = runs_display[-1]
+            self.widgets["select_check_run_non_deterministic"].value = runs_display[-1]
 
-        if runs_display[-1] == self.widgets["select_assert_run_deterministic"].value:
+        if runs_display[-1] == self.widgets["select_check_run_deterministic"].value:
             update_deterministic_run(
                 "value", runs_display[-1], runs_display[-1])
         else:
-            self.widgets["select_assert_run_deterministic"].value = runs_display[-1]
+            self.widgets["select_check_run_deterministic"].value = runs_display[-1]
 
     def switch_view(self, run_name):
         '''When received, switch selected run to run_name'''
 
         # This will trigger the widget's callback
-        self.widgets["select_assert_run"].value = run_name
+        self.widgets["select_check_run"].value = run_name
 
         # Constructor
 
@@ -324,7 +324,7 @@ class Asserts:
             self.sources["non_deterministic"].data = self.run_data
         else:
             self.sources["non_deterministic"].data = {
-                "assert": [], "accuracy_threshold": [], "assert_mode": [],
+                "check": [], "accuracy_threshold": [], "check_mode": [],
                 "mu": [], "sigma": []
             }
 
@@ -332,6 +332,6 @@ class Asserts:
             self.sources["deterministic"].data = self.deterministic_run_data
         else:
             self.sources["deterministic"].data = {
-                "assert": [], "accuracy_threshold": [], "assert_mode": [],
+                "check": [], "accuracy_threshold": [], "check_mode": [],
                 "value": [], "reference_value": []
             }

--- a/src/tools/ci/vfc_ci_report/compare_runs.py
+++ b/src/tools/ci/vfc_ci_report/compare_runs.py
@@ -132,10 +132,10 @@ class CompareRuns:
         n = self.current_n_runs
         main_dict = {key: value[-n:] for key, value in main_dict.items()}
 
-        # Generate color series for display of failed asserts
-        custom_colors = [True] * len(main_dict["assert"])
-        for i in range(len(main_dict["assert"])):
-            custom_colors[i] = "#1f77b4" if main_dict["assert"][i] else "#cc2b2b"
+        # Generate color series for display of failed checks
+        custom_colors = [True] * len(main_dict["check"])
+        for i in range(len(main_dict["check"])):
+            custom_colors[i] = "#1f77b4" if main_dict["check"][i] else "#cc2b2b"
 
         # Generate ColumnDataSources for the 3 dotplots
         for stat in ["sigma", "s10", "s2"]:
@@ -362,7 +362,7 @@ class CompareRuns:
             ("Message", "@message"),
             ("σ", "@sigma"),
             ("Number of samples", "@nsamples"),
-            ("Assert target accuracy", "@accuracy_threshold")
+            ("Check's accuracy target", "@accuracy_threshold")
         ]
 
         plot.fill_dotplot(
@@ -391,7 +391,7 @@ class CompareRuns:
             ("s", "@s10"),
             ("s lower bound", "@s10_lower_bound"),
             ("Number of samples", "@nsamples"),
-            ("Assert target accuracy ", "@accuracy_threshold")
+            ("Check's accuracy target", "@accuracy_threshold")
         ]
 
         plot.fill_dotplot(

--- a/src/tools/ci/vfc_ci_report/compare_runs.py
+++ b/src/tools/ci/vfc_ci_report/compare_runs.py
@@ -322,7 +322,7 @@ class CompareRuns:
             js_tap_callback=js_tap_callback,
             server_tap_callback=self.inspect_run_callback_sigma,
             lines=True,
-            custom_colors=True
+            custom_colors="custom_colors"
         )
         self.doc.add_root(self.plots["sigma_plot"])
 
@@ -352,7 +352,7 @@ class CompareRuns:
             server_tap_callback=self.inspect_run_callback_s10,
             lines=True,
             lower_bound=True,
-            custom_colors=True
+            custom_colors="custom_colors"
         )
         s10_tab = Panel(child=self.plots["s10_plot"], title="Base 10")
 
@@ -380,7 +380,7 @@ class CompareRuns:
             server_tap_callback=self.inspect_run_callback_s2,
             lines=True,
             lower_bound=True,
-            custom_colors=True
+            custom_colors="custom_colors"
         )
         s2_tab = Panel(child=self.plots["s2_plot"], title="Base 2")
 

--- a/src/tools/ci/vfc_ci_report/compare_runs.py
+++ b/src/tools/ci/vfc_ci_report/compare_runs.py
@@ -54,6 +54,55 @@ class CompareRuns:
     def update_plots(self):
 
         if self.data.empty:
+            # Initialize empty dicts and return
+
+            for stat in ["sigma", "s10", "s2"]:
+                dict = {
+                    "%s_x" % stat: [],
+
+                    "is_git_commit": [],
+                    "date": [],
+                    "hash": [],
+                    "author": [],
+                    "message": [],
+
+                    stat: [],
+
+                    "nsamples": [],
+                    "accuracy_threshold": [],
+
+                    "custom_colors": []
+                }
+
+                if stat == "s10" or stat == "s2":
+                    dict["%s_lower_bound" % stat] = []
+
+                self.sources["%s_source" % stat].data = dict
+
+            # Boxplot dict
+            dict = {
+                "is_git_commit": [],
+                "date": [],
+                "hash": [],
+                "author": [],
+                "message": [],
+
+                "x": [],
+                "min": [],
+                "quantile25": [],
+                "quantile50": [],
+                "quantile75": [],
+                "max": [],
+                "mu": [],
+                "pvalue": [],
+
+                "nsamples": [],
+
+                "custom_colors": []
+            }
+
+            self.sources["boxplot_source"].data = dict
+
             return
 
         # Select all data matching current test/var/backend

--- a/src/tools/ci/vfc_ci_report/compare_runs.py
+++ b/src/tools/ci/vfc_ci_report/compare_runs.py
@@ -294,7 +294,7 @@ class CompareRuns:
             tooltips_formatters=box_tooltips_formatters,
             js_tap_callback=js_tap_callback,
             server_tap_callback=self.inspect_run_callback_boxplot,
-            custom_colors=True
+            custom_colors="custom_colors"
         )
         self.doc.add_root(self.plots["boxplot"])
 

--- a/src/tools/ci/vfc_ci_report/compare_runs.py
+++ b/src/tools/ci/vfc_ci_report/compare_runs.py
@@ -49,55 +49,12 @@ import plot
 
 class CompareRuns:
 
-    # Helper functions related to CompareRuns
-
-    def gen_x_series(self, timestamps):
-        '''
-        From an array of timestamps, returns the array of runs names (for the x
-        axis ticks), as well as the metadata (in a dict of arrays) associated
-        to this array (will be used in tooltips)
-        '''
-
-        # Initialize the objects to return
-        x_series = []
-        x_metadata = dict(
-            date=[],
-            is_git_commit=[],
-            hash=[],
-            author=[],
-            message=[]
-        )
-
-        # n == 0 means we want all runs, we also make sure not to go out of
-        # bound if asked for more runs than we have
-        n = self.current_n_runs
-        if n == 0 or n > len(timestamps):
-            n = len(timestamps)
-
-        for i in range(0, n):
-            # Get metadata associated to this run
-            row_metadata = helper.get_metadata(
-                self.metadata, timestamps[-i - 1])
-            date = time.ctime(timestamps[-i - 1])
-
-            # Fill the x series
-            str = row_metadata["name"]
-            x_series.insert(0, helper.get_metadata(
-                self.metadata, timestamps[-i - 1])["name"])
-
-            # Fill the metadata lists
-            x_metadata["date"].insert(0, date)
-            x_metadata["is_git_commit"].insert(
-                0, row_metadata["is_git_commit"])
-            x_metadata["hash"].insert(0, row_metadata["hash"])
-            x_metadata["author"].insert(0, row_metadata["author"])
-            x_metadata["message"].insert(0, row_metadata["message"])
-
-        return x_series, x_metadata
-
-        # Plots update function
+    # Plots update function
 
     def update_plots(self):
+
+        if self.data.empty:
+            return
 
         # Select all data matching current test/var/backend
 
@@ -105,8 +62,14 @@ class CompareRuns:
                              self.widgets["select_var"].value,
                              self.widgets["select_backend"].value]
 
+        runs = runs.sort_values(by=["timestamp"])
+
         timestamps = runs["timestamp"]
-        x_series, x_metadata = self.gen_x_series(timestamps.sort_values())
+        x_series, x_metadata = helper.gen_x_series(
+            self.metadata,
+            timestamps.sort_values(),
+            self.current_n_runs
+        )
 
         # Update source
 
@@ -119,6 +82,11 @@ class CompareRuns:
         # Select the last n runs only
         n = self.current_n_runs
         main_dict = {key: value[-n:] for key, value in main_dict.items()}
+
+        # Generate color series for display of failed asserts
+        custom_colors = [True] * len(main_dict["assert"])
+        for i in range(len(main_dict["assert"])):
+            custom_colors[i] = "#1f77b4" if main_dict["assert"][i] else "#cc2b2b"
 
         # Generate ColumnDataSources for the 3 dotplots
         for stat in ["sigma", "s10", "s2"]:
@@ -134,6 +102,9 @@ class CompareRuns:
                 stat: main_dict[stat],
 
                 "nsamples": main_dict["nsamples"],
+                "accuracy_threshold": main_dict["accuracy_threshold"],
+
+                "custom_colors": custom_colors
             }
 
             if stat == "s10" or stat == "s2":
@@ -168,7 +139,9 @@ class CompareRuns:
             "mu": main_dict["mu"],
             "pvalue": main_dict["pvalue"],
 
-            "nsamples": main_dict["nsamples"]
+            "nsamples": main_dict["nsamples"],
+
+            "custom_colors": custom_colors
         }
 
         self.sources["boxplot_source"].data = dict
@@ -282,8 +255,7 @@ class CompareRuns:
 
         # Custom JS callback that will be used when tapping on a run
         # Only switches the view, a server callback is required to update plots
-        # (defined inside template to avoid bloating server w/ too much JS code)
-        js_tap_callback = "goToInspectRuns();"
+        js_tap_callback = "changeView(\"inspect-runs\");"
 
         # Box plot
         self.plots["boxplot"] = figure(
@@ -322,6 +294,7 @@ class CompareRuns:
             tooltips_formatters=box_tooltips_formatters,
             js_tap_callback=js_tap_callback,
             server_tap_callback=self.inspect_run_callback_boxplot,
+            custom_colors=True
         )
         self.doc.add_root(self.plots["boxplot"])
 
@@ -339,7 +312,8 @@ class CompareRuns:
             ("Author", "@author"),
             ("Message", "@message"),
             ("σ", "@sigma"),
-            ("Number of samples", "@nsamples")
+            ("Number of samples", "@nsamples"),
+            ("Assert target accuracy", "@accuracy_threshold")
         ]
 
         plot.fill_dotplot(
@@ -347,7 +321,8 @@ class CompareRuns:
             tooltips=sigma_tooltips,
             js_tap_callback=js_tap_callback,
             server_tap_callback=self.inspect_run_callback_sigma,
-            lines=True
+            lines=True,
+            custom_colors=True
         )
         self.doc.add_root(self.plots["sigma_plot"])
 
@@ -366,7 +341,8 @@ class CompareRuns:
             ("Message", "@message"),
             ("s", "@s10"),
             ("s lower bound", "@s10_lower_bound"),
-            ("Number of samples", "@nsamples")
+            ("Number of samples", "@nsamples"),
+            ("Assert target accuracy ", "@accuracy_threshold")
         ]
 
         plot.fill_dotplot(
@@ -375,7 +351,8 @@ class CompareRuns:
             js_tap_callback=js_tap_callback,
             server_tap_callback=self.inspect_run_callback_s10,
             lines=True,
-            lower_bound=True
+            lower_bound=True,
+            custom_colors=True
         )
         s10_tab = Panel(child=self.plots["s10_plot"], title="Base 10")
 
@@ -402,7 +379,8 @@ class CompareRuns:
             js_tap_callback=js_tap_callback,
             server_tap_callback=self.inspect_run_callback_s2,
             lines=True,
-            lower_bound=True
+            lower_bound=True,
+            custom_colors=True
         )
         s2_tab = Panel(child=self.plots["s2_plot"], title="Base 2")
 
@@ -419,14 +397,20 @@ class CompareRuns:
         # Initial selections
 
         # Test/var/backend combination (we select all first elements at init)
-        self.tests = self.data\
-            .index.get_level_values("test").drop_duplicates().tolist()
+        if not self.data.empty:
+            self.tests = self.data\
+                .index.get_level_values("test").drop_duplicates().tolist()
 
-        self.vars = self.data.loc[self.tests[0]]\
-            .index.get_level_values("variable").drop_duplicates().tolist()
+            self.vars = self.data.loc[self.tests[0]]\
+                .index.get_level_values("variable").drop_duplicates().tolist()
 
-        self.backends = self.data.loc[self.tests[0], self.vars[0]]\
-            .index.get_level_values("vfc_backend").drop_duplicates().tolist()
+            self.backends = self.data.loc[self.tests[0], self.vars[0]]\
+                .index.get_level_values("vfc_backend").drop_duplicates().tolist()
+
+        else:
+            self.tests = ["None"]
+            self.vars = ["None"]
+            self.backends = ["None"]
 
         # Custom JS callback that will be used client side to filter selections
         filter_callback_js = """
@@ -514,9 +498,10 @@ class CompareRuns:
         # Communication methods
         # (to send/receive messages to/from master)
 
-    # Callback to change view to "Inspect runs" when plot element is clicked
-
     def inspect_run_callback(self, new, source_name, x_name):
+        '''
+        Callback to change view to "Inspect runs" when plot element is clicked
+        '''
 
         # In case we just unselected everything on the plot, then do nothing
         if not new:

--- a/src/tools/ci/vfc_ci_report/deterministic_compare.py
+++ b/src/tools/ci/vfc_ci_report/deterministic_compare.py
@@ -238,7 +238,9 @@ class DeterministicCompare:
             server_tap_callback=self.asserts_callback,
             lines=True,
             second_series="ieee",   # Will be used to display the IEEE results
-            custom_colors=True
+            legend="Backend value",
+            second_legend="IEEE reference value",
+            custom_colors="custom_colors"
         )
 
         self.doc.add_root(self.plots["comparison_plot"])

--- a/src/tools/ci/vfc_ci_report/deterministic_compare.py
+++ b/src/tools/ci/vfc_ci_report/deterministic_compare.py
@@ -89,10 +89,10 @@ class DeterministicCompare:
         n = self.current_n_runs
         dict = {key: value[-n:] for key, value in dict.items()}
 
-        # Generate color series for display of failed asserts
-        dict["custom_colors"] = [True] * len(dict["assert"])
-        for i in range(len(dict["assert"])):
-            dict["custom_colors"][i] = "#1f77b4" if dict["assert"][i] else "#cc2b2b"
+        # Generate color series for display of failed checks
+        dict["custom_colors"] = [True] * len(dict["check"])
+        for i in range(len(dict["check"])):
+            dict["custom_colors"][i] = "#1f77b4" if dict["check"][i] else "#cc2b2b"
 
         # Filter outliers if the box is checked
         if len(self.widgets["outliers_filtering_deterministic"].active) > 0:
@@ -107,7 +107,7 @@ class DeterministicCompare:
         dict["ieee"] = [0] * len(dict["value"])
 
         for i in range(len(dict["value"])):
-            if dict["assert"][i]:
+            if dict["check"][i]:
                 dict["ieee"][i] = nan
             else:
                 dict["ieee"][i] = dict["reference_value"][i]
@@ -236,7 +236,7 @@ class DeterministicCompare:
             "@reference_value": "printf"
         }
 
-        js_tap_callback = "changeView(\"asserts\");"
+        js_tap_callback = "changeView(\"checks\");"
 
         plot.fill_dotplot(
             self.plots["comparison_plot"], self.source,
@@ -244,7 +244,7 @@ class DeterministicCompare:
             tooltips=comparison_tooltips,
             tooltips_formatters=comparison_tooltips_formatters,
             js_tap_callback=js_tap_callback,
-            server_tap_callback=self.asserts_callback,
+            server_tap_callback=self.checks_callback,
             lines=True,
             second_series="ieee",   # Will be used to display the IEEE results
             legend="Backend value",
@@ -367,9 +367,9 @@ class DeterministicCompare:
         # Communication methods
         # (to send/receive messages to/from master)
 
-    def asserts_callback(self, attrname, old, new):
+    def checks_callback(self, attrname, old, new):
         '''
-        Callback to change view to "Asserts" view when plot element is clicked
+        Callback to change view to "Checks" view when plot element is clicked
         '''
 
         # In case we just unselected everything on the plot, then do nothing
@@ -380,7 +380,7 @@ class DeterministicCompare:
         index = new[-1]
         run_name = self.source.data["value_x"][index]
 
-        self.master.go_to_asserts(run_name)
+        self.master.go_to_checks(run_name)
 
     def change_repo(self, new_data, new_metadata):
         '''

--- a/src/tools/ci/vfc_ci_report/deterministic_compare.py
+++ b/src/tools/ci/vfc_ci_report/deterministic_compare.py
@@ -51,6 +51,15 @@ class DeterministicCompare:
     def update_plots(self):
 
         if self.data.empty:
+            # Initialize empty dict and return
+            dict = {
+                "value_x": [],
+                "value": [],
+                "ieee": [],
+                "custom_colors": []
+            }
+            self.source.data = dict
+
             return
 
         # Select all data matching current test/var/backend

--- a/src/tools/ci/vfc_ci_report/deterministic_compare.py
+++ b/src/tools/ci/vfc_ci_report/deterministic_compare.py
@@ -1,0 +1,437 @@
+#############################################################################
+#                                                                           #
+#  This file is part of Verificarlo.                                        #
+#                                                                           #
+#  Copyright (c) 2015-2021                                                  #
+#     Verificarlo contributors                                              #
+#     Universite de Versailles St-Quentin-en-Yvelines                       #
+#     CMLA, Ecole Normale Superieure de Cachan                              #
+#                                                                           #
+#  Verificarlo is free software: you can redistribute it and/or modify      #
+#  it under the terms of the GNU General Public License as published by     #
+#  the Free Software Foundation, either version 3 of the License, or        #
+#  (at your option) any later version.                                      #
+#                                                                           #
+#  Verificarlo is distributed in the hope that it will be useful,           #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#  GNU General Public License for more details.                             #
+#                                                                           #
+#  You should have received a copy of the GNU General Public License        #
+#  along with Verificarlo.  If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                           #
+#############################################################################
+
+# Manage the view comparing results of deerministic backends over runs.
+# At its creation, a DeterministicCompare object will create all the needed
+# Bokeh widgets and plots, setup the callback functions (either server side or
+# client side), initialize widgets selection, and from this selection generate
+# the first plots. Then, when callback functions are triggered, widgets
+# selections are updated, and plots are re-generated with the newly selected
+# data.
+
+import pandas as pd
+from math import nan
+
+from bokeh.plotting import figure, curdoc
+from bokeh.embed import components
+from bokeh.models import Select, ColumnDataSource, HoverTool, \
+    TextInput, CheckboxGroup, CustomJS
+
+import helper
+import plot
+
+##########################################################################
+
+
+class DeterministicCompare:
+
+    # Plots update function
+
+    def update_plots(self):
+
+        if self.data.empty:
+            return
+
+        # Select all data matching current test/var/backend
+
+        runs = self.data.loc[[self.widgets["select_deterministic_test"].value],
+                             self.widgets["select_deterministic_var"].value,
+                             self.widgets["select_deterministic_backend"].value]
+
+        runs = runs.sort_values(by=["timestamp"])
+
+        timestamps = runs["timestamp"]
+        x_series, x_metadata = helper.gen_x_series(
+            self.metadata,
+            timestamps.sort_values(),
+            self.current_n_runs
+        )
+
+        # Update source
+
+        dict = runs.to_dict("series")
+        dict["value_x"] = x_series
+
+        # Add metadata (for tooltip)
+        dict.update(x_metadata)
+
+        # Select the last n runs only
+        n = self.current_n_runs
+        dict = {key: value[-n:] for key, value in dict.items()}
+
+        # Generate color series for display of failed asserts
+        dict["custom_colors"] = [True] * len(dict["assert"])
+        for i in range(len(dict["assert"])):
+            dict["custom_colors"][i] = "#1f77b4" if dict["assert"][i] else "#cc2b2b"
+
+        # Filter outliers if the box is checked
+        if len(self.widgets["outliers_filtering_deterministic"].active) > 0:
+            outliers = helper.detect_outliers(dict["value"])
+            dict["value"] = helper.remove_outliers(dict["value"], outliers)
+            dict["value_x"] = helper.remove_outliers(
+                dict["%value_x"], outliers)
+
+        # Series to display IEEE results. This is different than reference_value,
+        # because the latter has to be 0 when no reference run has been done
+        # (because the value will be shown in the tooltip)
+        dict["ieee"] = [0] * len(dict["value"])
+
+        for i in range(len(dict["value"])):
+            if dict["assert"][i]:
+                dict["ieee"][i] = nan
+            else:
+                dict["ieee"][i] = dict["reference_value"][i]
+
+        self.source.data = dict
+
+        # Update x axis
+
+        helper.reset_x_range(
+            self.plots["comparison_plot"],
+            self.source.data["value_x"]
+        )
+
+        # Widgets' callback functions
+
+    def update_test(self, attrname, old, new):
+
+        # If the value is updated by the CustomJS,
+        # self.widgets["select_deterministic_var"].value won't be updated, so we
+        # have to look for that case and assign it manually.
+
+        # "new" should be a list when updated by CustomJS
+        if isinstance(new, list):
+            # If filtering removed all options, we might have an empty list
+            # (in this case, we just skip the callback and do nothing)
+            if len(new) > 0:
+                new = new[0]
+            else:
+                return
+
+        if new != self.widgets["select_deterministic_test"].value:
+            # The callback will be triggered again with the updated value
+            self.widgets["select_deterministic_test"].value = new
+            return
+
+        # New list of available vars
+        self.vars = self.data.loc[new]\
+            .index.get_level_values("variable").drop_duplicates().tolist()
+        self.widgets["select_deterministic_var"].options = self.vars
+
+        # Reset var selection if old one is not available in new vars
+        if self.widgets["select_deterministic_var"].value not in self.vars:
+            self.widgets["select_deterministic_var"].value = self.vars[0]
+            # The update_var callback will be triggered by the assignment
+
+        else:
+            # Trigger the callback manually (since the plots need to be updated
+            # anyway)
+            self.update_var(
+                "", "", self.widgets["select_deterministic_var"].value)
+
+    def update_var(self, attrname, old, new):
+
+        # If the value is updated by the CustomJS,
+        # self.widgets["select_deterministic_var"].value won't be updated, so we
+        # have to look for that case and assign it manually.
+
+        # new should be a list when updated by CustomJS
+        if isinstance(new, list):
+            new = new[0]
+
+        if new != self.widgets["select_deterministic_var"].value:
+            # The callback will be triggered again with the updated value
+            self.widgets["select_deterministic_var"].value = new
+            return
+
+        # New list of available backends
+        self.backends = self.data.loc[self.widgets["select_deterministic_test"].value,
+                                      self.widgets["select_deterministic_var"].value] .index.get_level_values("vfc_backend").drop_duplicates().tolist()
+        self.widgets["select_deterministic_backend"].options = self.backends
+
+        # Reset backend selection if old one is not available in new backends
+        if self.widgets["select_deterministic_backend"].value not in self.backends:
+            self.widgets["select_deterministic_backend"].value = self.backends[0]
+            # The update_backend callback will be triggered by the assignment
+
+        else:
+            # Trigger the callback manually (since the plots need to be updated
+            # anyway)
+            self.update_backend(
+                "", "", self.widgets["select_deterministic_backend"].value)
+
+    def update_backend(self, attrname, old, new):
+
+        # Simply update plots, since no other data is affected
+        self.update_plots()
+
+    def update_n_runs(self, attrname, old, new):
+        # Simply update runs selection (value and string display)
+        self.widgets["select_n_deterministic_runs"].value = new
+        self.current_n_runs = self.n_runs_dict[self.widgets["select_n_deterministic_runs"].value]
+
+        self.update_plots()
+
+    def update_outliers_filtering(self, attrname, old, new):
+        self.update_plots()
+
+        # Bokeh setup functions
+
+    def setup_plots(self):
+
+        tools = "pan, wheel_zoom, xwheel_zoom, ywheel_zoom, reset, save"
+
+        # Backend Vs Reference comparison plot
+        self.plots["comparison_plot"] = figure(
+            name="comparison_plot",
+            title="Variable with deterministic backend over runs",
+            plot_width=900,
+            plot_height=400,
+            x_range=[""],
+            tools=tools,
+            sizing_mode="scale_width")
+
+        comparison_tooltips = [
+            ("Git commit", "@is_git_commit"),
+            ("Date", "@date"),
+            ("Hash", "@hash"),
+            ("Author", "@author"),
+            ("Message", "@message"),
+            ("Backend value", "@value{%0.18e}"),
+            ("Reference value", "@reference_value{%0.18e}"),
+            ("Accuracy target", "@accuracy_threshold")
+        ]
+        comparison_tooltips_formatters = {
+            "@value": "printf",
+            "@reference_value": "printf"
+        }
+
+        js_tap_callback = "changeView(\"asserts\");"
+
+        plot.fill_dotplot(
+            self.plots["comparison_plot"], self.source,
+            data_field="value",
+            tooltips=comparison_tooltips,
+            tooltips_formatters=comparison_tooltips_formatters,
+            js_tap_callback=js_tap_callback,
+            server_tap_callback=self.asserts_callback,
+            lines=True,
+            second_series="ieee",   # Will be used to display the IEEE results
+            custom_colors=True
+        )
+
+        self.doc.add_root(self.plots["comparison_plot"])
+
+    def setup_widgets(self):
+
+        # Initial selection
+
+        # Test/var/backend combination (we select all first elements at init)
+        if not self.data.empty:
+            self.tests = self.data\
+                .index.get_level_values("test").drop_duplicates().tolist()
+
+            self.vars = self.data.loc[self.tests[0]]\
+                .index.get_level_values("variable").drop_duplicates().tolist()
+
+            self.backends = self.data.loc[self.tests[0], self.vars[0]]\
+                .index.get_level_values("vfc_backend").drop_duplicates().tolist()
+
+        else:
+            self.tests = ["None"]
+            self.vars = ["None"]
+            self.backends = ["None"]
+
+        # Custom JS callback that will be used client side to filter selections
+        filter_callback_js = """
+        selector.options = options.filter(e => e.includes(cb_obj.value));
+        """
+
+        # Test selector widget
+
+        # Number of runs to display
+        # The dict structure allows us to get int value from the display string
+        # in O(1)
+        self.n_runs_dict = {
+            "Last 3 runs": 3,
+            "Last 5 runs": 5,
+            "Last 10 runs": 10,
+            "All runs": 0
+        }
+
+        # Contains all options strings
+        n_runs_display = list(self.n_runs_dict.keys())
+
+        # Will be used when updating plots (contains actual number to diplay)
+        self.current_n_runs = self.n_runs_dict[n_runs_display[1]]
+
+        # Selector widget
+        self.widgets["select_deterministic_test"] = Select(
+            name="select_deterministic_test", title="Test :",
+            value=self.tests[0], options=self.tests
+        )
+        self.doc.add_root(self.widgets["select_deterministic_test"])
+        self.widgets["select_deterministic_test"].on_change(
+            "value", self.update_test)
+        self.widgets["select_deterministic_test"].on_change(
+            "options", self.update_test)
+
+        # Filter widget
+        self.widgets["deterministic_test_filter"] = TextInput(
+            name="deterministic_test_filter", title="Tests filter:"
+        )
+        self.widgets["deterministic_test_filter"].js_on_change(
+            "value",
+            CustomJS(
+                args=dict(
+                    options=self.tests,
+                    selector=self.widgets["select_deterministic_test"]),
+                code=filter_callback_js))
+        self.doc.add_root(self.widgets["deterministic_test_filter"])
+
+        # Number of runs to display
+
+        self.widgets["select_n_deterministic_runs"] = Select(
+            name="select_n_deterministic_runs", title="Display :",
+            value=n_runs_display[1], options=n_runs_display
+        )
+        self.doc.add_root(self.widgets["select_n_deterministic_runs"])
+        self.widgets["select_n_deterministic_runs"].on_change(
+            "value", self.update_n_runs)
+
+        # Variable selector widget
+
+        self.widgets["select_deterministic_var"] = Select(
+            name="select_deterministic_var", title="Variable :",
+            value=self.vars[0], options=self.vars
+        )
+        self.doc.add_root(self.widgets["select_deterministic_var"])
+        self.widgets["select_deterministic_var"].on_change(
+            "value", self.update_var)
+        self.widgets["select_deterministic_var"].on_change(
+            "options", self.update_var)
+
+        # Backend selector widget
+
+        self.widgets["select_deterministic_backend"] = Select(
+            name="select_deterministic_backend",
+            title="Verificarlo backend (deterministic) :",
+            value=self.backends[0],
+            options=self.backends)
+        self.doc.add_root(self.widgets["select_deterministic_backend"])
+        self.widgets["select_deterministic_backend"].on_change(
+            "value", self.update_backend)
+
+        # Outliers filtering checkbox
+
+        self.widgets["outliers_filtering_deterministic"] = CheckboxGroup(
+            name="outliers_filtering_deterministic",
+            labels=["Filter outliers"], active=[]
+        )
+        self.doc.add_root(self.widgets["outliers_filtering_deterministic"])
+        self.widgets["outliers_filtering_deterministic"]\
+            .on_change("active", self.update_outliers_filtering)
+
+        # Communication methods
+        # (to send/receive messages to/from master)
+
+    def asserts_callback(self, attrname, old, new):
+        '''
+        Callback to change view to "Asserts" view when plot element is clicked
+        '''
+
+        # In case we just unselected everything on the plot, then do nothing
+        if not new:
+            return
+
+        # But if an element has been selected, go to the corresponding run
+        index = new[-1]
+        run_name = self.source.data["value_x"][index]
+
+        self.master.go_to_asserts(run_name)
+
+    def change_repo(self, new_data, new_metadata):
+        '''
+        When received, update data and metadata with the new repo, and update
+        everything
+        '''
+
+        self.data = new_data
+        self.metadata = new_metadata
+
+        # Update widgets(and automatically trigger plot updates)
+        self.tests = self.data\
+            .index.get_level_values("test").drop_duplicates().tolist()
+
+        self.vars = self.data.loc[self.tests[0]]\
+            .index.get_level_values("variable").drop_duplicates().tolist()
+
+        self.backends = self.data.loc[self.tests[0], self.vars[0]]\
+            .index.get_level_values("vfc_backend").drop_duplicates().tolist()
+
+        self.widgets["select_deterministic_test"].options = self.tests
+        self.widgets["select_deterministic_test"].value = self.tests[0]
+
+        # If changing repo doesn't affect the selection, trigger the callback
+        # manually
+        old = self.widgets["select_deterministic_backend"].value
+        if self.widgets["select_deterministic_backend"].value == old:
+            self.update_plots()
+
+    # Constructor
+
+    def __init__(self, master, doc, data, metadata):
+        '''
+        Here are the most important attributes of the CompareRuns class
+
+        master : reference to the ViewMaster class
+        doc : an object provided by Bokeh to add elements to the HTML document
+        data : pandas dataframe containing all the tests data (only for
+        deterministic backends)
+        metadata : pandas dataframe containing all the tests metadata
+
+        sources : ColumnDataSource object provided by Bokeh, contains current
+        data for the plots (inside the .data attribute)
+        plots : dictionary of Bokeh plots
+        widgets : dictionary of Bokeh widgets
+        '''
+
+        self.master = master
+
+        self.doc = doc
+        self.data = data
+        self.metadata = metadata
+
+        self.source = ColumnDataSource(data={})
+
+        self.plots = {}
+        self.widgets = {}
+
+        # Setup Bokeh objects
+        self.setup_plots()
+        self.setup_widgets()
+
+        # At this point, everything should have been initialized, so we can
+        # show the plots for the first time
+        self.update_plots()

--- a/src/tools/ci/vfc_ci_report/inspect_runs.py
+++ b/src/tools/ci/vfc_ci_report/inspect_runs.py
@@ -132,26 +132,54 @@ class InspectRuns:
 
         # Groupby and aggregate lines belonging to the same group in lists
 
-        groups = self.run_data[
-            self.run_data.index.isin(
-                [self.widgets["select_filter"].value],
-                level=filterby
-            )
-        ].groupby(groupby)
+        if not self.run_data.empty:
+            groups = self.run_data[
+                self.run_data.index.isin(
+                    [self.widgets["select_filter"].value],
+                    level=filterby
+                )
+            ].groupby(groupby)
 
-        groups = groups.agg({
-            "sigma": lambda x: x.tolist(),
-            "s10": lambda x: x.tolist(),
-            "s2": lambda x: x.tolist(),
+            groups = groups.agg({
+                "sigma": lambda x: x.tolist(),
+                "s10": lambda x: x.tolist(),
+                "s2": lambda x: x.tolist(),
 
-            "mu": lambda x: x.tolist(),
+                "mu": lambda x: x.tolist(),
 
-            # Used for mu weighted average first, then will be replaced
-            "nsamples": lambda x: x.tolist()
-        })
+                # Used for mu weighted average first, then will be replaced
+                "nsamples": lambda x: x.tolist()
+            })
 
-        # Compute the new distributions, ...
-        groups = self.data_processing(groups).to_dict("list")
+            # Compute the new distributions, ...
+            groups = self.data_processing(groups).to_dict("list")
+
+        else:
+            groups = {
+                "mu": [],
+                "nsamples": [],
+                "mu_x": [],
+                "sigma_x": [],
+                "sigma_min": [],
+                "sigma_quantile25": [],
+                "sigma_quantile50": [],
+                "sigma_quantile75": [],
+                "sigma_max": [],
+                "sigma_mu": [],
+                "s10_x": [],
+                "s10_min": [],
+                "s10_quantile25": [],
+                "s10_quantile50": [],
+                "s10_quantile75": [],
+                "s10_max": [],
+                "s10_mu": [],
+                "s2_x": [],
+                "s2_min": [],
+                "s2_quantile25": [],
+                "s2_quantile50": [],
+                "s2_quantile75": [],
+                "s2_max": [],
+                "s2_mu": []}
 
         # Update source
 

--- a/src/tools/ci/vfc_ci_report/inspect_runs.py
+++ b/src/tools/ci/vfc_ci_report/inspect_runs.py
@@ -53,25 +53,6 @@ class InspectRuns:
 
     # Helper functions related to InspectRun
 
-    def gen_runs_selection(self):
-        '''
-        Returns a dictionary mapping user-readable strings to all run timestamps
-        '''
-
-        runs_dict = {}
-
-        # Iterate over timestamp rows (runs) and fill dict
-        for row in self.metadata.iloc:
-            # The syntax used by pandas makes this part a bit tricky :
-            # row.name is the index of metadata (so it refers to the
-            # timestamp), whereas row["name"] is the column called "name"
-            # (which is the display string used for the run)
-
-            # runs_dict[run's name] = run's timestamp
-            runs_dict[row["name"]] = row.name
-
-        return runs_dict
-
     def gen_boxplot_tooltips(self, prefix):
         return [
             ("Name", "@%s_x" % prefix),
@@ -460,7 +441,7 @@ class InspectRuns:
         # Dict contains all inspectable runs (maps display strings to timestamps)
         # The dict structure allows to get the timestamp from the display string
         # in O(1)
-        self.runs_dict = self.gen_runs_selection()
+        self.runs_dict = helper.gen_runs_selection(self.metadata)
 
         # Dict maps display strings to column names for the different factors
         # (var, backend, test)
@@ -481,7 +462,7 @@ class InspectRuns:
         # This contains only entries matching the run
         self.run_data = self.data[self.data["timestamp"] == self.current_run]
 
-        change_run_callback_js = "updateRunMetadata(cb_obj.value);"
+        change_run_callback_js = "updateRunMetadata(cb_obj.value, \"\");"
 
         self.widgets["select_run"] = Select(
             name="select_run", title="Run :",
@@ -537,8 +518,11 @@ class InspectRuns:
         ]
         filterby = self.factors_dict[filterby]
 
-        options = self.run_data.index\
-            .get_level_values(filterby).drop_duplicates().tolist()
+        if not self.run_data.empty:
+            options = self.run_data.index\
+                .get_level_values(filterby).drop_duplicates().tolist()
+        else:
+            options = ["None"]
 
         self.widgets["select_filter"] = Select(
             # We need a different name to avoid collision in the template with
@@ -572,7 +556,7 @@ class InspectRuns:
         self.data = new_data
         self.metadata = new_metadata
 
-        self.runs_dict = self.gen_runs_selection()
+        self.runs_dict = helper.gen_runs_selection(self.metadata)
 
         runs_display = list(self.runs_dict.keys())
         current_run_display = runs_display[-1]

--- a/src/tools/ci/vfc_ci_report/main.py
+++ b/src/tools/ci/vfc_ci_report/main.py
@@ -40,7 +40,7 @@ from bokeh.models import Select, CustomJS
 import compare_runs
 import deterministic_compare
 import inspect_runs
-import asserts
+import checks
 
 import helper
 
@@ -160,7 +160,7 @@ if data.empty:
         "test", "variable", "backend",
         "sigma", "s10", "s2", "s10_lower_bound", "s2_lower_bound",
         "mu", "quantile25", "quantile50", "quantile75",
-        "accuracy_threshold", "assert", "assert_mode",
+        "accuracy_threshold", "check", "check_mode",
         "timestamp"
     ])
 
@@ -173,8 +173,8 @@ if deterministic_data.empty:
             "value",
             "accuracy_threshold",
             "reference_value",
-            "assert",
-            "assert_mode",
+            "check",
+            "check_mode",
             "timestamp"])
 
 # Generate the display strings for runs (runs ticks)
@@ -234,7 +234,7 @@ class ViewsMaster:
         self.deterministic.change_repo(
             filtered_deterministic_data, filtered_metadata)
         self.inspect.change_repo(filtered_data, filtered_metadata)
-        self.asserts.change_repo(
+        self.checks.change_repo(
             filtered_data, filtered_deterministic_data, filtered_metadata)
 
         # Communication functions
@@ -242,8 +242,8 @@ class ViewsMaster:
     def go_to_inspect(self, run_name):
         self.inspect.switch_view(run_name)
 
-    def go_to_asserts(self, run_name):
-        self.asserts.switch_view(run_name)
+    def go_to_checks(self, run_name):
+        self.checks.switch_view(run_name)
 
         # Constructor
 
@@ -346,8 +346,8 @@ class ViewsMaster:
             metadata=filtered_metadata
         )
 
-        # Initialize asserts table view
-        self.asserts = asserts.Asserts(
+        # Initialize checks table view
+        self.checks = checks.Checks(
             master=self,
             doc=curdoc(),
             data=filtered_data,

--- a/src/tools/ci/vfc_ci_report/main.py
+++ b/src/tools/ci/vfc_ci_report/main.py
@@ -154,21 +154,28 @@ data = pd.concat(data).sort_index()
 deterministic_data = pd.concat(deterministic_data).sort_index()
 
 # If no data/deterministic_data has been found, create an empty dataframe anyway
-# (with column names) to avoid crashes
+# (with column names) to avoid errors further in the code
 if data.empty:
     data = pd.DataFrame(columns=[
         "test", "variable", "backend",
         "sigma", "s10", "s2", "s10_lower_bound", "s2_lower_bound",
         "mu", "quantile25", "quantile50", "quantile75",
-        "accuracy_threshold", "assert",
+        "accuracy_threshold", "assert", "assert_mode",
         "timestamp"
     ])
 
 if deterministic_data.empty:
-    deterministic_data = pd.DataFrame(columns=[
-        "test", "variable", "backend",
-        "value", "accuracy_threshold", "reference_value", "assert", "timestamp"
-    ])
+    deterministic_data = pd.DataFrame(
+        columns=[
+            "test",
+            "variable",
+            "backend",
+            "value",
+            "accuracy_threshold",
+            "reference_value",
+            "assert",
+            "assert_mode",
+            "timestamp"])
 
 # Generate the display strings for runs (runs ticks)
 # By doing this in master, we ensure the homogeneity of display strings

--- a/src/tools/ci/vfc_ci_report/main.py
+++ b/src/tools/ci/vfc_ci_report/main.py
@@ -38,7 +38,10 @@ from bokeh.models import Select, CustomJS
 
 # Local imports from vfc_ci_server
 import compare_runs
+import deterministic_compare
 import inspect_runs
+import asserts
+
 import helper
 
 ##########################################################################
@@ -56,7 +59,6 @@ directory = "."
 
 max_files = 100
 ignore_recent = 0
-
 
 for i in range(1, len(sys.argv)):
 
@@ -97,6 +99,7 @@ if len(run_files) == 0:
 # These are arrays of Pandas dataframes for now
 metadata = []
 data = []
+deterministic_data = []
 
 # First pass for metadata
 for f in run_files:
@@ -142,8 +145,30 @@ for f in run_files:
 
     if current_timestamp <= max_timestamp:
         data.append(pd.read_hdf(directory + "/" + f, "data"))
+        deterministic_data.append(
+            pd.read_hdf(
+                directory + "/" + f,
+                "deterministic_data"))
 
 data = pd.concat(data).sort_index()
+deterministic_data = pd.concat(deterministic_data).sort_index()
+
+# If no data/deterministic_data has been found, create an empty dataframe anyway
+# (with column names) to avoid crashes
+if data.empty:
+    data = pd.DataFrame(columns=[
+        "test", "variable", "backend",
+        "sigma", "s10", "s2", "s10_lower_bound", "s2_lower_bound",
+        "mu", "quantile25", "quantile50", "quantile75",
+        "accuracy_threshold", "assert",
+        "timestamp"
+    ])
+
+if deterministic_data.empty:
+    deterministic_data = pd.DataFrame(columns=[
+        "test", "variable", "backend",
+        "value", "accuracy_threshold", "reference_value", "assert", "timestamp"
+    ])
 
 # Generate the display strings for runs (runs ticks)
 # By doing this in master, we ensure the homogeneity of display strings
@@ -159,7 +184,6 @@ helper.reset_run_strings()
 metadata["date"] = metadata.index.to_series().map(
     lambda x: time.ctime(x)
 )
-
 
 ##########################################################################
 
@@ -177,30 +201,51 @@ class ViewsMaster:
     # Callbacks
 
     def change_repo(self, attrname, old, new):
-        filtered_data = self.data[
-            helper.filterby_repo(
-                self.metadata, new, self.data["timestamp"]
-            )
-        ]
+        # Filter metadata by repository
         filtered_metadata = self.metadata[
             self.metadata["repo_name"] == new
         ]
 
+        # Filter data and deterministic_data by repository
+        if not data.empty:
+            filtered_data = self.data[
+                helper.filterby_repo(
+                    self.metadata, new, self.data["timestamp"]
+                )
+            ]
+        else:
+            filtered_data = data
+
+        if not deterministic_data.empty:
+            filtered_deterministic_data = self.deterministic_data[
+                helper.filterby_repo(
+                    self.metadata, new, self.deterministic_data["timestamp"]
+                )
+            ]
+
         self.compare.change_repo(filtered_data, filtered_metadata)
+        self.deterministic.change_repo(
+            filtered_deterministic_data, filtered_metadata)
         self.inspect.change_repo(filtered_data, filtered_metadata)
+        self.asserts.change_repo(
+            filtered_data, filtered_deterministic_data, filtered_metadata)
 
         # Communication functions
 
     def go_to_inspect(self, run_name):
         self.inspect.switch_view(run_name)
 
+    def go_to_asserts(self, run_name):
+        self.asserts.switch_view(run_name)
+
         # Constructor
 
-    def __init__(self, data, metadata):
+    def __init__(self, data, deterministic_data, metadata):
 
         curdoc().title = "Verificarlo Report"
 
         self.data = data
+        self.deterministic_data = deterministic_data
         self.metadata = metadata
 
         # Initialize repository selection
@@ -241,17 +286,32 @@ class ViewsMaster:
         curdoc().template_variables["metadata"] = self.metadata.to_json(
             orient="index")
 
+        # Show the first repository by default
         repo_name = list(repo_names_dict.keys())[0]
 
-        # Filter data and metadata by repository
-        filtered_data = self.data[
-            helper.filterby_repo(
-                self.metadata, repo_name, self.data["timestamp"]
-            )
-        ]
+        # Filter metadata by repository
         filtered_metadata = self.metadata[
             self.metadata["repo_name"] == repo_name
         ]
+
+        # Filter data and deterministic_data by repository
+        if not data.empty:
+            filtered_data = self.data[
+                helper.filterby_repo(
+                    self.metadata, repo_name, self.data["timestamp"]
+                )
+            ]
+        else:
+            filtered_data = data
+
+        if not deterministic_data.empty:
+            filtered_deterministic_data = self.deterministic_data[
+                helper.filterby_repo(
+                    self.metadata, repo_name, self.deterministic_data["timestamp"]
+                )
+            ]
+        else:
+            filtered_deterministic_data = deterministic_data
 
         # Initialize views
 
@@ -260,7 +320,15 @@ class ViewsMaster:
             master=self,
             doc=curdoc(),
             data=filtered_data,
-            metadata=filtered_metadata,
+            metadata=filtered_metadata
+        )
+
+        # Initialize deterministic runs comparison
+        self.deterministic = deterministic_compare.DeterministicCompare(
+            master=self,
+            doc=curdoc(),
+            data=filtered_deterministic_data,
+            metadata=filtered_metadata
         )
 
         # Initialize runs inspection
@@ -268,11 +336,21 @@ class ViewsMaster:
             master=self,
             doc=curdoc(),
             data=filtered_data,
-            metadata=filtered_metadata,
+            metadata=filtered_metadata
+        )
+
+        # Initialize asserts table view
+        self.asserts = asserts.Asserts(
+            master=self,
+            doc=curdoc(),
+            data=filtered_data,
+            deterministic_data=filtered_deterministic_data,
+            metadata=filtered_metadata
         )
 
 
 views_master = ViewsMaster(
     data=data,
+    deterministic_data=deterministic_data,
     metadata=metadata
 )

--- a/src/tools/ci/vfc_ci_report/plot.py
+++ b/src/tools/ci/vfc_ci_report/plot.py
@@ -59,7 +59,7 @@ def fill_dotplot(
     legend: lengend for the first data series
     second_legend: same for the second optional data series
     custom_colors: Will plot additional glyphs with a custom color (to display
-    assert errors for instance). Should be the name of the series of colors.
+    check errors for instance). Should be the name of the series of colors.
     '''
 
     # (Optional) Tooltip and tooltip formatters
@@ -157,7 +157,7 @@ def fill_boxplot(
     js_tap_callback: CustomJS object for client side click callback
     server_tap_callback: Callback object for server side click callback
     custom_colors: Will plot additional glyphs with a custom color (to display
-    assert errors for instance). Series of colors.
+    check errors for instance). Series of colors.
     '''
 
     # (Optional) Tooltip and tooltip formatters
@@ -259,9 +259,9 @@ def fill_barplot(
 
     single_series: Series that display one value at each x (string)
     double_series: Series that display two values at each x (list of strings, size 2)
-    columns: Array of columns to display. Size should be coherent with "assert_mode".
+    columns: Array of columns to display. Size should be coherent with "check_mode".
     legend: Array of texts to put in the legend. This should be specified when
-    plotting more than one culum, and its size should be coherent with "assert_mode".
+    plotting more than one culum, and its size should be coherent with "check_mode".
     tooltips: Bokeh Tooltip object to use for the plot
     tooltips_formatters: Formatter for the tooltip
     js_tap_callback: CustomJS object for client side click callback

--- a/src/tools/ci/vfc_ci_report/plot.py
+++ b/src/tools/ci/vfc_ci_report/plot.py
@@ -42,7 +42,7 @@ def fill_dotplot(
     second_series=None,
     legend=None,
     second_legend=None,
-    custom_colors="blue"
+    custom_colors="#1f77b4"
 ):
     '''
     General function for filling dotplots.
@@ -103,7 +103,7 @@ def fill_dotplot(
         if lines:
             second_line = plot.line(
                 x="%s_x" % data_field, y=second_series, source=source,
-                color="grey", line_dash="dashed"
+                color="gray", line_dash="dashed"
             )
 
     # (Optional) Draw lines between dots
@@ -145,7 +145,7 @@ def fill_boxplot(
     prefix="",
     tooltips=None, tooltips_formatters=None,
     js_tap_callback=None, server_tap_callback=None,
-    custom_colors=""
+    custom_colors=None
 ):
     '''
     General function for filling boxplots.
@@ -193,17 +193,30 @@ def fill_boxplot(
     )
 
     # Boxes
-    full_box = plot.vbar(
-        name="full_box",
-        x="%sx" % prefix, width=0.5,
-        top="%squantile75" % prefix, bottom="%squantile25" % prefix,
-        source=source, line_color="black", fill_color=custom_colors
-    )
-    bottom_box = plot.vbar(
-        x="%sx" % prefix, width=0.5,
-        top="%squantile50" % prefix, bottom="%squantile25" % prefix,
-        source=source, line_color="black", fill_color=custom_colors
-    )
+    if custom_colors is not None:
+        full_box = plot.vbar(
+            name="full_box",
+            x="%sx" % prefix, width=0.5,
+            top="%squantile75" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black", fill_color=custom_colors
+        )
+        bottom_box = plot.vbar(
+            x="%sx" % prefix, width=0.5,
+            top="%squantile50" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black", fill_color=custom_colors
+        )
+    else:
+        full_box = plot.vbar(
+            name="full_box",
+            x="%sx" % prefix, width=0.5,
+            top="%squantile75" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black"
+        )
+        bottom_box = plot.vbar(
+            x="%sx" % prefix, width=0.5,
+            top="%squantile50" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black"
+        )
 
     # Mu dot
     mu_dot = plot.dot(
@@ -246,9 +259,9 @@ def fill_barplot(
 
     single_series: Series that display one value at each x (string)
     double_series: Series that display two values at each x (list of strings, size 2)
-    columns: Array of columns to display. Size should be coherent with "mode".
+    columns: Array of columns to display. Size should be coherent with "assert_mode".
     legend: Array of texts to put in the legend. This should be specified when
-    plotting more than one culum, and its size should be coherent with "mode".
+    plotting more than one culum, and its size should be coherent with "assert_mode".
     tooltips: Bokeh Tooltip object to use for the plot
     tooltips_formatters: Formatter for the tooltip
     js_tap_callback: CustomJS object for client side click callback

--- a/src/tools/ci/vfc_ci_report/plot.py
+++ b/src/tools/ci/vfc_ci_report/plot.py
@@ -26,6 +26,7 @@
 
 from bokeh.plotting import figure
 from bokeh.models import HoverTool, TapTool, CustomJS
+from bokeh.models.annotations import Legend, LegendItem
 from bokeh.colors import color
 from bokeh.transform import dodge
 
@@ -41,7 +42,7 @@ def fill_dotplot(
     second_series=None,
     legend=None,
     second_legend=None,
-    custom_colors=None
+    custom_colors="blue"
 ):
     '''
     General function for filling dotplots.
@@ -85,19 +86,18 @@ def fill_dotplot(
 
     # (Optional) Draw a second data series
     if second_series is not None:
-        # (Optional) Legend for the second data series
         if second_legend is not None:
             second_circle = plot.circle(
                 name="second_circle",
                 x="%s_x" % data_field, y=second_series, source=source, size=12,
-                fill_color="grey", line_color="grey",
+                fill_color="gray", line_color="gray",
                 legend_label=second_legend
             )
         else:
             second_circle = plot.circle(
                 name="second_circle",
                 x="%s_x" % data_field, y=second_series, source=source, size=12,
-                fill_color="grey", line_color="grey"
+                fill_color="gray", line_color="gray",
             )
 
         if lines:
@@ -111,36 +111,19 @@ def fill_dotplot(
         line = plot.line(x="%s_x" % data_field, y=data_field, source=source)
 
     # Draw dots (actually Bokeh circles)
-    # (Optional) Custom color palette (to display assert errors, for instance)
-    if custom_colors is not None:
-        # (Optional) Legend for the data series
-        if legend is not None:
-            circle = plot.circle(
-                name="circle",
-                x="%s_x" % data_field, y=data_field, source=source, size=12,
-                legend_label=legend,
-                fill_color=custom_colors, line_color=custom_colors
-            )
-        else:
-            circle = plot.circle(
-                name="circle",
-                x="%s_x" % data_field, y=data_field, source=source, size=12,
-                fill_color=custom_colors, line_color=custom_colors
-            )
-
+    if legend is not None:
+        circle = plot.circle(
+            name="circle",
+            x="%s_x" % data_field, y=data_field, source=source, size=12,
+            fill_color=custom_colors, line_color=custom_colors,
+            legend_label=legend
+        )
     else:
-        # (Optional) Legend for the data series
-        if legend is not None:
-            circle = plot.circle(
-                name="circle",
-                x="%s_x" % data_field, y=data_field, source=source, size=12,
-                legend_label=legend
-            )
-        else:
-            circle = plot.circle(
-                name="circle",
-                x="%s_x" % data_field, y=data_field, source=source, size=12
-            )
+        circle = plot.circle(
+            name="circle",
+            x="%s_x" % data_field, y=data_field, source=source, size=12,
+            fill_color=custom_colors, line_color=custom_colors
+        )
 
     # (Optional) Add server tap callback
     if server_tap_callback is not None:
@@ -162,7 +145,7 @@ def fill_boxplot(
     prefix="",
     tooltips=None, tooltips_formatters=None,
     js_tap_callback=None, server_tap_callback=None,
-    custom_colors=False
+    custom_colors=""
 ):
     '''
     General function for filling boxplots.
@@ -210,33 +193,17 @@ def fill_boxplot(
     )
 
     # Boxes
-
-    if not custom_colors:
-        full_box = plot.vbar(
-            name="full_box",
-            x="%sx" % prefix, width=0.5,
-            top="%squantile75" % prefix, bottom="%squantile25" % prefix,
-            source=source, line_color="black"
-        )
-        bottom_box = plot.vbar(
-            x="%sx" % prefix, width=0.5,
-            top="%squantile50" % prefix, bottom="%squantile25" % prefix,
-            source=source, line_color="black"
-        )
-
-    # (Optional) Custom color palette (to display assert errors, for instance)
-    else:
-        full_box = plot.vbar(
-            name="full_box",
-            x="%sx" % prefix, width=0.5,
-            top="%squantile75" % prefix, bottom="%squantile25" % prefix,
-            source=source, line_color="black", fill_color="custom_colors"
-        )
-        bottom_box = plot.vbar(
-            x="%sx" % prefix, width=0.5,
-            top="%squantile50" % prefix, bottom="%squantile25" % prefix,
-            source=source, line_color="black", fill_color="custom_colors"
-        )
+    full_box = plot.vbar(
+        name="full_box",
+        x="%sx" % prefix, width=0.5,
+        top="%squantile75" % prefix, bottom="%squantile25" % prefix,
+        source=source, line_color="black", fill_color=custom_colors
+    )
+    bottom_box = plot.vbar(
+        x="%sx" % prefix, width=0.5,
+        top="%squantile50" % prefix, bottom="%squantile25" % prefix,
+        source=source, line_color="black", fill_color=custom_colors
+    )
 
     # Mu dot
     mu_dot = plot.dot(
@@ -317,8 +284,8 @@ def fill_barplot(
             x=dodge("x", 0.15, range=plot.x_range), width=0.25,
             top=double_series[1],
             source=source,
-            line_color="grey",
-            fill_color="grey"
+            line_color="gray",
+            fill_color="gray"
         )
 
         vbars.append(vbar1)

--- a/src/tools/ci/vfc_ci_report/plot.py
+++ b/src/tools/ci/vfc_ci_report/plot.py
@@ -39,6 +39,8 @@ def fill_dotplot(
     lines=False,
     lower_bound=False,
     second_series=None,
+    legend=None,
+    second_legend=None,
     custom_colors=None
 ):
     '''
@@ -53,8 +55,10 @@ def fill_dotplot(
     lower_bound: Specify if a lower bound interval should be displayed
     second_series: Name of a second data series to plot on the same figure. It
     should also have its own x series with the "_x" prefix.
+    legend: lengend for the first data series
+    second_legend: same for the second optional data series
     custom_colors: Will plot additional glyphs with a custom color (to display
-    assert errors for instance). Series of colors.
+    assert errors for instance). Should be the name of the series of colors.
     '''
 
     # (Optional) Tooltip and tooltip formatters
@@ -81,11 +85,20 @@ def fill_dotplot(
 
     # (Optional) Draw a second data series
     if second_series is not None:
-        second_circle = plot.circle(
-            name="second_circle",
-            x="%s_x" % data_field, y=second_series, source=source, size=12,
-            fill_color="grey", line_color="grey"
-        )
+        # (Optional) Legend for the second data series
+        if second_legend is not None:
+            second_circle = plot.circle(
+                name="second_circle",
+                x="%s_x" % data_field, y=second_series, source=source, size=12,
+                fill_color="grey", line_color="grey",
+                legend_label=second_legend
+            )
+        else:
+            second_circle = plot.circle(
+                name="second_circle",
+                x="%s_x" % data_field, y=second_series, source=source, size=12,
+                fill_color="grey", line_color="grey"
+            )
 
         if lines:
             second_line = plot.line(
@@ -98,19 +111,36 @@ def fill_dotplot(
         line = plot.line(x="%s_x" % data_field, y=data_field, source=source)
 
     # Draw dots (actually Bokeh circles)
-    if custom_colors is None:
-        circle = plot.circle(
-            name="circle",
-            x="%s_x" % data_field, y=data_field, source=source, size=12
-        )
-
     # (Optional) Custom color palette (to display assert errors, for instance)
+    if custom_colors is not None:
+        # (Optional) Legend for the data series
+        if legend is not None:
+            circle = plot.circle(
+                name="circle",
+                x="%s_x" % data_field, y=data_field, source=source, size=12,
+                legend_label=legend,
+                fill_color=custom_colors, line_color=custom_colors
+            )
+        else:
+            circle = plot.circle(
+                name="circle",
+                x="%s_x" % data_field, y=data_field, source=source, size=12,
+                fill_color=custom_colors, line_color=custom_colors
+            )
+
     else:
-        circle = plot.circle(
-            name="circle",
-            x="%s_x" % data_field, y=data_field, source=source, size=12,
-            fill_color="custom_colors", line_color="custom_colors"
-        )
+        # (Optional) Legend for the data series
+        if legend is not None:
+            circle = plot.circle(
+                name="circle",
+                x="%s_x" % data_field, y=data_field, source=source, size=12,
+                legend_label=legend
+            )
+        else:
+            circle = plot.circle(
+                name="circle",
+                x="%s_x" % data_field, y=data_field, source=source, size=12
+            )
 
     # (Optional) Add server tap callback
     if server_tap_callback is not None:

--- a/src/tools/ci/vfc_ci_report/plot.py
+++ b/src/tools/ci/vfc_ci_report/plot.py
@@ -26,6 +26,8 @@
 
 from bokeh.plotting import figure
 from bokeh.models import HoverTool, TapTool, CustomJS
+from bokeh.colors import color
+from bokeh.transform import dodge
 
 from math import pi
 
@@ -35,7 +37,9 @@ def fill_dotplot(
     tooltips=None, tooltips_formatters=None,
     js_tap_callback=None, server_tap_callback=None,
     lines=False,
-    lower_bound=False
+    lower_bound=False,
+    second_series=None,
+    custom_colors=None
 ):
     '''
     General function for filling dotplots.
@@ -47,6 +51,10 @@ def fill_dotplot(
     server_tap_callback: Callback object for server side click callback
     lines: Specify if lines should be drawn to connect the dots
     lower_bound: Specify if a lower bound interval should be displayed
+    second_series: Name of a second data series to plot on the same figure. It
+    should also have its own x series with the "_x" prefix.
+    custom_colors: Will plot additional glyphs with a custom color (to display
+    assert errors for instance). Series of colors.
     '''
 
     # (Optional) Tooltip and tooltip formatters
@@ -71,15 +79,38 @@ def fill_dotplot(
             source=source, line_color="black"
         )
 
-    # Draw dots (actually Bokeh circles)
-    circle = plot.circle(
-        name="circle",
-        x="%s_x" % data_field, y=data_field, source=source, size=12
-    )
+    # (Optional) Draw a second data series
+    if second_series is not None:
+        second_circle = plot.circle(
+            name="second_circle",
+            x="%s_x" % data_field, y=second_series, source=source, size=12,
+            fill_color="grey", line_color="grey"
+        )
+
+        if lines:
+            second_line = plot.line(
+                x="%s_x" % data_field, y=second_series, source=source,
+                color="grey", line_dash="dashed"
+            )
 
     # (Optional) Draw lines between dots
     if lines:
         line = plot.line(x="%s_x" % data_field, y=data_field, source=source)
+
+    # Draw dots (actually Bokeh circles)
+    if custom_colors is None:
+        circle = plot.circle(
+            name="circle",
+            x="%s_x" % data_field, y=data_field, source=source, size=12
+        )
+
+    # (Optional) Custom color palette (to display assert errors, for instance)
+    else:
+        circle = plot.circle(
+            name="circle",
+            x="%s_x" % data_field, y=data_field, source=source, size=12,
+            fill_color="custom_colors", line_color="custom_colors"
+        )
 
     # (Optional) Add server tap callback
     if server_tap_callback is not None:
@@ -100,7 +131,8 @@ def fill_boxplot(
     plot, source,
     prefix="",
     tooltips=None, tooltips_formatters=None,
-    js_tap_callback=None, server_tap_callback=None
+    js_tap_callback=None, server_tap_callback=None,
+    custom_colors=False
 ):
     '''
     General function for filling boxplots.
@@ -111,6 +143,8 @@ def fill_boxplot(
     tooltips_formatters: Formatter for the tooltip
     js_tap_callback: CustomJS object for client side click callback
     server_tap_callback: Callback object for server side click callback
+    custom_colors: Will plot additional glyphs with a custom color (to display
+    assert errors for instance). Series of colors.
     '''
 
     # (Optional) Tooltip and tooltip formatters
@@ -146,17 +180,33 @@ def fill_boxplot(
     )
 
     # Boxes
-    full_box = plot.vbar(
-        name="full_box",
-        x="%sx" % prefix, width=0.5,
-        top="%squantile75" % prefix, bottom="%squantile25" % prefix,
-        source=source, line_color="black"
-    )
-    bottom_box = plot.vbar(
-        x="%sx" % prefix, width=0.5,
-        top="%squantile50" % prefix, bottom="%squantile25" % prefix,
-        source=source, line_color="black"
-    )
+
+    if not custom_colors:
+        full_box = plot.vbar(
+            name="full_box",
+            x="%sx" % prefix, width=0.5,
+            top="%squantile75" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black"
+        )
+        bottom_box = plot.vbar(
+            x="%sx" % prefix, width=0.5,
+            top="%squantile50" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black"
+        )
+
+    # (Optional) Custom color palette (to display assert errors, for instance)
+    else:
+        full_box = plot.vbar(
+            name="full_box",
+            x="%sx" % prefix, width=0.5,
+            top="%squantile75" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black", fill_color="custom_colors"
+        )
+        bottom_box = plot.vbar(
+            x="%sx" % prefix, width=0.5,
+            top="%squantile50" % prefix, bottom="%squantile25" % prefix,
+            source=source, line_color="black", fill_color="custom_colors"
+        )
 
     # Mu dot
     mu_dot = plot.dot(
@@ -175,6 +225,90 @@ def fill_boxplot(
             "indices", server_tap_callback)
 
         mu_dot.data_source.selected.on_change("indices", server_tap_callback)
+
+    # Plot appearance
+    plot.xgrid.grid_line_color = None
+    plot.ygrid.grid_line_color = None
+
+    plot.yaxis[0].formatter.power_limit_high = 0
+    plot.yaxis[0].formatter.power_limit_low = 0
+    plot.yaxis[0].formatter.precision = 3
+
+    plot.xaxis[0].major_label_orientation = pi / 8
+
+
+def fill_barplot(
+    plot, source,
+    single_series=None, double_series=None,
+    tooltips=None, tooltips_formatters=None,
+    js_tap_callback=None, server_tap_callback=None,
+):
+    '''
+    General function for filling barplots.
+    Here are the possible parameters :
+
+    single_series: Series that display one value at each x (string)
+    double_series: Series that display two values at each x (list of strings, size 2)
+    columns: Array of columns to display. Size should be coherent with "mode".
+    legend: Array of texts to put in the legend. This should be specified when
+    plotting more than one culum, and its size should be coherent with "mode".
+    tooltips: Bokeh Tooltip object to use for the plot
+    tooltips_formatters: Formatter for the tooltip
+    js_tap_callback: CustomJS object for client side click callback
+    server_tap_callback: Callback object for server side click callback
+    '''
+
+    vbars = []
+    vbars_names = []
+
+    # Draw "single" vbar
+    if single_series is not None:
+        vbar = plot.vbar(
+            name="vbar",
+            x="x", width=0.5,
+            top=single_series,
+            source=source
+        )
+
+        vbars.append(vbar)
+        vbars_names.append("vbar")
+
+    # Draw "double" vbars
+    if double_series is not None:
+        vbar1 = plot.vbar(
+            name="vbar1",
+            x=dodge("x", -0.15, range=plot.x_range), width=0.25,
+            top=double_series[0],
+            source=source
+        )
+
+        vbar2 = plot.vbar(
+            name="vbar2",
+            x=dodge("x", 0.15, range=plot.x_range), width=0.25,
+            top=double_series[1],
+            source=source,
+            line_color="grey",
+            fill_color="grey"
+        )
+
+        vbars.append(vbar1)
+        vbars.append(vbar2)
+        vbars_names.append("vbar1")
+        vbars_names.append("vbar2")
+
+    # (Optional) Tooltip and tooltip formatters
+    if tooltips is not None:
+        hover = HoverTool(tooltips=tooltips, mode="vline", names=vbars_names)
+
+        if tooltips_formatters is not None:
+            hover.formatters = tooltips_formatters
+
+        plot.add_tools(hover)
+
+    # (Optional) Add server tap callback
+    if server_tap_callback is not None:
+        for vbar in vbars:
+            vbar.data_source.selected.on_change("indices", server_tap_callback)
 
     # Plot appearance
     plot.xgrid.grid_line_color = None

--- a/src/tools/ci/vfc_ci_report/static/index.js
+++ b/src/tools/ci/vfc_ci_report/static/index.js
@@ -105,18 +105,18 @@ document.getElementById("inspect-runs-button")
 });
 
 
-// Listen to clicks on "Asserts" non-deterministic button
-let assertsButtons = document.getElementsByClassName("asserts-button");
+// Listen to clicks on "Checks" non-deterministic button
+let checksButtons = document.getElementsByClassName("checks-button");
 
-for (let i=0; i<assertsButtons.length; i++) {
-    assertsButtons[i].addEventListener("click", () => {
-        changeView("non-deterministic-asserts");
+for (let i=0; i<checksButtons.length; i++) {
+    checksButtons[i].addEventListener("click", () => {
+        changeView("non-deterministic-checks");
     });
 }
 
-document.getElementById("asserts-deterministic-button")
+document.getElementById("checks-deterministic-button")
 .addEventListener("click", () => {
-    changeView("deterministic-asserts");
+    changeView("deterministic-checks");
 });
 
 

--- a/src/tools/ci/vfc_ci_report/static/index.js
+++ b/src/tools/ci/vfc_ci_report/static/index.js
@@ -56,6 +56,7 @@ document.getElementById("navbar-burger")
 
 // Helper function to navigate between views
 function changeView(classPrefix) {
+    window.scrollTo(0, 0);
 
     // Enable/disable the active class on buttons
     let buttons = document.getElementById("buttons-container").childNodes;
@@ -84,22 +85,39 @@ function changeView(classPrefix) {
     }
 }
 
-// Listen to clicks on "Compare runs" button
-document.getElementById("compare-runs-button").addEventListener("click", () => {
-    // Nothing else to do for this button
-    changeView("compare-runs");
-});
+// Listen to clicks on "Compare runs" non-deterministic button
+let compareButtons = document.getElementsByClassName("compare-runs-button");
 
-// Listen to clicks on "Inspect runs" button
-// (dedicated function as this needs to be called in a CustomJS callback)
-function goToInspectRuns() {
-    window.scrollTo(0, 0);
-
-    changeView("inspect-runs");
+for (let i=0; i<compareButtons.length; i++) {
+    compareButtons[i].addEventListener("click", () => {
+        changeView("compare-runs");
+    });
 }
 
+// Listen to clicks on "Compare runs" deterministic button
+document.getElementById("deterministic-button").addEventListener("click", () => {
+    changeView("deterministic");
+});
+
 document.getElementById("inspect-runs-button")
-.addEventListener("click", goToInspectRuns);
+.addEventListener("click", () => {
+    changeView("inspect-runs")
+});
+
+
+// Listen to clicks on "Asserts" non-deterministic button
+let assertsButtons = document.getElementsByClassName("asserts-button");
+
+for (let i=0; i<assertsButtons.length; i++) {
+    assertsButtons[i].addEventListener("click", () => {
+        changeView("non-deterministic-asserts");
+    });
+}
+
+document.getElementById("asserts-deterministic-button")
+.addEventListener("click", () => {
+    changeView("deterministic-asserts");
+});
 
 
 
@@ -133,7 +151,8 @@ setTimeout(pollBokehLoading, 100);
 
 
 // Update the run metadata (in inspect run mode)
-function updateRunMetadata(runId) {
+// Prefix will be appended to all DOM elements' ids
+function updateRunMetadata(runId, prefix) {
 
     // Assume runId is the run's timestamp
     let run = metadata[runId];
@@ -143,7 +162,7 @@ function updateRunMetadata(runId) {
     if(!run) {
         for(let [key, value] of Object.entries(metadata)) {
 
-            if (!metadata.hasOwnProperty(key)) continue;
+            if(!metadata.hasOwnProperty(key)) continue;
             if(value.name == runId) {
                 run = value;
                 break;
@@ -167,27 +186,27 @@ function updateRunMetadata(runId) {
 
 
     // Edit innerHTML with new metadata
-    document.getElementById("run-date").innerHTML = run.date;
+    document.getElementById(prefix + "run-date").innerHTML = run.date;
 
     if(run.is_git_commit) {
-        document.getElementById("is-git-commit").style.display = "";
-        document.getElementById("not-git-commit").style.display = "none";
+        document.getElementById(prefix + "is-git-commit").style.display = "";
+        document.getElementById(prefix + "not-git-commit").style.display = "none";
 
-        document.getElementById("run-hash").innerHTML = run.hash;
-        document.getElementById("run-author").innerHTML = run.author;
-        document.getElementById("run-message").innerHTML = run.message;
+        document.getElementById(prefix + "run-hash").innerHTML = run.hash;
+        document.getElementById(prefix + "run-author").innerHTML = run.author;
+        document.getElementById(prefix + "run-message").innerHTML = run.message;
 
-        document.getElementById("git-commit-link")
+        document.getElementById(prefix + "git-commit-link")
         .setAttribute("href", commit_link);
-        document.getElementById("git-commit-link")
+        document.getElementById(prefix + "git-commit-link")
         .innerHTML = "View this commit on " + gitHost;
 
     } else {
-        document.getElementById("is-git-commit").style.display = "none";
-        document.getElementById("not-git-commit").style.display = "";
+        document.getElementById(prefix + "is-git-commit").style.display = "none";
+        document.getElementById(prefix + "not-git-commit").style.display = "";
 
-        document.getElementById("run-hash").innerHTML = "";
-        document.getElementById("run-author").innerHTML = "";
-        document.getElementById("run-message").innerHTML = "";
+        document.getElementById(prefix + "run-hash").innerHTML = "";
+        document.getElementById(prefix + "run-author").innerHTML = "";
+        document.getElementById(prefix + "run-message").innerHTML = "";
     }
 }

--- a/src/tools/ci/vfc_ci_report/templates/index.html
+++ b/src/tools/ci/vfc_ci_report/templates/index.html
@@ -45,12 +45,12 @@
                 display : none; /* Hidden by default */
             }
 
-            #deterministic-asserts-container {
+            #deterministic-checks-container {
                 margin-top: 1em;
                 display : none; /* Hidden by default */
             }
 
-            #non-deterministic-asserts-container {
+            #non-deterministic-checks-container {
                 margin-top: 1em;
                 display : none; /* Hidden by default */
             }
@@ -152,15 +152,15 @@
 
                     <div class="navbar-item has-dropdown is-hoverable">
 
-                        <a class="navbar-link asserts-button">
-                            Asserts table
+                        <a class="navbar-link checks-button">
+                            Checks table
                         </a>
 
                         <div class="navbar-dropdown">
-                            <a class="navbar-item asserts-button">
+                            <a class="navbar-item checks-button">
                             Non-deterministic backends
                             </a>
-                            <a class="navbar-item" id="asserts-deterministic-button">
+                            <a class="navbar-item" id="checks-deterministic-button">
                             Deterministic backends
                             </a>
                         </div>
@@ -374,14 +374,14 @@
             </div>
         </main>
 
-        <!-- CONTENT : ASSERTS NON-DETERMINISTIC -->
-        <main class="container" id="non-deterministic-asserts-container">
+        <!-- CONTENT : CHECKS NON-DETERMINISTIC -->
+        <main class="container" id="non-deterministic-checks-container">
             <div class="columns">
 
                 <!-- SELECTORS -->
                 <div class="column">
                     <h4 class="title is-4">Selectors</h4>
-                    {{ embed(roots.select_assert_run_non_deterministic) }}
+                    {{ embed(roots.select_check_run_non_deterministic) }}
 
                     <br>
                     <br>
@@ -389,35 +389,35 @@
                     <h4 class="title is-4">Run metadata</h4>
 
                     <b>Date :</b>
-                    <div id="non-deterministic-asserts-run-date" style="display: inline;">
+                    <div id="non-deterministic-checks-run-date" style="display: inline;">
                     </div>
 
                     <br>
 
-                    <div id="non-deterministic-asserts-is-git-commit">
+                    <div id="non-deterministic-checks-is-git-commit">
 
                         <b>Hash :</b>
-                        <div id="non-deterministic-asserts-run-hash" style="display: inline;">
+                        <div id="non-deterministic-checks-run-hash" style="display: inline;">
                         </div>
                         <br>
                         <b>Author :</b>
-                        <div id="non-deterministic-asserts-run-author" style="display: inline;">
+                        <div id="non-deterministic-checks-run-author" style="display: inline;">
                         </div>
                         <br>
                         <b>Message :</b>
-                        <div id="non-deterministic-asserts-run-message" style="display: inline;">
+                        <div id="non-deterministic-checks-run-message" style="display: inline;">
                         </div>
 
                         <br>
                         <br>
 
-                        <a id="non-deterministic-asserts-git-commit-link" href="" target="_blank">
+                        <a id="non-deterministic-checks-git-commit-link" href="" target="_blank">
                             View this commit on
                         </a>
 
                     </div>
 
-                    <div id="non-deterministic-asserts-not-git-commit">
+                    <div id="non-deterministic-checks-not-git-commit">
 
                         This run is not linked to a Git commit.
 
@@ -428,28 +428,28 @@
                 <!-- PLOTS -->
                 <div class="column is-9">
                     <div style="display: flex; margin-bottom: 24px;">
-                        <h3 class="title is-3" style="margin: 0;">Asserts table</h3>
+                        <h3 class="title is-3" style="margin: 0;">Checks table</h3>
                         <span style="align-self: flex-end; margin-left: 10px;">
                             (non-deterministic backends)
                         </span>
                     </div>
 
                     <div class="card plot-card">
-                        {{ embed(roots.non_deterministic_asserts_table) }}
+                        {{ embed(roots.non_deterministic_checks_table) }}
                     </div>
 
                 </div>
             </div>
         </main>
 
-        <!-- CONTENT : ASSERTS DETERMINISTIC -->
-        <main class="container" id="deterministic-asserts-container">
+        <!-- CONTENT : CHECKS DETERMINISTIC -->
+        <main class="container" id="deterministic-checks-container">
             <div class="columns">
 
                 <!-- SELECTORS -->
                 <div class="column">
                     <h4 class="title is-4">Selectors</h4>
-                    {{ embed(roots.select_assert_run_deterministic) }}
+                    {{ embed(roots.select_check_run_deterministic) }}
 
                     <br>
                     <br>
@@ -457,35 +457,35 @@
                     <h4 class="title is-4">Run metadata</h4>
 
                     <b>Date :</b>
-                    <div id="deterministic-asserts-run-date" style="display: inline;">
+                    <div id="deterministic-checks-run-date" style="display: inline;">
                     </div>
 
                     <br>
 
-                    <div id="deterministic-asserts-is-git-commit">
+                    <div id="deterministic-checks-is-git-commit">
 
                         <b>Hash :</b>
-                        <div id="deterministic-asserts-run-hash" style="display: inline;">
+                        <div id="deterministic-checks-run-hash" style="display: inline;">
                         </div>
                         <br>
                         <b>Author :</b>
-                        <div id="deterministic-asserts-run-author" style="display: inline;">
+                        <div id="deterministic-checks-run-author" style="display: inline;">
                         </div>
                         <br>
                         <b>Message :</b>
-                        <div id="deterministic-asserts-run-message" style="display: inline;">
+                        <div id="deterministic-checks-run-message" style="display: inline;">
                         </div>
 
                         <br>
                         <br>
 
-                        <a id="deterministic-asserts-git-commit-link" href="" target="_blank">
+                        <a id="deterministic-checks-git-commit-link" href="" target="_blank">
                             View this commit on
                         </a>
 
                     </div>
 
-                    <div id="deterministic-asserts-not-git-commit">
+                    <div id="deterministic-checks-not-git-commit">
 
                         This run is not linked to a Git commit.
 
@@ -496,14 +496,14 @@
                 <!-- PLOTS -->
                 <div class="column is-9">
                     <div style="display: flex; margin-bottom: 24px;">
-                        <h3 class="title is-3" style="margin: 0;">Asserts table</h3>
+                        <h3 class="title is-3" style="margin: 0;">Checks table</h3>
                         <span style="align-self: flex-end; margin-left: 10px;">
                             (deterministic backends)
                         </span>
                     </div>
 
                     <div class="card plot-card">
-                        {{ embed(roots.deterministic_asserts_table) }}
+                        {{ embed(roots.deterministic_checks_table) }}
                     </div>
 
                 </div>
@@ -534,8 +534,8 @@
 
         changeRepository("{{initial_repo}}");
         updateRunMetadata({{initial_timestamp}}, "");
-        updateRunMetadata({{initial_timestamp}}, "non-deterministic-asserts-");
-        updateRunMetadata({{initial_timestamp}}, "deterministic-asserts-");
+        updateRunMetadata({{initial_timestamp}}, "non-deterministic-checks-");
+        updateRunMetadata({{initial_timestamp}}, "deterministic-checks-");
     </script>
 
     {% endblock %}

--- a/src/tools/ci/vfc_ci_report/templates/index.html
+++ b/src/tools/ci/vfc_ci_report/templates/index.html
@@ -35,9 +35,24 @@
                 margin-top: 1em;
             }
 
+            #deterministic-container {
+                margin-top: 1em;
+                display : none; /* Hidden by default */
+            }
+
             #inspect-runs-container {
                 margin-top: 1em;
-                display : none; /* This one is hidden by default */
+                display : none; /* Hidden by default */
+            }
+
+            #deterministic-asserts-container {
+                margin-top: 1em;
+                display : none; /* Hidden by default */
+            }
+
+            #non-deterministic-asserts-container {
+                margin-top: 1em;
+                display : none; /* Hidden by default */
             }
 
             .plot-card {
@@ -107,19 +122,50 @@
             <!-- MENU (content) -->
             <div id="navbar-content" class="navbar-menu">
 
-                <div id="buttons-container" class="navbar-start">
+                <div id="buttons-container" class="navbar-menu">
 
                     <div id="select-repo" style="margin-top: 15px;">
                         {{ embed(roots.select_repo) }}
                     </div>
 
-                    <a class="navbar-item is-active" id="compare-runs-button">
-                        Compare runs
-                    </a>
+                    <div class="navbar-item has-dropdown is-hoverable">
+
+                        <a class="navbar-link compare-runs-button">
+                            Compare runs
+                        </a>
+
+                        <div class="navbar-dropdown">
+                            <a class="navbar-item compare-runs-button">
+                            Non-deterministic backends
+                            </a>
+                            <a class="navbar-item" id="deterministic-button">
+                            Deterministic backends
+                            </a>
+                        </div>
+
+                    </div>
 
                     <a class="navbar-item" id="inspect-runs-button">
                         Inspect runs
                     </a>
+
+
+                    <div class="navbar-item has-dropdown is-hoverable">
+
+                        <a class="navbar-link asserts-button">
+                            Asserts table
+                        </a>
+
+                        <div class="navbar-dropdown">
+                            <a class="navbar-item asserts-button">
+                            Non-deterministic backends
+                            </a>
+                            <a class="navbar-item" id="asserts-deterministic-button">
+                            Deterministic backends
+                            </a>
+                        </div>
+
+                    </div>
                 </div>
 
                 <div class="navbar-end">
@@ -143,7 +189,7 @@
             </div>
         </nav>
 
-        <!-- CONTENT : COMPARE RUNS -->
+        <!-- CONTENT : COMPARE RUNS (NON DETERMINISTIC)-->
         <main class="container" id="compare-runs-container">
             <div class="columns">
 
@@ -169,7 +215,13 @@
 
                 <!-- PLOTS -->
                 <div class="column is-9">
-                    <h3 class="title is-3">Plots</h3>
+                    <div style="display: flex; margin-bottom: 24px;">
+                        <h3 class="title is-3" style="margin: 0;">Plots</h3>
+                        <span style="align-self: flex-end; margin-left: 10px;">
+                            (non-deterministic backends)
+                        </span>
+                    </div>
+
                     <div class="container">
                         <div class="card plot-card">
                             {{ embed(roots.s_tabs) }}
@@ -186,6 +238,50 @@
                         <div class="card plot-card">
                             {{ embed(roots.boxplot) }}
                         </div>
+                    </div>
+                </div>
+
+            </div>
+        </main>
+
+        <!-- CONTENT : COMPARE RUNS (DETERMINISTIC)-->
+        <main class="container" id="deterministic-container">
+
+            <div class="columns">
+
+                <!-- SELECTORS -->
+                <div class="column">
+                    <h4 class="title is-4">Selectors</h4>
+                    <div id="compare-widgets">
+                        {{ embed(roots.deterministic_test_filter) }} {{ embed(roots.select_deterministic_test) }}
+                        <br> {{ embed(roots.select_deterministic_var) }}
+                        <br> {{ embed(roots.select_deterministic_backend) }}
+                        <br> {{ embed(roots.outliers_filtering_deterministic) }}
+                        <br>
+                        <br> {{ embed(roots.select_n_deterministic_runs) }}
+
+                        <br>
+                        <br>
+                    </div>
+                </div>
+
+                <div class="is-divider-vertical"></div>
+
+                <!-- PLOTS -->
+                <div class="column is-9">
+                    <div style="display: flex; margin-bottom: 24px;">
+                        <h3 class="title is-3" style="margin: 0;">Plots</h3>
+                        <span style="align-self: flex-end; margin-left: 10px;">
+                            (deterministic backends)
+                        </span>
+                    </div>
+
+                    <div class="container">
+                        <div class="card plot-card">
+                            {{ embed(roots.comparison_plot) }}
+                        </div>
+
+                        <br>
                     </div>
                 </div>
 
@@ -251,7 +347,13 @@
 
                 <!-- PLOTS -->
                 <div class="column is-9">
-                    <h3 class="title is-3">Plots</h3>
+                    <div style="display: flex; margin-bottom: 24px;">
+                        <h3 class="title is-3" style="margin: 0;">Plots</h3>
+                        <span style="align-self: flex-end; margin-left: 10px;">
+                            (runs inspection)
+                        </span>
+                    </div>
+
                     <div class="card plot-card" style="z-index: 3;">
                         {{ embed(roots.s_tabs_inspect) }}
                     </div>
@@ -272,6 +374,141 @@
             </div>
         </main>
 
+        <!-- CONTENT : ASSERTS NON-DETERMINISTIC -->
+        <main class="container" id="non-deterministic-asserts-container">
+            <div class="columns">
+
+                <!-- SELECTORS -->
+                <div class="column">
+                    <h4 class="title is-4">Selectors</h4>
+                    {{ embed(roots.select_assert_run_non_deterministic) }}
+
+                    <br>
+                    <br>
+
+                    <h4 class="title is-4">Run metadata</h4>
+
+                    <b>Date :</b>
+                    <div id="non-deterministic-asserts-run-date" style="display: inline;">
+                    </div>
+
+                    <br>
+
+                    <div id="non-deterministic-asserts-is-git-commit">
+
+                        <b>Hash :</b>
+                        <div id="non-deterministic-asserts-run-hash" style="display: inline;">
+                        </div>
+                        <br>
+                        <b>Author :</b>
+                        <div id="non-deterministic-asserts-run-author" style="display: inline;">
+                        </div>
+                        <br>
+                        <b>Message :</b>
+                        <div id="non-deterministic-asserts-run-message" style="display: inline;">
+                        </div>
+
+                        <br>
+                        <br>
+
+                        <a id="non-deterministic-asserts-git-commit-link" href="" target="_blank">
+                            View this commit on
+                        </a>
+
+                    </div>
+
+                    <div id="non-deterministic-asserts-not-git-commit">
+
+                        This run is not linked to a Git commit.
+
+                    </div>
+
+                </div>
+
+                <!-- PLOTS -->
+                <div class="column is-9">
+                    <div style="display: flex; margin-bottom: 24px;">
+                        <h3 class="title is-3" style="margin: 0;">Asserts table</h3>
+                        <span style="align-self: flex-end; margin-left: 10px;">
+                            (non-deterministic backends)
+                        </span>
+                    </div>
+
+                    <div class="card plot-card">
+                        {{ embed(roots.non_deterministic_asserts_table) }}
+                    </div>
+
+                </div>
+            </div>
+        </main>
+
+        <!-- CONTENT : ASSERTS DETERMINISTIC -->
+        <main class="container" id="deterministic-asserts-container">
+            <div class="columns">
+
+                <!-- SELECTORS -->
+                <div class="column">
+                    <h4 class="title is-4">Selectors</h4>
+                    {{ embed(roots.select_assert_run_deterministic) }}
+
+                    <br>
+                    <br>
+
+                    <h4 class="title is-4">Run metadata</h4>
+
+                    <b>Date :</b>
+                    <div id="deterministic-asserts-run-date" style="display: inline;">
+                    </div>
+
+                    <br>
+
+                    <div id="deterministic-asserts-is-git-commit">
+
+                        <b>Hash :</b>
+                        <div id="deterministic-asserts-run-hash" style="display: inline;">
+                        </div>
+                        <br>
+                        <b>Author :</b>
+                        <div id="deterministic-asserts-run-author" style="display: inline;">
+                        </div>
+                        <br>
+                        <b>Message :</b>
+                        <div id="deterministic-asserts-run-message" style="display: inline;">
+                        </div>
+
+                        <br>
+                        <br>
+
+                        <a id="deterministic-asserts-git-commit-link" href="" target="_blank">
+                            View this commit on
+                        </a>
+
+                    </div>
+
+                    <div id="deterministic-asserts-not-git-commit">
+
+                        This run is not linked to a Git commit.
+
+                    </div>
+
+                </div>
+
+                <!-- PLOTS -->
+                <div class="column is-9">
+                    <div style="display: flex; margin-bottom: 24px;">
+                        <h3 class="title is-3" style="margin: 0;">Asserts table</h3>
+                        <span style="align-self: flex-end; margin-left: 10px;">
+                            (deterministic backends)
+                        </span>
+                    </div>
+
+                    <div class="card plot-card">
+                        {{ embed(roots.deterministic_asserts_table) }}
+                    </div>
+
+                </div>
+            </div>
+        </main>
     </div>
 
     <!--- LOADER -->
@@ -296,7 +533,9 @@
         }
 
         changeRepository("{{initial_repo}}");
-        updateRunMetadata({{initial_timestamp}});
+        updateRunMetadata({{initial_timestamp}}, "");
+        updateRunMetadata({{initial_timestamp}}, "non-deterministic-asserts-");
+        updateRunMetadata({{initial_timestamp}}, "deterministic-asserts-");
     </script>
 
     {% endblock %}


### PR DESCRIPTION
This PR brings two important features for Verificarlo CI : 

- **Support for deterministic backends** (such as VPREC) : if a backend is considered deterministic, a large part of the data processing will be ignored (computation of significant digits, etc ...), and results from this backend will be shown separately in the report.
- **Asserts system** : Probes can now optionally be linked with an "assert". This is corresponds to an accuracy target for the variable, which will be checked in preprocessing. Asserts can be used with both deterministic and non-deterministic backends, and can be of absolute or relative type. For each case, the way to validate the probe is different.

Documentation has also been updated to explain those features more in details.