### PR TITLE
Redirect logger_info to stdout instead of stderr

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 Verificarlo CHANGELOG
 
+# [Unreleased]
+
+## Changed
+  * VFC_BACKENDS_LOGGER=False behaviour. Now truly disable logger_info output.
+  * Redirect logger_info to stdout instead of stderr
 
 # [v0.7.0] 2022/01/22
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ Verificarlo CHANGELOG
 
 # [Unreleased]
 
+## Added
+  * Add VFC_BACKENDS_LOGFILE environment variable to redirect logger_info to a file
 ## Changed
   * VFC_BACKENDS_LOGGER=False behaviour. Now truly disable logger_info output.
   * Redirect logger_info to stdout instead of stderr

--- a/doc/02-Backends.md
+++ b/doc/02-Backends.md
@@ -80,6 +80,17 @@ environment variable `VFC_BACKENDS_COLORED_LOGGER`.
    $ export VFC_BACKENDS_COLORED_LOGGER="False"
 ```
 
+To redirect the logger info, export the
+environment variable `VFC_BACKENDS_LOGFILE`.
+Verificarlo will suffix the name with the current TID. 
+
+```bash
+   $ export VFC_BACKENDS_LOGFILE='verificarlo.log'
+   $ ./test
+   $ ls
+   $ verificarlo.log.3636865
+```
+
 The IEEE, MCA, MCA-MPFR, Bitmask and Cancellation backends are all re-entrant.
 
 ### IEEE Backend (libinterflop_ieee.so)

--- a/src/common/logger.c
+++ b/src/common/logger.c
@@ -124,14 +124,14 @@ void logger_info(const char *fmt, ...) {
   va_start(ap, fmt);
   if (logger_enabled) {
     if (logger_colored) {
-      fprintf(stderr, "%sInfo%s [%s%s%s]: ", ansi_colors[info_color],
+      fprintf(stdout, "%sInfo%s [%s%s%s]: ", ansi_colors[info_color],
               ansi_colors[reset_color], ansi_colors[backend_color],
               BACKEND_HEADER_STR, ansi_colors[reset_color]);
     } else {
-      fprintf(stderr, "Info [%s]: ", BACKEND_HEADER_STR);
+      fprintf(stdout, "Info [%s]: ", BACKEND_HEADER_STR);
     }
+    vfprintf(stdout, fmt, ap);
   }
-  vfprintf(stderr, fmt, ap);
 }
 
 /* Display the warning message */
@@ -170,14 +170,14 @@ void logger_error(const char *fmt, ...) {
 void vlogger_info(const char *fmt, va_list argp) {
   if (logger_enabled) {
     if (logger_colored) {
-      fprintf(stderr, "%sInfo%s [%s%s%s]: ", ansi_colors[info_color],
+      fprintf(stdout, "%sInfo%s [%s%s%s]: ", ansi_colors[info_color],
               ansi_colors[reset_color], ansi_colors[backend_color],
               BACKEND_HEADER_STR, ansi_colors[reset_color]);
     } else {
-      fprintf(stderr, "Info [%s]: ", BACKEND_HEADER_STR);
+      fprintf(stdout, "Info [%s]: ", BACKEND_HEADER_STR);
     }
+    vfprintf(stdout, fmt, argp);
   }
-  vfprintf(stderr, fmt, argp);
 }
 
 /* Display the warning message */

--- a/src/common/logger.c
+++ b/src/common/logger.c
@@ -18,11 +18,15 @@
  *                                                                           *\
  ****************************************************************************/
 #include <err.h>
+#include <errno.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <strings.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #define str(X) #X
 #define xstr(X) str(X)
@@ -32,6 +36,8 @@
 #endif
 
 #define BACKEND_HEADER_STR xstr(BACKEND_HEADER)
+
+static const char backend_header[] = BACKEND_HEADER_STR;
 
 /* ANSI colors */
 typedef enum {
@@ -88,11 +94,15 @@ typedef enum {
 /* Environment variable for enabling/disabling the logger */
 static const char vfc_backends_logger[] = "VFC_BACKENDS_LOGGER";
 
+/* Environment variable for specifying the verificarlo logger output file */
+static const char vfc_backends_logfile[] = "VFC_BACKENDS_LOGFILE";
+
 /* Environment variable for enabling/disabling the color */
 static const char vfc_backends_colored_logger[] = "VFC_BACKENDS_COLORED_LOGGER";
 
 static bool logger_enabled = true;
 static bool logger_colored = false;
+static FILE *logger_logfile = NULL;
 
 /* Returns true if the logger is enabled */
 bool is_logger_enabled(void) {
@@ -118,78 +128,95 @@ bool is_logger_colored(void) {
   }
 }
 
+pid_t get_tid() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+  return gettid();
+#pragma GCC diagnostic pop
+}
+
+void _error() {
+  int errsv = errno;
+  const int BUFF_SIZE = 512;
+  char buff[BUFF_SIZE];
+  strerror_r(errsv, buff, BUFF_SIZE);
+  err(EXIT_FAILURE, "Error [%s]: %s", BACKEND_HEADER_STR, buff);
+}
+
+void set_logger_logfile(void) {
+  if (logger_logfile != NULL) {
+    return;
+  }
+  const char *logger_logfile_env = getenv(vfc_backends_logfile);
+  if (logger_logfile_env == NULL) {
+    logger_logfile = stdout;
+  } else {
+    /* Create log file specific to TID to avoid non-deterministic output */
+    char tmp[1024];
+    sprintf(tmp, "%s.%d", logger_logfile_env, get_tid());
+    logger_logfile = fopen(tmp, "a");
+    if (logger_logfile == NULL) {
+      _error();
+    }
+  }
+}
+
+void logger_header(FILE *stream, const char *lvl_name,
+                   const level_color lvl_color, const bool colored) {
+  if (colored) {
+    fprintf(stream, "%s%s%s [%s%s%s]: ", ansi_colors[lvl_color], lvl_name,
+            ansi_colors[reset_color], ansi_colors[backend_color],
+            BACKEND_HEADER_STR, ansi_colors[reset_color]);
+  } else {
+    fprintf(stream, "%s [%s]: ", lvl_name, backend_header);
+  }
+}
+
 /* Display the info message */
 void logger_info(const char *fmt, ...) {
-  va_list ap;
-  va_start(ap, fmt);
   if (logger_enabled) {
-    if (logger_colored) {
-      fprintf(stdout, "%sInfo%s [%s%s%s]: ", ansi_colors[info_color],
-              ansi_colors[reset_color], ansi_colors[backend_color],
-              BACKEND_HEADER_STR, ansi_colors[reset_color]);
-    } else {
-      fprintf(stdout, "Info [%s]: ", BACKEND_HEADER_STR);
-    }
-    vfprintf(stdout, fmt, ap);
+    logger_header(logger_logfile, "Info", info_color, logger_colored);
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(logger_logfile, fmt, ap);
+    va_end(ap);
   }
 }
 
 /* Display the warning message */
 void logger_warning(const char *fmt, ...) {
+  if (logger_enabled) {
+    logger_header(stderr, "Warning", warning_color, logger_colored);
+  }
   va_list ap;
   va_start(ap, fmt);
-  if (logger_enabled) {
-    if (logger_colored) {
-      fprintf(stderr, "%sWarning%s [%s%s%s]: ", ansi_colors[warning_color],
-              ansi_colors[reset_color], ansi_colors[backend_color],
-              BACKEND_HEADER_STR, ansi_colors[reset_color]);
-    } else {
-      fprintf(stderr, "Warning [%s]: ", BACKEND_HEADER_STR);
-    }
-  }
   vwarnx(fmt, ap);
+  va_end(ap);
 }
 
 /* Display the error message */
 void logger_error(const char *fmt, ...) {
+  if (logger_enabled) {
+    logger_header(stderr, "Error", error_color, logger_colored);
+  }
   va_list ap;
   va_start(ap, fmt);
-  if (logger_enabled) {
-    if (logger_colored) {
-      fprintf(stderr, "%sError%s [%s%s%s]: ", ansi_colors[error_color],
-              ansi_colors[reset_color], ansi_colors[backend_color],
-              BACKEND_HEADER_STR, ansi_colors[reset_color]);
-    } else {
-      fprintf(stderr, "Error [%s]: ", BACKEND_HEADER_STR);
-    }
-  }
   verrx(EXIT_FAILURE, fmt, ap);
+  va_end(ap);
 }
 
 /* Display the info message */
 void vlogger_info(const char *fmt, va_list argp) {
   if (logger_enabled) {
-    if (logger_colored) {
-      fprintf(stdout, "%sInfo%s [%s%s%s]: ", ansi_colors[info_color],
-              ansi_colors[reset_color], ansi_colors[backend_color],
-              BACKEND_HEADER_STR, ansi_colors[reset_color]);
-    } else {
-      fprintf(stdout, "Info [%s]: ", BACKEND_HEADER_STR);
-    }
-    vfprintf(stdout, fmt, argp);
+    logger_header(logger_logfile, "Info", info_color, logger_colored);
+    vfprintf(logger_logfile, fmt, argp);
   }
 }
 
 /* Display the warning message */
 void vlogger_warning(const char *fmt, va_list argp) {
   if (logger_enabled) {
-    if (logger_colored) {
-      fprintf(stderr, "%sWarning%s [%s%s%s]: ", ansi_colors[warning_color],
-              ansi_colors[reset_color], ansi_colors[backend_color],
-              BACKEND_HEADER_STR, ansi_colors[reset_color]);
-    } else {
-      fprintf(stderr, "Warning [%s]: ", BACKEND_HEADER_STR);
-    }
+    logger_header(stderr, "Warning", warning_color, logger_colored);
   }
   vwarnx(fmt, argp);
 }
@@ -197,19 +224,13 @@ void vlogger_warning(const char *fmt, va_list argp) {
 /* Display the error message */
 void vlogger_error(const char *fmt, va_list argp) {
   if (logger_enabled) {
-    if (logger_colored) {
-      fprintf(stderr, "%sError%s [%s%s%s]: ", ansi_colors[error_color],
-              ansi_colors[reset_color], ansi_colors[backend_color],
-              BACKEND_HEADER_STR, ansi_colors[reset_color]);
-    } else {
-      fprintf(stderr, "Error [%s]: ", BACKEND_HEADER_STR);
-    }
+    logger_header(stderr, "Error", error_color, logger_colored);
   }
   verrx(EXIT_FAILURE, fmt, argp);
 }
 
 void logger_init(void) {
-
   logger_enabled = is_logger_enabled();
   logger_colored = is_logger_colored();
+  set_logger_logfile();
 }

--- a/tests/test_bitmask_backend/test.sh
+++ b/tests/test_bitmask_backend/test.sh
@@ -45,6 +45,8 @@ GCC=${GCC_PATH}
 $GCC -D REAL=double -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_float -lquadmath
 $GCC -D REAL=float -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_double -lquadmath
 
+export VFC_BACKENDS_LOGGER=False
+
 # Test operates at different precisions, and different operands.
 # It compares that results are equivalents up to the bit.
 verificarlo-c --function=operate --verbose -D REAL=float -D SAMPLES=$SAMPLES -O0 test.c -o test_float

--- a/tests/test_daz_ftz/test.sh
+++ b/tests/test_daz_ftz/test.sh
@@ -31,6 +31,7 @@ compare() {
     check_success
 }
 
+export VFC_BACKENDS_LOGGER=False
 export VFC_BACKENDS_SILENT_LOAD="TRUE"
 
 rm -f run_parallel

--- a/tests/test_ddebug_archimedes/test.sh
+++ b/tests/test_ddebug_archimedes/test.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+export VFC_BACKENDS_LOGGER=False
+
 make clean
 make dd
 
-if grep "archimedes.c:16" dd.line/rddmin-cmp/dd.line.exclude ; then
-  if grep "archimedes.c:17" dd.line/rddmin-cmp/dd.line.exclude ; then
+if grep "archimedes.c:16" dd.line/rddmin-cmp/dd.line.exclude; then
+  if grep "archimedes.c:17" dd.line/rddmin-cmp/dd.line.exclude; then
     echo "success !"
     exit 0
   else

--- a/tests/test_ddebug_canc/test.sh
+++ b/tests/test_ddebug_canc/test.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
+export VFC_BACKENDS_LOGGER=False
+
 make clean
 make dd
 
-if grep "archimedes.c:16" dd.line/rddmin-cmp/dd.line.exclude ; then
-    echo "line 16 should not be flagged (round-off)"
-    exit 1
+if grep "archimedes.c:16" dd.line/rddmin-cmp/dd.line.exclude; then
+  echo "line 16 should not be flagged (round-off)"
+  exit 1
 fi
 
-if grep "archimedes.c:17" dd.line/rddmin-cmp/dd.line.exclude ; then
-    echo "success !"
-    exit 0
-  else
-    echo "missing line 17 (cancellation)"
-    exit 1
+if grep "archimedes.c:17" dd.line/rddmin-cmp/dd.line.exclude; then
+  echo "success !"
+  exit 0
+else
+  echo "missing line 17 (cancellation)"
+  exit 1
 fi

--- a/tests/test_ddebug_integration/test.sh
+++ b/tests/test_ddebug_integration/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # set -e
 
+export VFC_BACKENDS_LOGGER=False
+
 make clean
 make dd
 
@@ -12,7 +14,7 @@ echo "Problematic instructions are:"
 cat dd.line/rddmin-cmp/dd.line.exclude
 echo "=============================================================="
 
-if grep "integrate.hxx:23" dd.line/rddmin-cmp/dd.line.exclude > /dev/null ; then
+if grep "integrate.hxx:23" dd.line/rddmin-cmp/dd.line.exclude >/dev/null; then
   echo "found integrate.hxx:23 in exclude rddmin"
 else
   echo "MISSING integrate.hxx:23 in exclude rddmin"

--- a/tests/test_ieee_backend/test_options.sh
+++ b/tests/test_ieee_backend/test_options.sh
@@ -2,33 +2,33 @@
 set -e
 
 export VFC_BACKENDS_SILENT_LOAD="true"
-export VFC_BACKENDS_LOGGER="false"
+export VFC_BACKENDS_LOGGER="true"
 
 run() {
     export VFC_BACKENDS="libinterflop_ieee.so ${DEBUG_MODE} ${OPTIONS}"
     echo -e "\n### ${VFC_BACKENDS}"
-    ./test_options 2> log
+    ./test_options >log
 }
 
 eval_condition() {
-    
+
     if [[ $? != 0 ]]; then
-	echo 0
+        echo 0
     else
-	echo 1
+        echo 1
     fi
 }
 
 check() {
-  
+
     RESULT=$1
     ERROR_MSG=$2
-    
-    if [[ "$RESULT" != 0 ]] ; then
-       echo $ERROR_MSG
-       exit 1
+
+    if [[ "$RESULT" != 0 ]]; then
+        echo $ERROR_MSG
+        exit 1
     else
-	echo "[ok]"
+        echo "[ok]"
     fi
 }
 
@@ -39,36 +39,57 @@ for TYPE in float double; do
     DEBUG_MODE="--debug"
     OPTIONS=""
     run
-    check "$(grep -q "Decimal" log; echo $?)" "Error debug mode (Decimal) not printed"
+    check "$(
+        grep -q "Decimal" log
+        echo $?
+    )" "Error debug mode (Decimal) not printed"
 
     DEBUG_MODE="--debug-binary"
     OPTIONS=""
-    run   
-    check "$(grep -q "Binary" log; echo $?)" "Error debug mode (Decimal_bin) not printed"
+    run
+    check "$(
+        grep -q "Binary" log
+        echo $?
+    )" "Error debug mode (Decimal_bin) not printed"
 
     DEBUG_MODE="--debug"
     OPTIONS="--no-backend-name"
     run
-    check "$(grep -vq "Decimal" log; echo $?)" "Error debug mode (Decimal) printed"
+    check "$(
+        grep -vq "Decimal" log
+        echo $?
+    )" "Error debug mode (Decimal) printed"
 
     DEBUG_MODE="--debug-binary"
     OPTIONS="--no-backend-name"
     run
-    check "$(grep -vq "Binary" log; echo $?)" "Error debug mode (Binary) printed"
+    check "$(
+        grep -vq "Binary" log
+        echo $?
+    )" "Error debug mode (Binary) printed"
 
     DEBUG_MODE="--debug"
     OPTIONS="--print-new-line"
     run
-    check "$(grep -vq "Decimal" log; echo $?)" "Error no new lines printed"
+    check "$(
+        grep -vq "Decimal" log
+        echo $?
+    )" "Error no new lines printed"
 
     DEBUG_MODE="--debug-binary"
     OPTIONS="--print-new-line"
     run
-    check "$(test '$(wc -l log)'; echo $?)" "Error no new lines printed"
+    check "$(
+        test '$(wc -l log)'
+        echo $?
+    )" "Error no new lines printed"
 
     DEBUG_MODE="--count-op"
     OPTIONS=""
     run
-    check "$(grep -vq "add=" log; echo $?)" "Error no counts printed"
+    check "$(
+        grep -vq "add=" log
+        echo $?
+    )" "Error no counts printed"
 
 done

--- a/tests/test_logger/test.c
+++ b/tests/test_logger/test.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) { return 0; }

--- a/tests/test_logger/test.sh
+++ b/tests/test_logger/test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+OUTPUT_FILE=output
+ERROR_FILE=error
+
+show_env() {
+    echo "VFC_BACKENDS_LOGGER=${VFC_BACKENDS_LOGGER}"
+    echo "VFC_BACKENDS_SILENT_LOAD=${VFC_BACKENDS_SILENT_LOAD}"
+    echo "VFC_BACKENDS_LOGFILE=${VFC_BACKENDS_LOGFILE}"
+    echo "VFC_BACKENDS=${VFC_BACKENDS}"
+}
+
+reset_env() {
+    unset VFC_BACKENDS_LOGGER
+    unset VFC_BACKENDS_SILENT_LOAD
+    unset VFC_BACKENDS_LOGFILE
+    export VFC_BACKENDS="libinterflop_mca.so"
+    rm -f $OUTPUT_FILE $ERROR_FILE test.log.*
+}
+
+check() {
+    RESULT=${1}
+    ERROR_MSG=${2}
+    if [[ "$RESULT" != 0 ]]; then
+        echo "[not ok]"
+        show_env
+        echo "${ERROR_MSG}"
+        exit 1
+    else
+        echo "[ok]"
+    fi
+}
+
+check_empty() {
+    check "$(
+        [ ! -s $1 ]
+        echo $?
+    )" "${2}"
+}
+
+check_non_empty() {
+    check "$(
+        [ -s $1 ]
+        echo $?
+    )" "${2}"
+}
+
+check_logger_info() {
+    check "$(
+        grep -q "Info \[verificarlo\]" ${1}
+        echo $?
+    )" "${2}"
+}
+
+check_backend_info() {
+    check "$(
+        grep -q "Info \[interflop_mca\]" ${1}
+        echo $?
+    )" "${2}"
+}
+
+compile() {
+    verificarlo test.c -o test
+}
+
+run() {
+    ./test >$OUTPUT_FILE 2>$ERROR_FILE
+}
+
+compile
+
+echo "* Test 1: Check logger_info is redirected on stdout by default"
+reset_env
+run
+check_logger_info $OUTPUT_FILE "Error: logger_info not displayed on stdout"
+check_backend_info $OUTPUT_FILE "Error: logger_info not displayed on stdout"
+check_empty $ERROR_FILE "Error: stderr non empty"
+
+echo "* Test 2: Check VFC_BACKENDS_LOGGER=False disables the logger_info"
+reset_env
+export VFC_BACKENDS_LOGGER=False
+run
+check_empty $OUTPUT_FILE "Error: logger displayed on stdout"
+check_empty $ERROR_FILE "Error: logger displayed on stderr"
+
+echo "* Test 3: Check VFC_BACKENDS_LOGFILE='test.log' redirects logger_info into test.log"
+reset_env
+export VFC_BACKENDS_LOGGER=True
+export VFC_BACKENDS_LOGFILE='test.log'
+run
+check_empty $OUTPUT_FILE "Error: logger_info displayed on stdout"
+check_empty $ERROR_FILE "Error: logger_info displayed on stderr"
+check_logger_info test.log.* "Error: logger_info not displayed on test.log"
+check_backend_info test.log.* "Error: logger_info not displayed on test.log"
+
+echo "* Test 4: Check logger_error is displayed when an error occured and VFC_BACKENDS_LOGFILE is set"
+reset_env
+export VFC_BACKENDS_LOGGER=True
+export VFC_BACKENDS=""
+export VFC_BACKENDS_LOGFILE="test.log"
+run
+check_empty $OUTPUT_FILE "Error: logger_error displayed on stdout"
+check_empty test.log.* "Error: logger_error displayed on test.log"
+check_non_empty $ERROR_FILE "Error: logger_error not displayed on stderr"
+
+echo "* Test 5: Check logger_error is displayed when an error occured and VFC_BACKENDS_LOGGER=False"
+reset_env
+export VFC_BACKENDS_LOGGER=False
+export VFC_BACKENDS=""
+run
+check_empty $OUTPUT_FILE "Error: logger_error displayed on stdout"
+check_empty test.log.* "Error: logger_error displayed on test.log"
+check_non_empty $ERROR_FILE "Error: logger_error not displayed on stderr"

--- a/tests/test_rr_mode_exact/compute_error.sh
+++ b/tests/test_rr_mode_exact/compute_error.sh
@@ -10,6 +10,7 @@ cd $TMPDIR
 
 export VFC_BACKENDS="$BACKEND ${PREC} --mode rr"
 for i in $(seq 100); do
+    export VFC_BACKENDS_LOGFILE="tmp"
     ${BIN} >>output_${BACKEND}_${EXP}
 done
 echo Testing $EXP with $BACKEND

--- a/tests/test_rr_mode_exact/test.sh
+++ b/tests/test_rr_mode_exact/test.sh
@@ -6,12 +6,11 @@ for EXP in FLOAT FLOAT_POW2 DOUBLE DOUBLE_POW2; do
 done
 
 rm -f run_parallel
-for BACKEND in libinterflop_mca.so; do
-  for PREC in "--precision-binary32=24" "--precision-binary64=53"; do
-    echo Testing $EXP with $BACKEND
-    BIN=$PWD/rr_mode_${EXP,,}
-    echo "./compute_error.sh ${BACKEND} ${EXP} ${PREC} ${BIN}" >>run_parallel
-  done
+export BACKEND=libinterflop_mca.so
+for PREC in "--precision-binary32=24" "--precision-binary64=53"; do
+  echo Testing $EXP with $BACKEND
+  BIN=$PWD/rr_mode_${EXP,,}
+  echo "./compute_error.sh ${BACKEND} ${EXP} ${PREC} ${BIN}" >>run_parallel
 done
 
 parallel -j $(nproc) <run_parallel

--- a/tests/test_vprec_backend/generic_test.sh
+++ b/tests/test_vprec_backend/generic_test.sh
@@ -4,6 +4,8 @@
 ##uncomment to show all command executed by the script
 #set -x
 
+export VFC_BACKENDS_LOGGER=False
+
 if [[ $# != 6 ]]; then
 	echo "expected 5 arguments, $# given"
 	echo "usecase range_min range_step precision_min precision_step n_samples"

--- a/tests/test_vprec_backend_simple/test.sh
+++ b/tests/test_vprec_backend_simple/test.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 set -xe
 
+export VFC_BACKENDS_LOGGER=False
 
 ## Denormal tests for range 2, precision 3
-cat > input.txt << EOF
+cat >input.txt <<EOF
 0x1.a53a8b6373154p-1 0x1.cfa1850291880p-4
 -0x1.6312bf6a7f2f8p-1 -0x1.5b403af9711e8p-3
 0x1.e4f85f0e582c0p-1 0x1.4b57c729ba5e0p-3
@@ -16,8 +17,7 @@ EOF
 ./compare.sh FULL 2 3 float x input.txt
 
 ## Denormal tests for range 2, precision 23
-cat > input.txt << EOF
+cat >input.txt <<EOF
 -0x1.eee201b1c85d4p-1 0x1.22034fafd4a10p-4
 EOF
 ./compare.sh FULL 2 23 float x input.txt
-

--- a/tests/test_vprec_instrument/test.sh
+++ b/tests/test_vprec_instrument/test.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 #set -e
 
+export VFC_BACKENDS_LOGGER=False
+
 verificarlo-c test_mantissa.c -o test_mantissa --inst-func -lm
 
 # mode none
 rm -f output.txt
 
-echo "--------------------------------------------------------------" >> output.txt
-echo "							 Mantissa 							" >> output.txt
-echo "--------------------------------------------------------------" >> output.txt
-printf "\n------------------- Instrumentation = None -------------------\n" >> output.txt
+echo "--------------------------------------------------------------" >>output.txt
+echo "							 Mantissa 							" >>output.txt
+echo "--------------------------------------------------------------" >>output.txt
+printf "\n------------------- Instrumentation = None -------------------\n" >>output.txt
 
 export VFC_BACKENDS="libinterflop_vprec.so --prec-output-file=config.txt"
-./test_mantissa 52 23 >> /dev/null
+./test_mantissa 52 23 >>/dev/null
 
 double_arr=(1 26 51)
 float_arr=(1 11 22)
@@ -20,143 +22,141 @@ float_arr=(1 11 22)
 for i in 0 1 2; do
 	./set_input_file config.txt ${double_arr[$i]} 11 ${float_arr[$i]} 8 Ffloat/powf main/Fdouble main/Ffloat Fdouble/pow
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=none --mode=ib"
-	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=none --mode=ob"
-	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 done
 
 # mode arguments
 
-printf "\n---------------- Instrumentation = Arguments -----------------\n" >> output.txt
+printf "\n---------------- Instrumentation = Arguments -----------------\n" >>output.txt
 
 for i in 0 1 2; do
 	./set_input_file config.txt ${double_arr[$i]} 11 ${float_arr[$i]} 8 Ffloat/powf main/Fdouble main/Ffloat Fdouble/pow
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=arguments --mode=ib"
-	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=arguments --mode=ob"
-	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 done
 
 # mode operations
 
-printf "\n--------------- Instrumentation = Operations -----------------\n" >> output.txt
+printf "\n--------------- Instrumentation = Operations -----------------\n" >>output.txt
 
 for i in 0 1 2; do
 	./set_input_file config.txt ${double_arr[$i]} 11 ${float_arr[$i]} 8 Ffloat/powf main/Fdouble main/Ffloat Fdouble/pow
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=operations --mode=ib"
-	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=operations --mode=ob"
-	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 done
 
 # mode all
 
-printf "\n------------------ Instrumentation = All --------------------\n" >> output.txt
+printf "\n------------------ Instrumentation = All --------------------\n" >>output.txt
 
 for i in 0 1 2; do
 	./set_input_file config.txt ${double_arr[$i]} 11 ${float_arr[$i]} 8 Ffloat/powf main/Fdouble main/Ffloat Fdouble/pow
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=all --mode=ib"
-	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	InBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=all --mode=ob"
-	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >> output.txt
-	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >> output.txt
+	printf "\n	OutBound Rounding at bit of the mantissa ${double_arr[$i]} in double precision and at bit ${float_arr[$i]} in single precision\n\n" >>output.txt
+	./test_mantissa ${double_arr[$i]} ${float_arr[$i]} >>output.txt
 done
 
 verificarlo-c test_exponent.c -o test_exponent --inst-func -lm
 
-echo "--------------------------------------------------------------" >> output.txt
-echo "							 Exponent 							" >> output.txt
-echo "--------------------------------------------------------------" >> output.txt
-echo "" >> output.txt
+echo "--------------------------------------------------------------" >>output.txt
+echo "							 Exponent 							" >>output.txt
+echo "--------------------------------------------------------------" >>output.txt
+echo "" >>output.txt
 
 export VFC_BACKENDS="libinterflop_vprec.so --prec-output-file=config.txt"
-./test_exponent 52 23 >> /dev/null
+./test_exponent 52 23 >>/dev/null
 
 double_arr=(11 10)
 float_arr=(8 7)
 
 # mode none
 
-printf "\n------------------- Instrumentation = None -------------------\n" >> output.txt
+printf "\n------------------- Instrumentation = None -------------------\n" >>output.txt
 
 for i in 0 1; do
 	./set_input_file config.txt 52 ${double_arr[$i]} 23 ${float_arr[$i]} main/Fdouble main/Ffloat
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=none --mode=ib"
-	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=none --mode=ob"
-	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 done
 
 # mode arguments
 
-printf "\n---------------- Instrumentation = Arguments -----------------\n" >> output.txt
+printf "\n---------------- Instrumentation = Arguments -----------------\n" >>output.txt
 
 for i in 0 1; do
 	./set_input_file config.txt 52 ${double_arr[$i]} 23 ${float_arr[$i]} main/Fdouble main/Ffloat
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=arguments --mode=ib"
-	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=arguments --mode=ob"
-	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 done
 
 # mode operations
 
-printf "\n--------------- Instrumentation = Operations -----------------\n" >> output.txt
+printf "\n--------------- Instrumentation = Operations -----------------\n" >>output.txt
 
 for i in 0 1; do
 	./set_input_file config.txt 52 ${double_arr[$i]} 23 ${float_arr[$i]} main/Fdouble main/Ffloat
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=operations --mode=ib"
-	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=operations --mode=ob"
-	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 done
 
 # mode all
 
-printf "\n------------------ Instrumentation = All --------------------\n" >> output.txt
+printf "\n------------------ Instrumentation = All --------------------\n" >>output.txt
 
 for i in 0 1; do
 	./set_input_file config.txt 52 ${double_arr[$i]} 23 ${float_arr[$i]} main/Fdouble main/Ffloat
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=all --mode=ib"
-	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	InBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 	export VFC_BACKENDS="libinterflop_vprec.so --prec-input-file=config.txt --instrument=all --mode=ob"
-	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >> output.txt
-	./test_exponent >> output.txt
+	printf "\n	OutBound Rounding of the exponent at bit ${double_arr[$i]} in double precision and ${float_arr[$i]} in simple precision\n\n" >>output.txt
+	./test_exponent >>output.txt
 done
 
-echo "--------------------------------------------------------------" >> output.txt
-echo "							 Range 							" >> output.txt
-echo "--------------------------------------------------------------" >> output.txt
-echo "" >> output.txt
+echo "--------------------------------------------------------------" >>output.txt
+echo "							 Range 							" >>output.txt
+echo "--------------------------------------------------------------" >>output.txt
+echo "" >>output.txt
 
 verificarlo-c test_range.c -o test_range --inst-func -lm
 
 export VFC_BACKENDS="libinterflop_vprec.so --prec-output-file=config.txt"
 
-printf "Functions Fdouble and Ffloat take real numbers from 1 to 102 and from -1 to -102 and subtract 10 \n\n" >> output.txt
+printf "Functions Fdouble and Ffloat take real numbers from 1 to 102 and from -1 to -102 and subtract 10 \n\n" >>output.txt
 
 ./test_range
-./print_range config.txt main/Ffloat main/Fdouble >> output.txt
+./print_range config.txt main/Ffloat main/Fdouble >>output.txt
 
-if [ $(diff -U 0 result.txt output.txt | grep ^@ | wc -l) == 0 ]
-then 
+if [ $(diff -U 0 result.txt output.txt | grep ^@ | wc -l) == 0 ]; then
 	exit 0
-else 
+else
 	echo $(diff -U 0 result.txt output.txt | grep ^@ | wc -l)
 	exit 1
 fi
-


### PR DESCRIPTION
- Redirect logger_info to stdout instead of stderr since it is not an error output
-  Modify VFC_BACKENDS_LOGGER=False behaviour to disable logger_info outputs.