### PR TITLE
testplan.test should preserve environment when running tests

### DIFF
--- a/tests/testplan.test
+++ b/tests/testplan.test
@@ -10,7 +10,7 @@ echo "1..$count"
 test_number=1
 for t in $tests; do
     echo $t
-    if bash -c -l "cd $t && ./test.sh > test.log 2>&1" ; then
+    if bash -c "cd $t && ./test.sh > test.log 2>&1" ; then
     echo
         echo "ok $test_number $t"
     else


### PR DESCRIPTION
When using custom path --prefix installations, tests broke because the local PATH and PYTHONPATH environment were not preserved. To fix this avoid running tests inside a log shell as this does not preserve the environment.