### PR TITLE
Add `interflop_call` function into `interflop_backend_interface_t`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ Verificarlo CHANGELOG
 
 ## Added
   * Add VFC_BACKENDS_LOGFILE environment variable to redirect logger_info to a file
+  * Add `interflop_call` function into interflop_backend_interface_t interface.
+  Allows user to directly call low-level backend functions
+  * Add INTERFLOP_CALL_INEXACT allowing to directly perturb one fp value through `interflop_call` mechanism
+  * Add test_usercall_inexact to test the INTERFLOP_CALL_INEXACT user call
 ## Changed
   * VFC_BACKENDS_LOGGER=False behaviour. Now truly disable logger_info output.
   * Redirect logger_info to stdout instead of stderr

--- a/src/backends/interflop-bitmask/interflop_bitmask.c
+++ b/src/backends/interflop-bitmask/interflop_bitmask.c
@@ -13,7 +13,7 @@
  *  Copyright (c) 2018                                                       *\
  *     Universite de Versailles St-Quentin-en-Yvelines                       *\
  *                                                                           *\
- *  Copyright (c) 2019-2021                                                  *\
+ *  Copyright (c) 2019-2022                                                  *\
  *     Verificarlo Contributors                                              *\
  *                                                                           *\
  ****************************************************************************/
@@ -530,6 +530,7 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
       _interflop_sub_double,
       _interflop_mul_double,
       _interflop_div_double,
+      NULL,
       NULL,
       NULL,
       NULL,

--- a/src/backends/interflop-cancellation/interflop_cancellation.c
+++ b/src/backends/interflop-cancellation/interflop_cancellation.c
@@ -13,7 +13,7 @@
  *  Copyright (c) 2018                                                       *\
  *     Universite de Versailles St-Quentin-en-Yvelines                       *\
  *                                                                           *\
- *  Copyright (c) 2019-2021                                                  *\
+ *  Copyright (c) 2019-2022                                                  *\
  *     Verificarlo Contributors                                              *\
  *                                                                           *\
  ****************************************************************************/
@@ -218,6 +218,7 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
       _interflop_sub_double,
       _interflop_mul_double,
       _interflop_div_double,
+      NULL,
       NULL,
       NULL,
       NULL,

--- a/src/backends/interflop-ieee/interflop_ieee.c
+++ b/src/backends/interflop-ieee/interflop_ieee.c
@@ -13,7 +13,7 @@
  *  Copyright (c) 2018                                                       *\
  *     Universite de Versailles St-Quentin-en-Yvelines                       *\
  *                                                                           *\
- *  Copyright (c) 2019-2021                                                  *\
+ *  Copyright (c) 2019-2022                                                  *\
  *     Verificarlo Contributors                                              *\
  *                                                                           *\
  ****************************************************************************/
@@ -418,6 +418,7 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
       _interflop_mul_double,
       _interflop_div_double,
       _interflop_cmp_double,
+      NULL,
       NULL,
       NULL,
       _interflop_finalize};

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -13,7 +13,7 @@
  *  Copyright (c) 2018                                                       *\
  *     Universite de Versailles St-Quentin-en-Yvelines                       *\
  *                                                                           *\
- *  Copyright (c) 2019-2021                                                  *\
+ *  Copyright (c) 2019-2022                                                  *\
  *     Verificarlo Contributors                                              *\
  *                                                                           *\
  ****************************************************************************/
@@ -1636,6 +1636,7 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
       NULL,
       _interflop_enter_function,
       _interflop_exit_function,
+      NULL,
       _interflop_finalize};
 
   return interflop_backend_vprec;

