### PR TITLE
Clean-up configure.ac and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PYTHONPATH /usr/local/lib/python$PYTHON_VERSION/site-packages/:$PYTHONPATH
 # Retrieve dependencies
 RUN apt-get -y update && apt-get -y --no-install-recommends install tzdata
 RUN apt-get -y install --no-install-recommends \
-    bash ca-certificates make git libmpfr-dev \
+    bash ca-certificates make git \
     autogen dh-autoreconf autoconf automake autotools-dev libedit-dev libtool libz-dev binutils \
     clang-${LLVM_VERSION} llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
     gcc-${GCC_VERSION} g++-${GCC_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PYTHONPATH /usr/local/lib/python$PYTHON_VERSION/site-packages/:$PYTHONPATH
 # Retrieve dependencies
 RUN apt-get -y update && apt-get -y --no-install-recommends install tzdata
 RUN apt-get -y install --no-install-recommends \
-    bash ca-certificates make git \
+    bash ca-certificates make git libmpfr-dev \
     autogen dh-autoreconf autoconf automake autotools-dev libedit-dev libtool libz-dev binutils \
     clang-${LLVM_VERSION} llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev \
     gcc-${GCC_VERSION} g++-${GCC_VERSION} \

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ Verificarlo includes different numerical backends. Please refer to the [backends
 
   * [IEEE Backend (libinterflop_ieee.so)](doc/02-Backends.md#ieee-backend-libinterflop_ieeeso)
   * [MCA Backend (libinterflop_mca.so)](doc/02-Backends.md#mca-backend-libinterflop_mcaso)
-  * [MCA-MPFR Backend (libinterflop_mca_mpfr.so)](doc/02-Backends.md#mca-mpfr-backend-libinterflop_mca_mpfrso)
   * [Bitmask Backend (libinterflop_bitmask.so)](doc/02-Backends.md#bitmask-backend-libinterflop_bitmaskso)
   * [Cancellation Backend (libinterflop_cancellation.so)](doc/02-Backends.md#cancellation-backend-libinterflop_cancellationso)
   * [VPREC Backend (libinterflop_vprec.so)](doc/02-Backends.md#vprec-backend-libinterflop_vprecso)

--- a/configure.ac
+++ b/configure.ac
@@ -85,17 +85,22 @@ else
    AC_SUBST(FC, $FLANG)
 fi
 
+# Check for parallel (required for the test infrastructure)
+AC_PATH_PROG(PARALLEL, [parallel], [])
+if test -z "$PARALLEL"; then
+  AC_MSG_ERROR([Could not find parallel])
+fi
+
 AC_CHECK_LIB([c], [exit], , AC_MSG_ERROR([Could not find c library]))
-AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find mpfr library]))
-AC_CHECK_LIB([mpfr], [mpfr_clear], , AC_MSG_ERROR([Could not find mpfr library]))
+AC_CHECK_LIB([m], [sin], , AC_MSG_ERROR([Could not find math library]))
 
 # Reset libs after ac_check_lib We do not want each and every backend or the
-# libvfcinstrument frontend to be linked against libmpfr or libgfortran for
+# libvfcinstrument frontend to be linked against libgfortran for
 # example. -l flags should be added individually in each Makefile.am
 LIBS=""
 
 # Check for header files.
-AC_CHECK_HEADERS([fcntl.h float.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h mpfr.h], , AC_MSG_ERROR([Missing required headers]))
+AC_CHECK_HEADERS([fcntl.h float.h inttypes.h limits.h malloc.h stdint.h stdlib.h string.h sys/time.h unistd.h utime.h], , AC_MSG_ERROR([Missing required headers]))
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/doc/01-Install.md
+++ b/doc/01-Install.md
@@ -2,10 +2,9 @@
 
 Please ensure that Verificarlo's dependencies are installed on your system:
 
-  * GNU mpfr library http://www.mpfr.org/
   * LLVM, clang and opt from 4.0 up to 11.0.1, http://clang.llvm.org/
   * gcc from 4.9
-  * flang for Fortran support
+  * flang for Fortran support (optional)
   * python3 with the following packages :
     * numpy
     * scipy (version 1.5.0 or above)
@@ -16,6 +15,7 @@ Please ensure that Verificarlo's dependencies are installed on your system:
     * jinja2
     * bokeh
   * autotools (automake, autoconf)
+  * parallel (only required for running the test suite)
 
 Then run the following command inside verificarlo directory:
 

--- a/doc/02-Backends.md
+++ b/doc/02-Backends.md
@@ -91,7 +91,7 @@ Verificarlo will suffix the name with the current TID.
    $ verificarlo.log.3636865
 ```
 
-The IEEE, MCA, MCA-MPFR, Bitmask and Cancellation backends are all re-entrant.
+The IEEE, MCA, Bitmask and Cancellation backends are all re-entrant.
 
 ### IEEE Backend (libinterflop_ieee.so)
 
@@ -159,7 +159,7 @@ operations count:
 
 The MCA backends implements Montecarlo Arithmetic.  It uses quad type to
 compute MCA operations on doubles and double type to compute MCA operations
-on floats. It is much faster than the legacy MCA-MPFR backend.
+on floats.
 
 ```bash
 VFC_BACKENDS="libinterflop_mca.so --help" ./test

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -144,7 +144,7 @@ def linker_mode(sources, options, libraries, output, args):
     f = tempfile.NamedTemporaryFile(mode='w+')
     sources = ' '.join([os.path.splitext(s)[0]+'.o' for s in sources])
     if args.static:
-        cmd = f'{output} {sources} {options} {libraries} {vfcwrapper_o} -static  -lmpfr -lgmp -lm -ldl'
+        cmd = f'{output} {sources} {options} {libraries} {vfcwrapper_o} -static -lgmp -lm -ldl'
     else:
         cmd = f'{output} {sources} {options} {libraries} {vfcwrapper_o} {mcalib_options} -ldl'
 


### PR DESCRIPTION
- Remove obsolete checks, library dependencies and documentation references to MPFR.
- Add check for `parallel` in configure.ac.