### PR TITLE
Fix name display issue in vfc_ci report

### DIFF
--- a/src/tools/ci/vfc_ci_report/helper.py
+++ b/src/tools/ci/vfc_ci_report/helper.py
@@ -184,7 +184,7 @@ def get_run_name(timestamp, hash):
         str = "%s week%s ago"
     # > 1 month
     else:
-        n = diff / 2592000
+        n = int(diff / 2592000)
         str = "%s month%s ago"
 
     plural = ""


### PR DESCRIPTION
As explained in 2ef47d2 :

Run names older than one month in the report used to not be rounded as
expected. This caused the name to show the number of elapsed month as a
float. -> Simply fixed by ading the missing call to int.