--- a/src/common/interflop.h
+++ b/src/common/interflop.h
@@ -24,6 +24,17 @@ enum FCMP_PREDICATE {
 /* Enumeration of types managed by function instrumentation */
 enum FTYPES { FFLOAT, FDOUBLE, FFLOAT_PTR, FDOUBLE_PTR, FTYPES_END };
 
+typedef enum {
+  /* Allows perturbing one floating-point value */
+  /* signature: void inexact(enun FTYPES type, void *value) */
+  INTERFLOP_INEXACT_ID = 1,
+  INTERFLOP_CUSTOM_ID = -1
+} interflop_call_id;
+
+/* User function to directly call low-level backend functions */
+/* Takes an id to identify the actual function to call and variadic argument */
+void interflop_call(interflop_call_id id, ...);
+
 typedef struct interflop_function_info {
   // Indicate the identifier of the function
   char *id;
@@ -64,6 +75,7 @@ struct interflop_backend_interface_t {
   void (*interflop_exit_function)(interflop_function_stack_t *stack,
                                   void *context, int nb_args, va_list ap);
 
+  void (*interflop_user_call)(void *context, interflop_call_id id, va_list ap);
   /* interflop_finalize: called at the end of the instrumented program
    * execution */
   void (*interflop_finalize)(void *context);

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -85,10 +85,10 @@ void _init_rng_state_struct(rng_state_t *rng_state, bool choose_seed,
 
 /* Get a new identifier for the calling thread */
 /* Generic threads can have inconsistent identifiers, assigned by the system, */
-/* we therefore need to set an order between threads, for the case
+/* we therefore need to set an order between threads, for the case */
 /* when the seed is fixed, to insure some repeatability between executions */
-/* @param global_tid_lock pointer to the mutex controling the access to the
- * Unique TID */
+/* @param global_tid_lock pointer to the mutex controling the access to the */
+/* Unique TID */
 /* @param global_tid pointer to the unique TID */
 /* @return a new unique identifier for each calling thread*/
 unsigned long long int _get_new_tid(pthread_mutex_t *global_tid_lock,
@@ -97,8 +97,8 @@ unsigned long long int _get_new_tid(pthread_mutex_t *global_tid_lock,
 /* Returns a 64-bit unsigned integer r (0 <= r < 2^64) */
 /* Manages the internal state of the RNG, if necessary */
 /* @param rng_state pointer to the structure holding all the RNG-related data */
-/* @param global_tid_lock pointer to the mutex controling the access to the
- * Unique TID */
+/* @param global_tid_lock pointer to the mutex controling the access to the */
+/* Unique TID */
 /* @param global_tid pointer to the unique TID */
 /* @return a 64-bit unsigned integer r (0 <= r < 2^64) */
 uint64_t _get_rand_uint64(rng_state_t *rng_state,
@@ -108,8 +108,8 @@ uint64_t _get_rand_uint64(rng_state_t *rng_state,
 /* Returns a random double in the (0,1) open interval */
 /* Manages the internal state of the RNG, if necessary */
 /* @param rng_state pointer to the structure holding all the RNG-related data */
-/* @param global_tid_lock pointer to the mutex controling the access to the
- * Unique TID */
+/* @param global_tid_lock pointer to the mutex controling the access to the */
+/* Unique TID */
 /* @param global_tid pointer to the unique TID */
 /* @return a floating point number r (0.0 < r < 1.0) */
 double _get_rand(rng_state_t *rng_state, pthread_mutex_t *global_tid_lock,

--- a/src/vfcwrapper/main.c
+++ b/src/vfcwrapper/main.c
@@ -452,6 +452,17 @@ __attribute__((constructor(0))) static void vfc_init(void) {
   } while (0)
 #endif
 
+void interflop_call(interflop_call_id id, ...) {
+  va_list ap;
+  for (unsigned char i = 0; i < loaded_backends; i++) {
+    if (backends[i].interflop_user_call) {
+      va_start(ap, id);
+      backends[i].interflop_user_call(contexts[i], id, ap);
+      va_end(ap);
+    }
+  }
+}
+
 #define define_arithmetic_wrapper(precision, operation, operator)              \
   precision _##precision##operation(precision a, precision b) {                \
     precision c = NAN;                                                         \

--- a/tests/test_usercall_inexact/clean.sh
+++ b/tests/test_usercall_inexact/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -Rf log.* test_* *.o

--- a/tests/test_usercall_inexact/test.c
+++ b/tests/test_usercall_inexact/test.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <interflop.h>
+
+#ifndef REAL
+#error "REAL type not defined"
+#endif
+
+#ifndef N
+#error "Number of repetitions not defined"
+#endif
+
+void binary32_test() {
+  float x = 0.1f;
+  fprintf(stderr, "Before %.6a\n", x);
+  interflop_call(INTERFLOP_INEXACT_ID, FFLOAT, &x);
+  fprintf(stderr, "After  %.6a\n", x);
+}
+
+void binary64_test() {
+  double x = 0.1;
+  fprintf(stderr, "Before %.13a\n", x);
+  interflop_call(INTERFLOP_INEXACT_ID, FDOUBLE, &x);
+  fprintf(stderr, "After  %.13a\n", x);
+}
+
+#define DO_TEST(X) _Generic(X, float : binary32_test, double : binary64_test)()
+
+int main(int argc, char *argv[]) {
+
+  REAL x;
+
+  for (int i = 0; i < N; i++) {
+    DO_TEST(x);
+  }
+
+  return 0;
+}

--- a/tests/test_usercall_inexact/test.sh
+++ b/tests/test_usercall_inexact/test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+export VFC_BACKENDS_LOGGER=False
+export N=30
+
+echo $LD_LIBRARY_PATH
+
+clean() {
+    rm -f bfr.* aft.*
+}
+
+run_test() {
+    BACKEND=$1
+    REAL=$2
+    N=$3
+    RES=$4
+    echo "Test ${BACKEND}"
+    verificarlo-c test.c -DREAL=${REAL} -DN=${N} -o test_${REAL}
+    VFC_BACKENDS="${BACKEND}" ./test_${REAL} 2>log.${REAL}
+    grep "Before" log.${REAL} | grep -o '0x[0-9].[0-9a-f]*p[-+][0-9]*' >bfr.${REAL}
+    grep "After" log.${REAL} | grep -o '0x[0-9].[0-9a-f]*p[-+][0-9]*' >aft.${REAL}
+    diff bfr.${REAL} aft.${REAL}
+    if [[ $? == ${RES} ]]; then
+        echo "Test fail"
+        exit 1
+    fi
+}
+
+clean
+for REAL in float double; do
+    run_test "libinterflop_ieee.so" $REAL $N 1
+    clean
+    run_test "libinterflop_mca.so" $REAL $N 0
+    clean
+    run_test "libinterflop_mca.so -m ieee" $REAL $N 1
+    clean
+done


### PR DESCRIPTION
- Allows the user to call low-level backend functions directly
- Only implemented in the libinterflop_mca.so backend
- INTERFLOP_CALL_INEXACT: allows one to perturb one floating-point value directly. Perturbation is done at VIRTUAL_PRECISION - 1 to always introduce a noise, even when t=24 or t=53.