### PR TITLE
Add test to check MCA SR properties

### DIFF
--- a/tests/test_sr/check.py
+++ b/tests/test_sr/check.py
@@ -18,34 +18,42 @@ def read(name):
         freqs = freq(data)
     return freqs
 
+# TODO: Determine the tolerance precisely with a confidence interval depending
+# on the sampled iterations.
 TOLERANCE=15
 
 if __name__ == "__main__":
+    import sys
+    assert(len(sys.argv) == 2)
+    its = int(sys.argv[1])
     f = read("binary32-23")
     assert(len(f) == 1)
-    assert(f['0x1.4000020000000p+0'] == 100)
-    # For inexact24(1.0 + 2**-23) since the computed value is exact in 24 bits,
+    assert(f['0x1.4000020000000p+0'] == its)
+    # For inexact24(1.25 + 2**-23) since the computed value is exact in 24 bits,
     # SR (MCA RR 24) should preserve the value
 
     f = read("binary32-24")
     assert(len(f) == 2)
-    assert(50 - TOLERANCE < f['0x1.4000000000000p+0'] < 50 + TOLERANCE)
-    # For inexact24(1.0 + 2**-24) we are in the middle of the interval
+    target = its*50.0/100.
+    assert(target - TOLERANCE < f['0x1.4000000000000p+0'] < target + TOLERANCE)
+    # For inexact24(1.25 + 2**-24) we are in the middle of the interval
     # SR (MCA RR 24) should give us with 50% chance one of the two
     # upper and lower bounds 0x1.4000000000000p+0 and 0x1.4000020000000p+0
 
     f = read("binary32-25")
     assert(len(f) == 2)
-    assert(75 - TOLERANCE < f['0x1.4000000000000p+0'] < 75 + TOLERANCE)
-    # For inexact24(1.0 + 2**-25) we are in the quarter of the interval
+    target = its*75.0/100
+    assert(target - TOLERANCE < f['0x1.4000000000000p+0'] < target + TOLERANCE)
+    # For inexact24(1.25 + 2**-25) we are in the quarter of the interval
     # SR (MCA RR 24) should give us
     # upper and lower bounds 0x1.4000000000000p+0 and 0x1.4000020000000p+0
     # with probabilities 75% and 25% respectively
 
     f = read("binary32-26")
     assert(len(f) == 2)
-    assert(87.5 - TOLERANCE < f['0x1.4000000000000p+0'] < 87.5 + TOLERANCE)
-    # For inexact24(1.0 + 2**-26) we are in the eight of the interval
+    target = its*87.5/100
+    assert(target - TOLERANCE < f['0x1.4000000000000p+0'] < target + TOLERANCE)
+    # For inexact24(1.25 + 2**-26) we are in the eight of the interval
     # SR (MCA RR 24) should give us
     # upper and lower bounds 0x1.4000000000000p+0 and 0x1.4000020000000p+0
     # with probabilities 87.5% and 12.5% respectively
@@ -53,16 +61,19 @@ if __name__ == "__main__":
     # Assert similar properties for double precision
     f = read("binary64-52")
     assert(len(f) == 1)
-    assert(f['0x1.4000000000001p+0'] == 100)
+    assert(f['0x1.4000000000001p+0'] == its)
 
     f = read("binary64-53")
     assert(len(f) == 2)
-    assert(50 - TOLERANCE < f['0x1.4000000000000p+0'] < 50 + TOLERANCE)
+    target = its*50.0/100
+    assert(target - TOLERANCE < f['0x1.4000000000000p+0'] < target + TOLERANCE)
 
     f = read("binary64-54")
     assert(len(f) == 2)
-    assert(75 - TOLERANCE < f['0x1.4000000000000p+0'] < 75 + TOLERANCE)
+    target = its*75.0/100
+    assert(target - TOLERANCE < f['0x1.4000000000000p+0'] < target + TOLERANCE)
 
     f = read("binary64-55")
     assert(len(f) == 2)
-    assert(87.5 - TOLERANCE < f['0x1.4000000000000p+0'] < 87.5 + TOLERANCE)
+    target = its*87.5/100
+    assert(target - TOLERANCE < f['0x1.4000000000000p+0'] < target + TOLERANCE)

