### PR TITLE
Minor corrections to vfc_probes and documentation

### DIFF
--- a/doc/06-Postprocessing.md
+++ b/doc/06-Postprocessing.md
@@ -168,8 +168,8 @@ table :
 
 | |Absolute|Relative|
 --- | --- | ---
-|Non-deterministic|\|Standard deviation\| < Target | \|Standard deviation\| / \|Empirical average\| < Target
-|Deterministic|\|IEEE value\| -  \|Backend value\| < Target|(\|IEEE value\| -  \|Backend value\|) / \|IEEE value\| < Target
+|Non-deterministic|\|Standard deviation\| < Target | Standard deviation / \|Empirical average\| < Target
+|Deterministic|\|IEEE value -  Backend value\| < Target|\|IEEE value -  Backend value\| / \|IEEE value\| < Target
 
 By default, the standard deviation is used to estimate the error, and must be
 inferior to the accuracy threshold for the probe to pass (or inferior to the

--- a/doc/06-Postprocessing.md
+++ b/doc/06-Postprocessing.md
@@ -107,8 +107,13 @@ To use `vfc_probes` in your tests, simply include its header file :
 #include <vfc_probes.h>
 ```
 
-... and build your code with the the `-lvfc_probes` flag to link the shared
-library.
+... and build your code with the the `-lvfc_probes` flag to link the library.
+
+**Note** : If you were to compile some `vfc_probes` tests with an other
+compiler than Verificarlo, you would get errors because of undefined references
+to some functions used by `vfc_probes`. If you ever need to write tests that
+could be compiled with or without Verificarlo, you should probably wrap calls
+to `vfc_probes` functions inside preprocessor conditionals.
 
 All your probes will be stored in the `vfc_probes` structure. Here is how it
 should be initialized :

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,5 @@
 noinst_LTLIBRARIES = libtinymt64.la libvprec_tools.la libvfc_hashmap.la
+lib_LIBRARIES = libvfc_probes.a
 
 libtinymt64_la_CFLAGS = -fPIC -static
 libtinymt64_la_SOURCES = \
@@ -15,16 +16,13 @@ libvfc_hashmap_la_SOURCES = \
 	vfc_hashmap.h \
 	vfc_hashmap.c
 
-
-lib_LTLIBRARIES = libvfc_probes.la
-
-libvfc_probes_la_SOURCES = vfc_hashmap.c vfc_probes.c
-if WALL_CFLAGS
-libvfc_probes_la_CFLAGS = -Wall -Wextra
-endif
+libvfc_probes_a_CFLAGS = -fPIC -static
+libvfc_probes_a_SOURCES = \
+	vfc_probes.h \
+	vfc_probes.c
 
 if BUILD_FLANG
-lib_LIBRARIES = libvfc_probes_f.a
+lib_LIBRARIES += libvfc_probes_f.a
 libvfc_probes_f_a_SOURCES = vfc_probes_f.f90
 library_includedir =$(includedir)/
 include_HEADERS = vfc_probes_f.mod

--- a/src/common/vfc_probes.c
+++ b/src/common/vfc_probes.c
@@ -181,7 +181,7 @@ int vfc_probe_kernel(vfc_probes *probes, char *testName, char *varName,
   newProbe->key = key;
   newProbe->value = val;
   newProbe->accuracyThreshold = accuracyThreshold;
-  newProbe->mode = malloc(sizeof(char) * strlen(mode));
+  newProbe->mode = malloc(sizeof(char) * (strlen(mode) + 1));
   strcpy(newProbe->mode, mode);
 
   vfc_hashmap_insert(probes->map, vfc_hashmap_str_function(key), newProbe);

--- a/src/common/vfc_probes.h
+++ b/src/common/vfc_probes.h
@@ -42,6 +42,10 @@
 #define VAR_NAME(var) #var // Simply returns the name of var into a string
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // A probe containing a double value as well as its key, which is needed when
 // dumping the probes. Optionally, an accuracy threshold can be defined : it
 // will be re-used in the preprocessing to (un)validate the probe.
@@ -110,3 +114,7 @@ int vfc_probe_check_f(vfc_probes *probes, char *testName, char *varName,
 int vfc_probe_check_relative_f(vfc_probes *probes, char *testName,
                                char *varName, double *val,
                                double *accuracyThreshold);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
- Modify `Makefile.am` for `vfc_probes` (made it a simple static library instead of a libtool library)
- Use `extern "c"` in `vfc_probes` to avoid name mangling issues when using `vfc_probes` in C++
- Correction of typos in formulas of the `vfc_ci` doc

Before merging the PR, we might want to investigate on an issue with `vfc_ci` test that might happen with older versions of Scipy (for the Shapiro-Wilk test). If this is only a version issue, and not a problem with the code, then no other changes should be required.