--- a/tests/test_sr/check.py
+++ b/tests/test_sr/check.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+def freq(l):
+    """ return dictionnary of frequencies """
+    freq = {}
+    for item in l:
+        if (item in freq):
+            freq[item] += 1
+        else:
+            freq[item] = 1
+    return freq
+
+
+def read(name):
+    """ read filename and returns the distribution of outputs as a dictionnary """
+    with open(name, "r") as f:
+        data = [x.strip() for x in f.readlines()]
+        freqs = freq(data)
+    return freqs
+
+TOLERANCE=15
+
+if __name__ == "__main__":
+    f = read("binary32-23")
+    assert(len(f) == 1)
+    assert(f['0x1.4000020000000p+0'] == 100)
+    # For inexact24(1.0 + 2**-23) since the computed value is exact in 24 bits,
+    # SR (MCA RR 24) should preserve the value
+
+    f = read("binary32-24")
+    assert(len(f) == 2)
+    assert(50 - TOLERANCE < f['0x1.4000000000000p+0'] < 50 + TOLERANCE)
+    # For inexact24(1.0 + 2**-24) we are in the middle of the interval
+    # SR (MCA RR 24) should give us with 50% chance one of the two
+    # upper and lower bounds 0x1.4000000000000p+0 and 0x1.4000020000000p+0
+
+    f = read("binary32-25")
+    assert(len(f) == 2)
+    assert(75 - TOLERANCE < f['0x1.4000000000000p+0'] < 75 + TOLERANCE)
+    # For inexact24(1.0 + 2**-25) we are in the quarter of the interval
+    # SR (MCA RR 24) should give us
+    # upper and lower bounds 0x1.4000000000000p+0 and 0x1.4000020000000p+0
+    # with probabilities 75% and 25% respectively
+
+    f = read("binary32-26")
+    assert(len(f) == 2)
+    assert(87.5 - TOLERANCE < f['0x1.4000000000000p+0'] < 87.5 + TOLERANCE)
+    # For inexact24(1.0 + 2**-26) we are in the eight of the interval
+    # SR (MCA RR 24) should give us
+    # upper and lower bounds 0x1.4000000000000p+0 and 0x1.4000020000000p+0
+    # with probabilities 87.5% and 12.5% respectively
+
+    # Assert similar properties for double precision
+    f = read("binary64-52")
+    assert(len(f) == 1)
+    assert(f['0x1.4000000000001p+0'] == 100)
+
+    f = read("binary64-53")
+    assert(len(f) == 2)
+    assert(50 - TOLERANCE < f['0x1.4000000000000p+0'] < 50 + TOLERANCE)
+
+    f = read("binary64-54")
+    assert(len(f) == 2)
+    assert(75 - TOLERANCE < f['0x1.4000000000000p+0'] < 75 + TOLERANCE)
+
+    f = read("binary64-55")
+    assert(len(f) == 2)
+    assert(87.5 - TOLERANCE < f['0x1.4000000000000p+0'] < 87.5 + TOLERANCE)

--- a/tests/test_sr/clean.sh
+++ b/tests/test_sr/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -Rf *~ binary32-* binary64-* sr-binary32 sr-binary64 logs/ *.o

--- a/tests/test_sr/sr-binary32.c
+++ b/tests/test_sr/sr-binary32.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char * argv[]){
+    assert(argc == 2);
+    int p = atoi(argv[1]);
+    float a = 1.25;
+    float b = pow(2, -p);
+
+    for (int i=0; i < 100; i++) {
+      printf("%.13a\n", a+b);
+    }
+    return 0;
+}

--- a/tests/test_sr/sr-binary32.c
+++ b/tests/test_sr/sr-binary32.c
@@ -9,7 +9,7 @@ int main(int argc, char * argv[]){
     float a = 1.25;
     float b = pow(2, -p);
 
-    for (int i=0; i < 100; i++) {
+    for (int i=0; i < ITERATIONS; i++) {
       printf("%.13a\n", a+b);
     }
     return 0;

--- a/tests/test_sr/sr-binary64.c
+++ b/tests/test_sr/sr-binary64.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char * argv[]){
+    assert(argc == 2);
+    int p = atoi(argv[1]);
+    double a = 1.25;
+    double b = pow(2, -p);
+
+    for (int i=0; i < 100; i++) {
+      printf("%.13a\n", a+b);
+    }
+    return 0;
+}

--- a/tests/test_sr/sr-binary64.c
+++ b/tests/test_sr/sr-binary64.c
@@ -9,7 +9,7 @@ int main(int argc, char * argv[]){
     double a = 1.25;
     double b = pow(2, -p);
 
-    for (int i=0; i < 100; i++) {
+    for (int i=0; i < ITERATIONS; i++) {
       printf("%.13a\n", a+b);
     }
     return 0;

--- a/tests/test_sr/test.sh
+++ b/tests/test_sr/test.sh
@@ -6,8 +6,10 @@ mkdir logs/
 export VFC_BACKENDS_LOGFILE="logs/verificarlo.log"
 export BACKEND="libinterflop_mca.so"
 
-verificarlo-c -O0 sr-binary32.c -o sr-binary32 -lm
-verificarlo-c -O0 sr-binary64.c -o sr-binary64 -lm
+ITERATIONS=100
+
+verificarlo-c -DITERATIONS=$ITERATIONS -O0 sr-binary32.c -o sr-binary32 -lm
+verificarlo-c -DITERATIONS=$ITERATIONS -O0 sr-binary64.c -o sr-binary64 -lm
 
 for p in 23 24 25 26; do
   for PREC in "--mode=rr --precision-binary32=24"; do
@@ -21,7 +23,7 @@ for p in 52 53 54 55; do
   done
 done
 
-./check.py
+./check.py $ITERATIONS
 status=$?
 
 if [ $status -eq 0 ]; then

--- a/tests/test_sr/test.sh
+++ b/tests/test_sr/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+rm -rf logs/ binary32-* binary64-* sr
+mkdir logs/
+export VFC_BACKENDS_LOGFILE="logs/verificarlo.log"
+export BACKEND="libinterflop_mca.so"
+
+verificarlo-c -O0 sr-binary32.c -o sr-binary32 -lm
+verificarlo-c -O0 sr-binary64.c -o sr-binary64 -lm
+
+for p in 23 24 25 26; do
+  for PREC in "--mode=rr --precision-binary32=24"; do
+    VFC_BACKENDS="$BACKEND $PREC" ./sr-binary32 $p > binary32-$p
+  done
+done
+
+for p in 52 53 54 55; do
+  for PREC in "--mode=rr --precision-binary64=53"; do
+    VFC_BACKENDS="$BACKEND $PREC" ./sr-binary64 $p > binary64-$p
+  done
+done
+
+./check.py
+status=$?
+
+if [ $status -eq 0 ]; then
+  echo "Success!"
+else
+  echo "Failed!"
+fi
+
+exit $status


### PR DESCRIPTION
Since removing the MPFR reference backend we are missing good validity
tests for MCA backends.

This test checks basic statistical properties of MCA RR mode with
t=53 and t=24.

Test logic is detailed in check.py