### PR TITLE
Stochastic Round backend from Verrou

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,7 @@ AC_CONFIG_FILES([Makefile
                  src/backends/interflop-cancellation/Makefile
                  src/backends/interflop-bitmask/Makefile
                  src/backends/interflop-vprec/Makefile
+                 src/backends/interflop-verrou/Makefile
                  tests/Makefile
                  tests/paths.sh
                 ])

--- a/src/backends/Makefile.am
+++ b/src/backends/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS= interflop-ieee interflop-mca interflop-mca-int interflop-cancellation interflop-bitmask interflop-vprec
+SUBDIRS= interflop-ieee interflop-mca interflop-mca-int interflop-cancellation interflop-bitmask interflop-vprec interflop-verrou

--- a/src/backends/interflop-bitmask/interflop_bitmask.c
+++ b/src/backends/interflop-bitmask/interflop_bitmask.c
@@ -520,21 +520,18 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
 
   print_information_header(ctx);
 
-  struct interflop_backend_interface_t interflop_backend_bitmask = {
-      _interflop_add_float,
-      _interflop_sub_float,
-      _interflop_mul_float,
-      _interflop_div_float,
-      NULL,
-      _interflop_add_double,
-      _interflop_sub_double,
-      _interflop_mul_double,
-      _interflop_div_double,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      NULL};
+  //struct interflop_backend_interface_t interflop_backend_bitmask =
+  struct interflop_backend_interface_t config=interflop_backend_empty_interface;
+
+  config.add_float=_interflop_add_float;
+  config.sub_float=_interflop_sub_float;
+  config.mul_float=_interflop_mul_float;
+  config.div_float=_interflop_div_float;
+
+  config.add_double=_interflop_add_double;
+  config.sub_double=_interflop_sub_double;
+  config.mul_double=_interflop_mul_double;
+  config.div_double=_interflop_div_double;
 
   /* The seed for the RNG is initialized upon the first request for a random
      number */
@@ -542,5 +539,5 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
   _init_rng_state_struct(&rng_state, ctx->choose_seed,
                          (unsigned long long int)(ctx->seed), false);
 
-  return interflop_backend_bitmask;
+  return config;
 }

--- a/src/backends/interflop-cancellation/interflop_cancellation.c
+++ b/src/backends/interflop-cancellation/interflop_cancellation.c
@@ -208,21 +208,19 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
   logger_info("interflop_cancellation: loaded backend with tolerance = %d\n",
               TOLERANCE);
 
-  struct interflop_backend_interface_t interflop_backend_cancellation = {
-      _interflop_add_float,
-      _interflop_sub_float,
-      _interflop_mul_float,
-      _interflop_div_float,
-      NULL,
-      _interflop_add_double,
-      _interflop_sub_double,
-      _interflop_mul_double,
-      _interflop_div_double,
-      NULL,
-      NULL,
-      NULL,
-      NULL,
-      NULL};
+  struct interflop_backend_interface_t config=interflop_backend_empty_interface;
+
+  config.add_float=_interflop_add_float;
+  config.sub_float=_interflop_sub_float;
+  config.mul_float=_interflop_mul_float;
+  config.div_float=_interflop_div_float;
+
+  config.add_double=_interflop_add_double;
+  config.sub_double=_interflop_sub_double;
+  config.mul_double=_interflop_mul_double;
+  config.div_double=_interflop_div_double;
+
+
 
   /* The seed for the RNG is initialized upon the first request for a random
      number */
@@ -230,5 +228,5 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
   _init_rng_state_struct(&rng_state, ctx->choose_seed,
                          (unsigned long long int)(ctx->seed), false);
 
-  return interflop_backend_cancellation;
+  return config;
 }

--- a/src/backends/interflop-ieee/interflop_ieee.c
+++ b/src/backends/interflop-ieee/interflop_ieee.c
@@ -407,21 +407,21 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
   /* register %b format */
   register_printf_bit();
 
-  struct interflop_backend_interface_t interflop_backend_ieee = {
-      _interflop_add_float,
-      _interflop_sub_float,
-      _interflop_mul_float,
-      _interflop_div_float,
-      _interflop_cmp_float,
-      _interflop_add_double,
-      _interflop_sub_double,
-      _interflop_mul_double,
-      _interflop_div_double,
-      _interflop_cmp_double,
-      NULL,
-      NULL,
-      NULL,
-      _interflop_finalize};
+  struct interflop_backend_interface_t config=interflop_backend_empty_interface;
 
-  return interflop_backend_ieee;
+  config.add_float=_interflop_add_float;
+  config.sub_float=_interflop_sub_float;
+  config.mul_float=_interflop_mul_float;
+  config.div_float=_interflop_div_float;
+
+  config.add_double=_interflop_add_double;
+  config.sub_double=_interflop_sub_double;
+  config.mul_double=_interflop_mul_double;
+  config.div_double=_interflop_div_double;
+
+  config.cmp_float =_interflop_cmp_float;
+  config.cmp_double=_interflop_cmp_double;
+  config.finalize  =_interflop_finalize;
+
+  return config;
 }

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -629,27 +629,22 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
 
   print_information_header(ctx);
 
-  struct interflop_backend_interface_t interflop_backend_mca = {
-      _interflop_add_float,
-      _interflop_sub_float,
-      _interflop_mul_float,
-      _interflop_div_float,
-      NULL,
-      _interflop_add_double,
-      _interflop_sub_double,
-      _interflop_mul_double,
-      _interflop_div_double,
-      NULL,
-      NULL,
-      NULL,
-      _interflop_user_call,
-      NULL};
+  struct interflop_backend_interface_t config=interflop_backend_empty_interface;
+  
+  config.add_float=_interflop_add_float;
+  config.sub_float=_interflop_sub_float;
+  config.mul_float=_interflop_mul_float;
+  config.div_float=_interflop_div_float;
 
+  config.add_double=_interflop_add_double;
+  config.sub_double=_interflop_sub_double;
+  config.mul_double=_interflop_mul_double;
+  config.div_double=_interflop_div_double;
   /* The seed for the RNG is initialized upon the first request for a random
      number */
 
   _init_rng_state_struct(&rng_state, ctx->choose_seed,
                          (unsigned long long int)(ctx->seed), false);
 
-  return interflop_backend_mca;
+  return config;
 }

--- a/src/backends/interflop-verrou/COPYING
+++ b/src/backends/interflop-verrou/COPYING
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/src/backends/interflop-verrou/Makefile.am
+++ b/src/backends/interflop-verrou/Makefile.am
@@ -1,0 +1,8 @@
+lib_LTLIBRARIES = libinterflop_verrou.la
+libinterflop_verrou_la_SOURCES = interflop_verrou.cxx
+libinterflop_verrou_la_CFLAGS = -DBACKEND_HEADER="interflop_verrou" -DINTERFLOP_DYN_INTERFACE_ENABLED
+if WALL_CFLAGS
+libinterflop_verrou_la_CFLAGS += -Wall -Wextra
+endif
+libinterflop_verrou_la_LDFLAGS = -lm
+library_includedir =$(includedir)/

--- a/src/backends/interflop-verrou/interflop_verrou.cxx
+++ b/src/backends/interflop-verrou/interflop_verrou.cxx
@@ -1,0 +1,340 @@
+
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Interface for floating-point operations overloading.         ---*/
+/*---                                         interflop_verrou.cxx ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+#include "interflop_verrou.h"
+#include "vr_nextUlp.hxx"
+#include "vr_isNan.hxx"
+#include "vr_fma.hxx"
+#include <stddef.h>
+//extern "C" {
+#include "vr_rand.h"
+//}
+
+
+
+
+#include "vr_roundingOp.hxx"
+#include "vr_op.hxx"
+
+
+// * Global variables & parameters
+int CHECK_C  = 0;
+vr_RoundingMode DEFAULTROUNDINGMODE;
+vr_RoundingMode ROUNDINGMODE;
+unsigned int vr_seed;
+void (*vr_panicHandler)(const char*)=NULL;
+void (*vr_nanHandler)()=NULL;
+
+
+
+void verrou_set_panic_handler(void (*panicHandler)(const char*)){
+  vr_panicHandler=panicHandler;
+}
+
+void verrou_set_nan_handler(void (*nanHandler)()){
+  vr_nanHandler=nanHandler;
+}
+
+
+void (*vr_debug_print_op)(int,const char*, const double*, const double*)=NULL;
+void verrou_set_debug_print_op(void (*printOpHandler)(int nbArg,const char*name, const double* args,const double* res)){
+  vr_debug_print_op=printOpHandler;
+};
+
+
+// * Operation implementation
+const char*  verrou_rounding_mode_name (enum vr_RoundingMode mode) {
+  switch (mode) {
+  case VR_NEAREST:
+    return "NEAREST";
+  case VR_UPWARD:
+    return "UPWARD";
+  case VR_DOWNWARD:
+    return "DOWNWARD";
+  case VR_ZERO:
+    return "TOWARD_ZERO";
+  case VR_RANDOM:
+    return "RANDOM";
+  case VR_AVERAGE:
+    return "AVERAGE";
+  case VR_FARTHEST:
+    return "FARTHEST";
+  case VR_FLOAT:
+    return "FLOAT";
+  case VR_NATIVE:
+    return "NATIVE";
+  case VR_FTZ:
+    return "FTZ";
+  }
+
+  return "undefined";
+}
+
+
+
+
+// * C interface
+void IFV_FCTNAME(configure)(vr_RoundingMode mode,void* context) {
+  DEFAULTROUNDINGMODE = mode;
+  ROUNDINGMODE=mode;
+}
+
+void IFV_FCTNAME(finalize)(void* context){
+}
+
+const char* IFV_FCTNAME(get_backend_name)() {
+  return "verrou";
+}
+
+const char* IFV_FCTNAME(get_backend_version)() {
+  return "1.x-dev";
+}
+
+void verrou_begin_instr(){
+  ROUNDINGMODE=DEFAULTROUNDINGMODE;
+}
+
+void verrou_end_instr(){
+  ROUNDINGMODE= VR_NEAREST;
+}
+
+void verrou_set_seed (unsigned int seed) {
+  vr_seed = vr_rand_int (&vr_rand);
+  vr_rand_setSeed (&vr_rand, seed);
+}
+
+void verrou_set_random_seed () {
+  vr_rand_setSeed(&vr_rand, vr_seed);
+}
+
+void IFV_FCTNAME(add_double) (double a, double b, double* res,void* context) {
+  typedef OpWithSelectedRoundingMode<AddOp <double>  > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(add_float) (float a, float b, float* res,void* context) {
+  typedef OpWithSelectedRoundingMode<AddOp <float>  > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(sub_double) (double a, double b, double* res,void* context) {
+  typedef OpWithSelectedRoundingMode<SubOp <double> > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(sub_float) (float a, float b, float* res,void* context) {
+  typedef OpWithSelectedRoundingMode<SubOp <float>  > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(mul_double) (double a, double b, double* res,void* context) {
+  typedef OpWithSelectedRoundingMode<MulOp <double> > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(mul_float) (float a, float b, float* res,void* context) {
+  typedef OpWithSelectedRoundingMode<MulOp <float> > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(div_double) (double a, double b, double* res,void* context) {
+  typedef OpWithSelectedRoundingMode<DivOp <double> > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(div_float) (float a, float b, float* res,void* context) {
+  typedef OpWithSelectedRoundingMode<DivOp <float>  > Op;
+  Op::apply(Op::PackArgs(a,b),res,context);
+}
+
+void IFV_FCTNAME(cast_double_to_float) (double a, float* res, void* context){
+  typedef OpWithSelectedRoundingMode<CastOp<double,float>  > Op;
+  Op::apply(Op::PackArgs(a),res,context);
+}
+
+void IFV_FCTNAME(madd_double) (double a, double b, double c, double* res, void* context){
+  typedef OpWithSelectedRoundingMode<MAddOp <double> > Op;
+  Op::apply(Op::PackArgs(a,b,c), res,context);
+}
+
+void IFV_FCTNAME(madd_float) (float a, float b, float c, float* res, void* context){
+  typedef OpWithSelectedRoundingMode<MAddOp <float> > Op;
+  Op::apply(Op::PackArgs(a,b,c), res, context);
+}
+
+
+
+
+
+struct interflop_backend_interface_t IFV_FCTNAME(init)(void ** context){
+  struct interflop_backend_interface_t config=interflop_backend_empty_interface;
+
+  config.add_float = & IFV_FCTNAME(add_float);
+  config.sub_float = & IFV_FCTNAME(sub_float);
+  config.mul_float = & IFV_FCTNAME(mul_float);
+  config.div_float = & IFV_FCTNAME(div_float);
+
+  config.add_double = & IFV_FCTNAME(add_double);
+  config.sub_double = & IFV_FCTNAME(sub_double);
+  config.mul_double = & IFV_FCTNAME(mul_double);
+  config.div_double = & IFV_FCTNAME(div_double);
+
+  config.cast_double_to_float=& IFV_FCTNAME(cast_double_to_float);
+
+  config.madd_float  = & IFV_FCTNAME(madd_float);
+  config.madd_double = & IFV_FCTNAME(madd_double);
+
+  config.finalize = & IFV_FCTNAME(finalize);
+
+  return config;
+}
+
+
+//#ifdef INTERFLOP_DYN_INTERFACE_ENABLED
+#ifndef INTERFLOP_STATIC_INTERFACE_ENABLED
+
+#include <argp.h>
+#include <string.h>
+#include <strings.h>
+#include <iostream>
+#include <sys/time.h>
+#include <unistd.h>
+
+typedef struct verrou_conf{
+  vr_RoundingMode mode;
+  unsigned int seed;
+} verrou_conf_t;
+
+typedef enum {
+  KEY_ROUNDING_MODE,
+  KEY_SEED
+} key_args;
+
+static const char key_rounding_mode_str[] = "rounding-mode";
+static const char key_seed_str[] = "seed";
+
+
+static struct argp_option options[] = {
+  {key_rounding_mode_str, KEY_ROUNDING_MODE, "ROUNDING MODE", 0,
+   "select rounding mode among {nearest, upward, downward, toward_zero, random, average, farthest,float,native,ftz}", 0},
+  {key_seed_str, KEY_SEED, "SEED", 0, "fix the random generator seed", 0},
+  {0}};
+
+
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+  verrou_conf_t *conf = (verrou_conf_t *)state->input;
+  
+  switch (key) {
+  case KEY_ROUNDING_MODE:
+    if (strcasecmp("nearest", arg) == 0) {
+      conf->mode=VR_NEAREST;
+    } else if (strcasecmp("upward", arg) == 0) {
+      conf->mode=VR_UPWARD;
+    } else if (strcasecmp("downward", arg) == 0) {
+      conf->mode=VR_DOWNWARD;
+    } else if (strcasecmp("toward_zero", arg) == 0) {
+      conf->mode=VR_ZERO;
+    } else if (strcasecmp("random", arg) == 0) {
+      conf->mode=VR_RANDOM;
+    } else if (strcasecmp("average", arg) == 0) {
+      conf->mode=VR_AVERAGE;
+    } else if (strcasecmp("farthest", arg) == 0) {
+      conf->mode=VR_FARTHEST;
+    } else if (strcasecmp("float", arg) == 0) {
+      conf->mode=VR_FLOAT;
+    } else if (strcasecmp("native", arg) == 0) {
+      conf->mode=VR_NATIVE;
+    } else if (strcasecmp("ftz", arg) == 0) {
+      conf->mode=VR_FTZ;
+  
+    } else {
+      std::cerr << key_rounding_mode_str <<" invalid value provided, must be one of: "
+		<<" nearest, upward, downward, toward_zero, random, average, farthest,float,native,ftz."
+		<<std::endl;
+      exit(42);
+    }
+    break;
+
+  case KEY_SEED:
+    /* seed */
+    errno = 0;
+    char *endptr;
+    conf->seed = strtoull(arg, &endptr, 10);
+    if (errno != 0) {
+      std::cerr << key_seed_str <<" invalid value provided, must be an integer"
+		<< std::endl;
+      exit(42);
+    }
+    break;
+
+  default:
+    return ARGP_ERR_UNKNOWN;
+  }
+  return 0;
+  
+}
+
+static struct argp argp = {options, parse_opt, "", "", NULL, NULL, NULL};
+
+
+verrou_conf_t IFV_FCTNAME(parse)(int argc, char** argv, void* context){
+  
+  verrou_conf_t conf;
+  conf.mode=VR_NEAREST ; //default value  
+  conf.seed=(unsigned int) -1;
+
+  argp_parse(&argp, argc, argv, 0, 0, &conf);
+  std::cout << "Verrou rounding mode " << verrou_rounding_mode_name(conf.mode)<<std::endl;
+  return conf; 
+}
+
+
+struct interflop_backend_interface_t interflop_init(int argc, char **argv,
+                                                    void **context){
+  struct interflop_backend_interface_t config=IFV_FCTNAME(init)(context);
+
+  
+  verrou_conf_t conf=IFV_FCTNAME(parse)(argc, argv, *context);
+  IFV_FCTNAME(configure)(conf.mode, *context);
+
+  if(conf.seed==(unsigned int) -1){
+    struct timeval t1;
+    gettimeofday(&t1, NULL);
+    conf.seed =  t1.tv_usec + getpid();
+  }
+  verrou_set_seed (conf.seed);
+  
+
+  return config;
+}
+#endif

--- a/src/backends/interflop-verrou/interflop_verrou.h
+++ b/src/backends/interflop-verrou/interflop_verrou.h
@@ -1,0 +1,107 @@
+
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Interface for floatin-point operations overloading.          ---*/
+/*---                                           interflop_verrou.h ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+#ifndef __INTERFLOP_VERROU_H
+#define __INTERFLOP_VERROU_H
+
+//#define DEBUG_PRINT_OP
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define IFV_FCTNAME(FCT) interflop_verrou_##FCT
+
+  //#include "../interflop_backend_interface.h"
+#include "../../common/interflop.h"
+
+  
+  enum vr_RoundingMode {
+    VR_NEAREST,
+    VR_UPWARD,
+    VR_DOWNWARD,
+    VR_ZERO,
+    VR_RANDOM, // Must be immediately after standard rounding modes
+    VR_AVERAGE,
+    VR_FARTHEST,
+    VR_FLOAT,
+    VR_NATIVE,
+    VR_FTZ
+  };
+
+
+
+  void IFV_FCTNAME(configure)(enum vr_RoundingMode mode,void* context);
+  void IFV_FCTNAME(finalyze)(void* context);
+
+  const char* IFV_FCTNAME(get_backend_name)(void);
+  const char* IFV_FCTNAME(get_backend_version)(void);
+
+
+  const char* verrou_rounding_mode_name (enum vr_RoundingMode mode);
+
+  void verrou_begin_instr(void);
+  void verrou_end_instr(void);
+
+  void verrou_set_seed (unsigned int seed);
+  void verrou_set_random_seed (void);
+
+  extern void (*vr_panicHandler)(const char*);
+  void verrou_set_panic_handler(void (*)(const char*));
+  extern void (*vr_nanHandler)(void);
+  void verrou_set_nan_handler(void (*nanHandler)(void));
+
+  extern void (*vr_debug_print_op)(int,const char*, const double* args, const double* res);
+  void verrou_set_debug_print_op(void (*)(int nbArg, const char* name, const double* args, const double* res));
+
+  struct interflop_backend_interface_t IFV_FCTNAME(init)(void ** context);
+
+  void IFV_FCTNAME(add_double) (double a, double b, double* res, void* context);    
+  void IFV_FCTNAME(add_float)  (float a,  float b,  float*  res, void* context);
+  void IFV_FCTNAME(sub_double) (double a, double b, double* res, void* context);
+  void IFV_FCTNAME(sub_float)  (float a,  float b,  float*  res, void* context);
+  void IFV_FCTNAME(mul_double) (double a, double b, double* res, void* context);
+  void IFV_FCTNAME(mul_float)  (float a,  float b,  float*  res, void* context);
+  void IFV_FCTNAME(div_double) (double a, double b, double* res, void* context);
+  void IFV_FCTNAME(div_float)  (float a,  float b,  float*  res, void* context);
+
+  void IFV_FCTNAME(cast_double_to_float) (double a, float* b, void* context);
+
+  void IFV_FCTNAME(madd_double)(double a, double b, double c, double* res, void* context);
+  void IFV_FCTNAME(madd_float) (float a,  float b,  float c,  float*  res, void* context);
+
+  
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ndef __INTERFLOP_VERROU_H */

--- a/src/backends/interflop-verrou/vr_fma.hxx
+++ b/src/backends/interflop-verrou/vr_fma.hxx
@@ -1,0 +1,69 @@
+
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- This file contains low-level code calling FMA instructions.  ---*/
+/*---                                                   vr_fma.hxx ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+#pragma once
+
+#ifdef    USE_VERROU_FMA
+#include  <immintrin.h>
+//#include  <fmaintrin.h>
+
+template<class REALTYPE>
+inline REALTYPE vr_fma(const REALTYPE&, const REALTYPE&, const REALTYPE&){
+  return 0./ 0.; //nan to be sur not used
+}
+
+template<>
+inline double vr_fma<double>(const double& a, const double& b, const double& c){
+  double d;
+  __m128d ai, bi,ci,di;
+  ai = _mm_load_sd(&a);
+  bi = _mm_load_sd(&b);
+  ci = _mm_load_sd(&c);
+  di=_mm_fmadd_sd(ai,bi,ci);
+  d=_mm_cvtsd_f64(di);
+  return d;
+}
+
+
+template<>
+inline float vr_fma<float>(const float& a, const float& b, const float& c){
+  float d;
+  __m128 ai, bi,ci,di;
+  ai = _mm_load_ss(&a);
+  bi = _mm_load_ss(&b);
+  ci = _mm_load_ss(&c);
+  di=_mm_fmadd_ss(ai,bi,ci);
+  d=_mm_cvtss_f32(di);
+  return d;
+}
+#endif //USE_VERROU_FMA

--- a/src/backends/interflop-verrou/vr_isNan.hxx
+++ b/src/backends/interflop-verrou/vr_isNan.hxx
@@ -1,0 +1,94 @@
+
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Utilities for easier manipulation of floating-point values.  ---*/
+/*---                                                vr_isNan.hxx ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+#pragma once
+
+#include <cfloat>
+#include <stdint.h>
+
+
+#include "interflop_verrou.h"
+
+
+template <class REALTYPE>
+inline bool isNan (const REALTYPE & x) {
+  vr_panicHandler("isNan called on an unknown type");
+  return false;
+}
+
+template <>
+inline bool isNan<double> (const double & x) {
+  static const uint64_t maskSpecial = 0x7ff0000000000000;
+  static const uint64_t maskInf     = 0x000fffffffffffff;
+  const uint64_t* X = reinterpret_cast<const uint64_t*>(&x);
+  if ((*X & maskSpecial) == maskSpecial) {
+    if ((*X & maskInf) != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <>
+inline bool isNan<float> (const float & x) {
+  static const uint32_t maskSpecial = 0x7f800000;
+  static const uint32_t maskInf     = 0x007fffff;
+  const uint32_t* X = reinterpret_cast<const uint32_t*>(&x);
+  if ((*X & maskSpecial) == maskSpecial) {
+    if ((*X & maskInf) != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+
+
+template<class REALTYPE>
+inline bool isNanInf (const REALTYPE & x) {
+  vr_panicHandler("isNanInf called on an unknown type");
+  return false;
+}
+
+template <>
+inline bool isNanInf<double> (const double & x) {
+  static const uint64_t mask = 0x7ff0000000000000;
+  const uint64_t* X = reinterpret_cast<const uint64_t*>(&x);
+  return (*X & mask) == mask;
+}
+
+template <>
+inline bool isNanInf<float> (const float & x) {
+  static const uint32_t mask = 0x7f800000;
+  const uint32_t* X = reinterpret_cast<const uint32_t*>(&x);	
+  return (*X & mask) == mask;  
+}

--- a/src/backends/interflop-verrou/vr_nextUlp.hxx
+++ b/src/backends/interflop-verrou/vr_nextUlp.hxx
@@ -1,0 +1,112 @@
+
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Utilities for easier manipulation of floating-point values.  ---*/
+/*---                                                vr_nextUlp.hxx ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+#pragma once
+//#include <string>
+//#include <sstream>
+//#include <math.h>
+#include <cfloat>
+#include <stdint.h>
+#include <limits>
+
+#include "interflop_verrou.h"
+
+
+template<class REALTYPE>
+inline REALTYPE nextAwayFromZero(REALTYPE a){
+   vr_panicHandler("nextAwayFromZero called on unknown type");
+};
+
+template<>
+inline double nextAwayFromZero<double>(double a){
+  double res=a;
+  uint64_t* resU=reinterpret_cast<uint64_t*>(&res);
+  (*resU)+=1;
+  return res;
+};
+
+
+template<>
+inline float nextAwayFromZero<float>(float a){
+  float res=a;
+  uint32_t* resU=reinterpret_cast<uint32_t*>(&res);
+  (*resU)+=1;
+  return res;
+};
+
+
+
+template<class REALTYPE>
+inline REALTYPE nextTowardZero(REALTYPE a){
+  vr_panicHandler("nextTowardZero called on unknown type");
+};
+
+template<>
+inline double nextTowardZero<double>(double a){
+  double res=a;
+  uint64_t* resU=reinterpret_cast<uint64_t*>(&res);
+  (*resU)-=1;
+  return res;
+};
+
+
+template<>
+inline float nextTowardZero<float>(float a){
+  float res=a;
+  uint32_t* resU=reinterpret_cast<uint32_t*>(&res);
+  (*resU)-=1;
+  return res;
+};
+
+
+
+template<class REALTYPE>
+inline REALTYPE nextAfter(REALTYPE a){
+  if(a>=0 ){
+    return nextAwayFromZero(a);
+  }else{
+    return nextTowardZero(a);
+  }
+};
+
+template<class REALTYPE>
+inline REALTYPE nextPrev(REALTYPE a){
+  if(a==0){
+    return -std::numeric_limits<REALTYPE>::denorm_min();
+  }
+  if(a>0 ){
+    return nextTowardZero(a);
+  }else{
+    return nextAwayFromZero(a);
+  }
+};

--- a/src/backends/interflop-verrou/vr_op.hxx
+++ b/src/backends/interflop-verrou/vr_op.hxx
@@ -1,0 +1,673 @@
+
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Implementation of error estimation for all FP operations     ---*/
+/*---                                                    vr_op.hxx ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+#pragma once
+
+
+
+template<class> struct realTypeHelper;
+
+template<>
+struct realTypeHelper<float>{
+  typedef float SimdBasicType;
+  static const int SimdLength=1;
+};
+
+
+
+template<>
+struct realTypeHelper<double>{
+  typedef double SimdBasicType;
+  static const int SimdLength=1;
+};
+
+template<>
+struct realTypeHelper<long double>{
+  typedef long double SimdBasicType;
+  static const int SimdLength=1;
+};
+
+
+template<class REALTYPESIMD>
+struct realTypeHelper<const REALTYPESIMD>{
+  typedef typename realTypeHelper<REALTYPESIMD>::SimdBasicType SimdBasicType;
+  static const int SimdLength=realTypeHelper<REALTYPESIMD>::SimdLength;
+};
+
+
+
+
+template<class REALTYPE, int NB>
+struct vr_packArg;
+
+
+template<class REALTYPE>
+struct vr_packArg<REALTYPE,1>{
+  static const int nb= 1;
+  typedef REALTYPE RealType;
+  typedef typename realTypeHelper<REALTYPE>::SimdBasicType SimdBasicType;
+  typedef vr_packArg<SimdBasicType,1> SubPack;
+  
+  inline vr_packArg(const RealType& v1):arg1(v1)
+  {
+  };
+
+  inline const SubPack& getSubPack(int I)const{
+    return SubPack(arg1[I]);
+  }
+
+  inline void serialyzeDouble(double* res)const{
+    res[0]=(double)arg1;
+  }
+
+  inline bool isOneArgNanInf()const{
+    return isNanInf<RealType>(arg1);
+  }
+  
+  const RealType& arg1;
+
+
+};
+
+
+template<class REALTYPE>
+struct vr_packArg<REALTYPE,2>{
+  static const int nb= 2;
+  typedef REALTYPE RealType;
+  typedef typename realTypeHelper<REALTYPE>::SimdBasicType SimdBasicType;
+  typedef vr_packArg<SimdBasicType,2> SubPack;
+  
+  vr_packArg(const RealType& v1,const RealType& v2):arg1(v1),arg2(v2)
+  {
+  };
+
+  inline const SubPack getSubPack(int I)const{
+    return SubPack(arg1[I],arg2[I]);
+  }
+  
+  inline void serialyzeDouble(double* res)const{
+    res[0]=(double)arg1;
+    res[1]=(double)arg2;
+  }
+
+  inline bool isOneArgNanInf()const{
+    return (isNanInf<RealType>(arg1) || isNanInf<RealType>(arg2));
+  }
+
+  
+  const RealType& arg1;
+  const RealType& arg2;
+};
+
+
+template<class REALTYPE>
+struct vr_packArg<REALTYPE,3>{
+  static const int nb= 3;
+  typedef REALTYPE RealType;
+  typedef typename realTypeHelper<REALTYPE>::SimdBasicType SimdBasicType;
+  typedef vr_packArg<SimdBasicType,3> SubPack;
+  
+  vr_packArg(const RealType& v1,const RealType& v2,const RealType& v3):arg1(v1),arg2(v2),arg3(v3){
+  };
+
+  inline const SubPack& getSubPack(int I)const{
+    return SubPack(arg1[I],arg2[I],arg3[I]);
+  }
+  
+  inline void serialyzeDouble(double* res)const{
+    res[0]=(double)arg1;
+    res[1]=(double)arg2;
+    res[2]=(double)arg3;
+  }
+
+  inline bool isOneArgNanInf()const{
+    return (isNanInf<RealType>(arg1) || isNanInf<RealType>(arg2) || isNanInf<RealType>(arg3) );
+  }
+
+  
+  const RealType& arg1;
+  const RealType& arg2;
+  const RealType& arg3;
+};
+
+
+template<class REALTYPE, int NB>
+class vr_roundFloat;
+
+
+template<class REALTYPE>
+struct vr_roundFloat<REALTYPE, 1>{
+  vr_roundFloat(const vr_packArg<REALTYPE,1>& p): arg1(REALTYPE(float(p.arg1))){
+  }
+  vr_packArg<REALTYPE,1> getPack()const{
+    return vr_packArg<REALTYPE,1>(arg1);
+  }
+  const REALTYPE arg1;
+};
+
+
+template<class REALTYPE>
+struct vr_roundFloat<REALTYPE, 2>{
+  vr_roundFloat(const vr_packArg<REALTYPE,2>& p): arg1(REALTYPE(float(p.arg1 ))),
+						  arg2(REALTYPE(float(p.arg2 ))){
+  }
+  vr_packArg<REALTYPE,2> getPack()const{
+    return vr_packArg<REALTYPE,2>(arg1,arg2);
+  }
+  const REALTYPE arg1;
+  const REALTYPE arg2;
+};
+
+template<class REALTYPE>
+struct vr_roundFloat<REALTYPE, 3>{
+  vr_roundFloat(const vr_packArg<REALTYPE,3>& p): arg1(REALTYPE(float(p.arg1 ))),
+						  arg2(REALTYPE(float(p.arg2 ))),
+						  arg3(REALTYPE(float(p.arg3 ))){
+  }
+  vr_packArg<REALTYPE,3> getPack()const{
+    return vr_packArg<REALTYPE,3>(arg1,arg2,arg3);
+  }
+  const REALTYPE arg1;
+  const REALTYPE arg2;
+  const REALTYPE arg3;
+};
+
+
+
+
+
+template<typename REAL>
+class AddOp{
+public:
+  typedef REAL RealType;
+  typedef vr_packArg<RealType,2> PackArgs;
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "add";}
+#endif
+
+  static inline RealType nearestOp (const PackArgs&  p) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    return a+b;
+  }
+
+  static inline RealType error (const PackArgs& p, const RealType& x) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    const RealType z=x-a;
+    return ((a-(x-z)) + (b-z)); //algo TwoSum
+  }
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    return AddOp<RealType>::error(p,c);
+  }
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return p.isOneArgNanInf();
+  }
+
+  static inline void check(const PackArgs& p,const RealType & c){
+  }
+
+  static inline void twoSum(const RealType& a,const RealType& b, RealType& x,RealType& y ){
+    const PackArgs p(a,b);
+    x=AddOp<REAL>::nearestOp(p);
+    y=AddOp<REAL>::error(p,x);
+  }
+
+
+};
+
+
+template<typename REAL>
+class SubOp{
+public:
+  typedef REAL RealType;
+  typedef vr_packArg<RealType,2> PackArgs;
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "sub";}
+#endif
+
+
+
+  
+  static inline RealType nearestOp (const PackArgs&  p) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    return a-b;
+  }
+
+  static inline RealType error (const PackArgs& p, const RealType& x) {
+    const RealType & a(p.arg1);
+    const RealType & b(-p.arg2);
+    const RealType z=x-a;
+    return ((a-(x-z)) + (b-z)); //algo TwoSum
+  }
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return p.isOneArgNanInf();
+  }
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    return SubOp<RealType>::error(p,c);
+  }
+
+  static inline void check(const PackArgs& p,const RealType & c){
+  }
+
+};
+
+
+
+
+//splitFactor used by MulOp
+template<class REALTYPE>
+REALTYPE splitFactor(){
+  return 0./ 0.; //nan to make sure not used
+}
+
+template<>
+double splitFactor<double>(){
+  return 134217729; //((2^27)+1); /27 en double  sup(53/2) /
+}
+
+template<>
+float splitFactor<float>(){
+  return 4097; //((2^12)+1); / 24/2 en float/
+}
+
+
+
+
+template<typename REAL>
+class MulOp{
+public:
+  typedef REAL RealType;
+  typedef vr_packArg<RealType,2> PackArgs;
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "mul";}
+#endif
+
+
+  static inline RealType nearestOp (const PackArgs& p) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    return a*b;
+  };
+
+  static inline RealType error (const PackArgs& p, const RealType& x) {
+    /*Provient de "Accurate Sum and dot product" OGITA RUMP OISHI */
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    //    return __builtin_fma(a,b,-x);
+    //    VG_(umsg)("vr_fma \n");
+#ifdef    USE_VERROU_FMA
+    RealType c;
+    c=vr_fma(a,b,-x);
+    return c;
+#else
+    RealType a1,a2;
+    RealType b1,b2;
+    MulOp<RealType>::split(a,a1,a2);
+    MulOp<RealType>::split(b,b1,b2);
+
+    return (((a1*b1-x)+a1*b2+a2*b1)+a2*b2);
+#endif
+  };
+
+
+
+
+  static inline void split(RealType a, RealType& x, RealType& y){
+    //    const RealType factor=134217729; //((2^27)+1); /*27 en double*/
+    const RealType factor(splitFactor<RealType>());
+    const RealType c=factor*a;
+    x=(c-(c-a));
+    y=(a-x);
+  }
+
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    if(c!=0){
+      return MulOp<RealType>::error(p,c);
+    }else{
+      if(p.arg1==0 ||p.arg2==0){
+	return 0;
+      }
+      if(p.arg1>0){
+	return p.arg2;
+      }else{
+	return -p.arg2;
+      }
+    }
+  };
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return p.isOneArgNanInf();
+  }
+
+  static inline void check(const PackArgs& p,const RealType & c){
+  };
+
+  static inline void twoProd(const RealType& a,const RealType& b, RealType& x,RealType& y ){
+    const PackArgs p(a,b);
+    x=MulOp<REAL>::nearestOp(p);
+    y=MulOp<REAL>::error(p,x);
+  }
+
+};
+
+
+template<>
+class MulOp<float>{
+public:
+  typedef float RealType;
+  typedef vr_packArg<RealType,2> PackArgs;
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "mul";}
+#endif
+
+  static inline RealType nearestOp (const PackArgs& p) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    return a*b;
+  };
+
+  static inline RealType error (const PackArgs& p, const RealType& x) {
+    /*Provient de "Accurate Sum and dot product" OGITA RUMP OISHI */
+    const RealType a(p.arg1);
+    const RealType b(p.arg2);
+    //    return __builtin_fma(a,b,-x);
+    //    VG_(umsg)("vr_fma \n");
+#ifdef    USE_VERROU_FMA
+    RealType c;
+    c=vr_fma(a,b,-x);
+    return c;
+#else
+    RealType a1,a2;
+    RealType b1,b2;
+    MulOp<RealType>::split(a,a1,a2);
+    MulOp<RealType>::split(b,b1,b2);
+
+    return (((a1*b1-x)+a1*b2+a2*b1)+a2*b2);
+#endif
+  };
+
+
+
+
+  static inline void split(RealType a, RealType& x, RealType& y){
+    //    const RealType factor=134217729; //((2^27)+1); /*27 en double*/
+    const RealType factor(splitFactor<RealType>());
+    const RealType c=factor*a;
+    x=(c-(c-a));
+    y=(a-x);
+  }
+
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    double res=MulOp<double>::error(vr_packArg<double,2>((double)p.arg1,(double)p.arg2) ,(double)c);
+    if(res<0){
+      return -1;
+    }
+    if(res>0){
+      return 1;
+    }
+    return 0.;
+  };
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return p.isOneArgNanInf();
+  }
+
+  static inline void check(const PackArgs& p,const RealType & c){
+  };
+
+  static inline void twoProd(const RealType& a,const RealType& b, RealType& x,RealType& y ){
+    const PackArgs p(a,b);
+    x=MulOp<float>::nearestOp(p);
+    y=MulOp<float>::error(p,x);
+  }
+
+};
+
+
+
+
+
+template<typename REAL>
+class DivOp{
+public:
+  typedef REAL RealType;
+  typedef vr_packArg<RealType,2> PackArgs;
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "div";}
+#endif
+
+  static RealType inline nearestOp (const PackArgs& p) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    return a/b;
+  };
+
+  static inline RealType error (const PackArgs& p, const RealType& c) {
+    const RealType & x(p.arg1);
+    const RealType & y(p.arg2);
+#ifdef    USE_VERROU_FMA
+    const RealType r=-vr_fma(c,y,-x);
+    return r/y;
+#else
+    RealType u,uu;
+    MulOp<RealType>::twoProd(c,y,u,uu);
+    return ( x-u-uu)/y ;
+#endif
+  };
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    const RealType & x(p.arg1);
+    const RealType & y(p.arg2);
+#ifdef    USE_VERROU_FMA
+    const RealType r=-vr_fma(c,y,-x);
+    return r*y;
+#else
+    RealType u,uu;
+    MulOp<RealType>::twoProd(c,y,u,uu);
+    return ( x-u-uu)*y ;
+#endif
+  };
+
+
+  static inline void check(const PackArgs& p,const RealType & c){
+  };
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return (isNanInf<RealType>(p.arg1))||(p.arg2==RealType(0.));
+  }
+};
+
+
+template<>
+class DivOp<float>{
+public:
+  typedef float RealType;
+  typedef vr_packArg<RealType,2> PackArgs;
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "div";}
+#endif
+
+  static RealType inline nearestOp (const PackArgs& p) {
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    return a/b;
+  };
+
+  static inline RealType error (const PackArgs& p, const RealType& c) {
+    const RealType & x(p.arg1);
+    const RealType & y(p.arg2);
+#ifdef    USE_VERROU_FMA
+    const RealType r=-vr_fma(c,y,-x);
+    return r/y;
+#else
+    RealType u,uu;
+    MulOp<RealType>::twoProd(c,y,u,uu);
+    return ( x-u-uu)/y ;
+#endif
+  };
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    const double x((double)p.arg1);
+    const double y((double) p.arg2);
+#ifdef    USE_VERROU_FMA
+    const double r=-vr_fma((double)c,y,-x);
+
+    if(r>0){return p.arg2;}
+    if(r<0){return -p.arg2;}
+    //if(r==0){
+      return 0.;
+      //}
+#else
+    RealType u,uu;
+    MulOp<RealType>::twoProd(c,y,u,uu);
+    return ( x-u-uu)*y ;
+#endif
+  };
+
+
+  static inline void check(const PackArgs& p,const RealType & c){
+  };
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return (isNanInf<RealType>(p.arg1))||(p.arg2==RealType(0.));
+  }
+
+};
+
+
+
+template<typename REAL>
+class MAddOp{
+public:
+  typedef REAL RealType;
+  typedef vr_packArg<RealType,3> PackArgs;
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "madd";}
+#endif
+
+  
+  static RealType inline nearestOp (const PackArgs& p) {
+#ifdef    USE_VERROU_FMA
+    const RealType & a(p.arg1);
+    const RealType & b(p.arg2);
+    const RealType & c(p.arg3);
+    return vr_fma(a,b,c);
+#else
+    return 0./0.;
+#endif
+  };
+
+  static inline RealType error (const PackArgs& p, const RealType& z) {
+    //ErrFmaApp : Exact and Aproximated Error of the FMA By Boldo and Muller
+    const RealType & a(p.arg1);
+    const RealType & x(p.arg2);
+    const RealType & b(p.arg3);
+
+    RealType ph,pl;
+    MulOp<RealType>::twoProd(a,x, ph,pl);
+
+    RealType uh,ul;
+    AddOp<RealType>::twoSum(b,ph, uh,ul);
+
+    const RealType t(uh-z);
+    return (t+(pl+ul)) ;
+  };
+
+  static inline RealType sameSignOfError (const PackArgs& p,const RealType& c) {
+    return error(p,c) ;
+  };
+
+
+  static inline void check(const PackArgs& p, const RealType& d){
+  };
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return p.isOneArgNanInf();
+  }
+
+};
+
+
+
+template<typename REALINPUT, typename REALOUTPUT>
+class CastOp{
+public:
+  typedef REALINPUT RealTypeIn;
+  typedef REALOUTPUT RealTypeOut;
+  typedef RealTypeOut RealType;
+  typedef vr_packArg<RealTypeIn,1> PackArgs;
+  
+
+#ifdef DEBUG_PRINT_OP
+  static const char* OpName(){return "cast";}
+#endif
+
+
+  
+  static inline RealTypeOut nearestOp (const PackArgs& p) {
+    const RealTypeIn & in(p.arg1);
+    return (RealTypeOut)in;
+  };
+
+  static inline RealTypeOut error (const PackArgs& p, const RealTypeOut& z) {
+    const RealTypeIn & a(p.arg1);
+    const RealTypeIn errorHo= a- (RealTypeIn)z;
+    return (RealTypeOut) errorHo;
+  };
+
+  static inline RealTypeOut sameSignOfError (const PackArgs& p,const RealTypeOut& c) {
+    return error(p,c) ;
+  };
+
+  static inline bool isInfNotSpecificToNearest(const PackArgs&p){
+    return p.isOneArgNanInf();
+  }
+
+  static inline void check(const PackArgs& p, const RealTypeOut& d){
+  };
+
+};

--- a/src/backends/interflop-verrou/vr_rand.h
+++ b/src/backends/interflop-verrou/vr_rand.h
@@ -1,0 +1,77 @@
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Interface for random number generation.                      ---*/
+/*---                                                    vr_rand.h ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+#ifndef __VR_RAND_H
+#define __VR_RAND_H
+
+//#include "pub_tool_basics.h"
+#include <cstdint>
+
+#define VERROU_LOWGEN
+
+#ifndef VERROU_LOWGEN
+#include "../backend_mcaquad/common/tinymt64.h"
+#endif
+
+
+
+typedef struct Vr_Rand_ Vr_Rand;
+struct Vr_Rand_ {
+#ifdef VERROU_LOWGEN
+  uint64_t current_;
+  uint64_t next_;
+  uint64_t seed_;
+  int32_t count_;
+#else
+  uint64_t current_;
+  tinymt64_t gen_;
+  uint64_t seed_;
+  int32_t count_;
+#endif
+};
+
+//extern Vr_Rand vr_rand;
+
+Vr_Rand vr_rand;
+
+#include "vr_rand_implem.h"
+
+
+
+/* void vr_rand_setSeed (Vr_Rand * r, unsigned int c); */
+/* unsigned int vr_rand_getSeed (Vr_Rand * r); */
+/* bool vr_rand_bool (Vr_Rand * r); */
+/* int vr_rand_int (Vr_Rand * r); */
+/* int vr_rand_max (void); */
+
+
+
+#endif

--- a/src/backends/interflop-verrou/vr_rand_implem.h
+++ b/src/backends/interflop-verrou/vr_rand_implem.h
@@ -1,0 +1,99 @@
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Interface for random number generation.                      ---*/
+/*---                                             vr_rand_implem.h ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+//#include "vr_rand.h"
+
+//Warning FILE include in vr_rand.h
+
+
+
+#ifdef VERROU_LOWGEN
+inline static uint64_t vr_rand_next (Vr_Rand * r){
+  r->next_ = r->next_ * 1103515245 + 12345;
+  return (uint64_t)((r->next_/65536) % 32768);
+}
+inline int32_t vr_rand_max () {
+  return 32767;
+}
+
+inline void vr_rand_setSeed (Vr_Rand * r, uint64_t c) {
+  r->count_   = 0;
+  r->seed_    = c;
+  r->next_    = c;
+  r->current_ = vr_rand_next (r);
+}
+inline int32_t vr_loop(){
+  return 14; // 2**15= 32768
+}
+
+#else
+inline static uint64_t vr_rand_next (Vr_Rand * r){
+  return tinymt64_generate_uint64(&(r->gen_) );
+}
+inline int32_t vr_rand_max () {
+  int32_t max=2147483647;  //2**21-1
+  return max;
+}
+inline int32_t vr_loop(){
+  return 63; // 2**15= 32768
+}
+
+
+inline void vr_rand_setSeed (Vr_Rand * r, uint64_t c) {
+  tinymt64_init(&(r->gen_),c);
+  r->count_   = 0;
+  r->seed_    = c;
+  r->current_ = vr_rand_next (r);
+}
+
+#endif
+
+
+
+inline uint64_t vr_rand_getSeed (Vr_Rand * r) {
+  return r->seed_;
+}
+
+inline bool vr_rand_bool (Vr_Rand * r) {
+  if (r->count_ == vr_loop()){
+    r->current_ = vr_rand_next (r);
+    r->count_ = 0;
+  }
+  bool res = (r->current_ >> (r->count_++)) & 1;
+  // VG_(umsg)("Count : %u  res: %u\n", r->count_ ,res);
+  return res;
+}
+
+inline int32_t vr_rand_int (Vr_Rand * r) {
+  uint64_t res=vr_rand_next (r) % vr_rand_max();
+  return (int32_t)res;
+}

--- a/src/backends/interflop-verrou/vr_roundingOp.hxx
+++ b/src/backends/interflop-verrou/vr_roundingOp.hxx
@@ -1,0 +1,378 @@
+/*--------------------------------------------------------------------*/
+/*--- Verrou: a FPU instrumentation tool.                          ---*/
+/*--- Implementation of the software implementation of rounding    ---*/
+/*--- mode switching.                                              ---*/
+/*---                                            vr_roundingOp.hxx ---*/
+/*--------------------------------------------------------------------*/
+
+/*
+   This file is part of Verrou, a FPU instrumentation tool.
+
+   Copyright (C) 2014-2021 EDF
+     F. Févotte     <francois.fevotte@edf.fr>
+     B. Lathuilière <bruno.lathuiliere@edf.fr>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307, USA.
+
+   The GNU Lesser General Public License is contained in the file COPYING.
+*/
+
+
+#pragma once
+#include <limits>
+
+//#ifndef LIBMATHINTERP
+extern vr_RoundingMode ROUNDINGMODE;
+//#else
+//extern vr_RoundingMode ROUNDINGMODE;
+//#endif
+
+//#include "vr_fpRepr.hxx"
+#include "vr_nextUlp.hxx"
+#include "vr_isNan.hxx"
+
+#include "vr_op.hxx"
+
+template<class OP>
+class RoundingNearest{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    const RealType res=OP::nearestOp(p) ;
+    OP::check(p,res);
+    return res;
+  } ;
+
+};
+
+
+
+template<class OP>
+class RoundingFloat{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    vr_roundFloat<typename PackArgs::RealType, PackArgs::nb> roundedArgs (p);
+    const float res=(float) OP::nearestOp(roundedArgs.getPack()) ;
+    return RealType(res);
+  } ;
+
+};
+
+
+
+
+template<class OP>
+class RoundingRandom{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p ){
+    RealType res=OP::nearestOp(p);
+
+    if (isNanInf<RealType> (res)){
+      return res;
+    }
+
+    OP::check(p,res);
+    const RealType signError=OP::sameSignOfError(p,res);
+    if(signError==0.){
+      return res;
+    }else{
+      const bool doNoChange = vr_rand_bool(&vr_rand);
+      if(doNoChange){
+	return res;
+      }else{
+	if(signError>0){
+	  return nextAfter<RealType>(res);
+	}else{
+	  return nextPrev<RealType>(res);
+	}
+      }
+    }
+  } ;
+};
+
+
+
+template<class OP>
+class RoundingAverage{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    const RealType res=OP::nearestOp(p) ;
+
+    if (isNanInf<RealType> (res)){
+      return res;
+    }
+
+    OP::check(p,res);
+    const RealType error=OP::error(p,res);
+    if(error==0.){
+      return res;
+    }
+
+
+    if(error>0){
+      const RealType nextRes(nextAfter<RealType>(res));
+      const RealType u(nextRes -res);
+      const int s(1);
+      const bool doNotChange = ((vr_rand_int(&vr_rand) * u)
+				> (vr_rand_max() * s * error));
+      if(doNotChange){
+	return res;
+      }else{
+	return nextRes;
+      }
+
+    }
+    if(error<0){
+      const RealType prevRes(nextPrev<RealType>(res));
+      const RealType u(res -prevRes);
+      const int s(-1);
+      const bool doNotChange = ((vr_rand_int(&vr_rand) * u)
+				> (vr_rand_max() * s * error));
+      if(doNotChange){
+	return res;
+      }else{
+	return prevRes;
+      }
+    }
+    return res; //Should not occur
+  } ;
+};
+
+
+
+template<class OP>
+class RoundingZero{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    RealType res=OP::nearestOp(p) ;
+    OP::check(p,res);
+    const RealType signError=OP::sameSignOfError(p,res);
+
+    if(isNanInf<RealType>(res)){
+      if( (res!=std::numeric_limits<RealType>::infinity()) && (res!=-std::numeric_limits<RealType>::infinity())  ){
+	return res;
+      }else{
+	if(OP::isInfNotSpecificToNearest(p)){
+	  return res;
+	}else{
+	  if(res>0){
+	    return std::numeric_limits<RealType>::max();
+	  }else{
+	    return -std::numeric_limits<RealType>::max();
+	  }
+	  }
+      }
+    }
+
+    if( (signError>0 && res <0)||(signError<0 && res>0) ){
+      return nextTowardZero<RealType>(res);
+    }
+    return res;
+  } ;
+};
+
+
+template<class OP>
+class RoundingUpward{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    const RealType res=OP::nearestOp(p) ;
+    OP::check(p,res);
+
+    if(isNanInf<RealType>(res)){
+      if(res!=-std::numeric_limits<RealType>::infinity()){
+	return res;
+      }else{
+	if(OP::isInfNotSpecificToNearest(p)){
+	  return res;
+	}else{
+	  return -std::numeric_limits<RealType>::max();
+	}
+      }
+    }
+
+    const RealType signError=OP::sameSignOfError(p,res);
+
+    if(signError>0.){
+      if(res==0.){
+	return std::numeric_limits<RealType>::denorm_min();
+      }
+      if(res==-std::numeric_limits<RealType>::denorm_min()){
+	return 0.;
+      }
+       return nextAfter<RealType>(res);
+    }
+    return res;
+  } ;
+};
+
+
+template<class OP>
+class RoundingDownward{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    const RealType res=OP::nearestOp(p) ;
+    OP::check(p,res);
+
+    if(isNanInf<RealType>(res)){
+      if(res!=std::numeric_limits<RealType>::infinity()){
+	return res;
+      }else{
+	if(OP::isInfNotSpecificToNearest(p)){
+	  return res;
+	}else{
+	  return std::numeric_limits<RealType>::max();
+	}
+      }
+    }
+
+
+    const RealType signError=OP::sameSignOfError(p,res);
+    if(signError<0){
+      if(res==0.){
+	return -std::numeric_limits<RealType>::denorm_min();
+      }
+      if(res==std::numeric_limits<RealType>::denorm_min()){
+	return 0.;
+      }
+      return nextPrev<RealType>(res);
+    }
+    return res;
+  } ;
+};
+
+
+
+template<class OP>
+class RoundingFarthest{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline RealType apply(const PackArgs& p){
+    const RealType res=OP::nearestOp(p) ;
+    if (isNanInf<RealType> (res)){
+      return res;
+    }
+
+    OP::check(p,res);
+    const RealType error=OP::error(p,res);
+    if(error==0.){
+      return res;
+    }
+    if(error>0){
+      RealType newRes=nextAfter<RealType>(res);
+      RealType ulp(newRes-res);
+      if(2*error < ulp ){
+	return newRes;
+      }else{
+	return res;
+      }
+    }else{//error<0
+      RealType newRes=nextPrev<RealType>(res);
+      RealType ulp(res-newRes);
+      if(-2*error < ulp ){
+	return newRes;
+      }else{
+	return res;
+      }
+    }
+  }
+};
+
+
+
+
+#include "vr_op.hxx"
+
+template<class OP>
+class OpWithSelectedRoundingMode{
+public:
+  typedef typename OP::RealType RealType;
+  typedef typename OP::PackArgs PackArgs;
+
+  static inline void apply(const PackArgs& p, RealType* res, void* context){
+    *res=applySeq(p,context);
+#ifdef DEBUG_PRINT_OP
+    print_debug(p,res);
+#endif
+    if (isNan(*res)) {
+      vr_nanHandler();
+    }
+  }
+
+#ifdef DEBUG_PRINT_OP
+  static inline void print_debug(const PackArgs& p, const RealType* res){
+    static const int nbParam= OP::PackArgs::nb;
+
+    double args[nbParam];
+    const double resDouble(*res);
+    p.serialyzeDouble(args);
+    if(vr_debug_print_op==NULL) return ;
+    vr_debug_print_op(nbParam,OP::OpName(), args, &resDouble);
+  }
+#endif
+
+
+  static inline RealType applySeq(const PackArgs& p, void* context){
+    switch (ROUNDINGMODE) {
+    case VR_NEAREST:
+      return RoundingNearest<OP>::apply (p);
+    case VR_UPWARD:
+      return RoundingUpward<OP>::apply (p);
+    case VR_DOWNWARD:
+      return RoundingDownward<OP>::apply (p);
+    case VR_ZERO:
+      return RoundingZero<OP>::apply (p);
+    case VR_RANDOM:
+      return RoundingRandom<OP>::apply (p);
+    case VR_AVERAGE:
+      return RoundingAverage<OP>::apply (p);
+    case VR_FARTHEST:
+      return RoundingFarthest<OP>::apply (p);
+    case VR_FLOAT:
+      return RoundingFloat<OP>::apply (p);
+    case VR_NATIVE:
+      return RoundingNearest<OP>::apply (p);
+    case VR_FTZ:
+      vr_panicHandler("FTZ not implemented in backend_verrou");
+    }
+
+    return 0;
+  }
+};
+
+//#endif

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -1623,21 +1623,22 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
     }
   }
 
-  struct interflop_backend_interface_t interflop_backend_vprec = {
-      _interflop_add_float,
-      _interflop_sub_float,
-      _interflop_mul_float,
-      _interflop_div_float,
-      NULL,
-      _interflop_add_double,
-      _interflop_sub_double,
-      _interflop_mul_double,
-      _interflop_div_double,
-      NULL,
-      _interflop_enter_function,
-      _interflop_exit_function,
-      NULL,
-      _interflop_finalize};
+
+  struct interflop_backend_interface_t interflop_backend_vprec=interflop_backend_empty_interface;
+
+  interflop_backend_vprec.add_float=_interflop_add_float;
+  interflop_backend_vprec.sub_float=_interflop_sub_float;
+  interflop_backend_vprec.mul_float=_interflop_mul_float;
+  interflop_backend_vprec.div_float=_interflop_div_float;
+
+  interflop_backend_vprec.add_double=_interflop_add_double;
+  interflop_backend_vprec.sub_double=_interflop_sub_double;
+  interflop_backend_vprec.mul_double=_interflop_mul_double;
+  interflop_backend_vprec.div_double=_interflop_div_double;
+
+  interflop_backend_vprec.enter_function=_interflop_enter_function;
+  interflop_backend_vprec.exit_function =_interflop_exit_function;
+  interflop_backend_vprec.finalize=_interflop_finalize;
 
   return interflop_backend_vprec;
 }

--- a/src/common/interflop.h
+++ b/src/common/interflop.h
@@ -95,7 +95,7 @@ struct interflop_backend_interface_t {
   void (*exit_function)(interflop_function_stack_t *stack,
                                   void *context, int nb_args, va_list ap);
 
-  void (*interflop_user_call)(void *context, interflop_call_id id, va_list ap);
+  void (*user_call)(void *context, interflop_call_id id, va_list ap);
   /* interflop_finalize: called at the end of the instrumented program
    * execution */
   void (*finalize)(void *context);

--- a/src/common/interflop.h
+++ b/src/common/interflop.h
@@ -68,31 +68,49 @@ typedef struct interflop_function_stack {
 } interflop_function_stack_t;
 
 struct interflop_backend_interface_t {
-  void (*interflop_add_float)(float a, float b, float *c, void *context);
-  void (*interflop_sub_float)(float a, float b, float *c, void *context);
-  void (*interflop_mul_float)(float a, float b, float *c, void *context);
-  void (*interflop_div_float)(float a, float b, float *c, void *context);
-  void (*interflop_cmp_float)(enum FCMP_PREDICATE p, float a, float b, int *c,
+  const char* (*backend_name)(void);
+  const char* (*backend_version)(void);
+
+  void (*add_float)(float a, float b, float *c, void *context);
+  void (*sub_float)(float a, float b, float *c, void *context);
+  void (*mul_float)(float a, float b, float *c, void *context);
+  void (*div_float)(float a, float b, float *c, void *context);
+  void (*cmp_float)(enum FCMP_PREDICATE p, float a, float b, int *c,
                               void *context);
 
-  void (*interflop_add_double)(double a, double b, double *c, void *context);
-  void (*interflop_sub_double)(double a, double b, double *c, void *context);
-  void (*interflop_mul_double)(double a, double b, double *c, void *context);
-  void (*interflop_div_double)(double a, double b, double *c, void *context);
-  void (*interflop_cmp_double)(enum FCMP_PREDICATE p, double a, double b,
+  void (*add_double)(double a, double b, double *c, void *context);
+  void (*sub_double)(double a, double b, double *c, void *context);
+  void (*mul_double)(double a, double b, double *c, void *context);
+  void (*div_double)(double a, double b, double *c, void *context);
+  void (*cmp_double)(enum FCMP_PREDICATE p, double a, double b,
                                int *c, void *context);
 
-  void (*interflop_enter_function)(interflop_function_stack_t *stack,
+  void (*cast_double_to_float)(double a, float *b, void *context);
+  void (*madd_double)(double a, double b, double c, double *res, void *context);
+  void (*madd_float)(float a, float b, float c, float *res, void *context);
+
+  void (*enter_function)(interflop_function_stack_t *stack,
                                    void *context, int nb_args, va_list ap);
 
-  void (*interflop_exit_function)(interflop_function_stack_t *stack,
+  void (*exit_function)(interflop_function_stack_t *stack,
                                   void *context, int nb_args, va_list ap);
 
   void (*interflop_user_call)(void *context, interflop_call_id id, va_list ap);
   /* interflop_finalize: called at the end of the instrumented program
    * execution */
-  void (*interflop_finalize)(void *context);
+  void (*finalize)(void *context);
 };
+
+#define interflop_backend_empty_interface {	\
+      NULL, NULL,				\
+      NULL, NULL, NULL, NULL, NULL,		\
+      NULL, NULL, NULL, NULL, NULL,		\
+      NULL, NULL, NULL,			\
+      NULL,					\
+      NULL,					\
+      NULL,					\
+      NULL,					\
+      }
 
 /* interflop_init: called at initialization before using a backend.
  * It returns an interflop_backend_interface_t structure with callbacks

--- a/src/vfcwrapper/funcinstr.c
+++ b/src/vfcwrapper/funcinstr.c
@@ -140,8 +140,8 @@ void vfc_enter_function(char *func_name, char isLibraryFunction,
     va_start(ap, n * 4);
 
     for (int i = 0; i < loaded_backends; i++)
-      if (backends[i].interflop_enter_function)
-        backends[i].interflop_enter_function(&_vfc_call_stack, contexts[i], n,
+      if (backends[i].enter_function)
+        backends[i].enter_function(&_vfc_call_stack, contexts[i], n,
                                              ap);
 
     va_end(ap);
@@ -160,8 +160,8 @@ void vfc_exit_function(__attribute__((unused)) char *func_name,
     va_start(ap, n * 4);
 
     for (int i = 0; i < loaded_backends; i++)
-      if (backends[i].interflop_exit_function)
-        backends[i].interflop_exit_function(&_vfc_call_stack, contexts[i], n,
+      if (backends[i].exit_function)
+        backends[i].exit_function(&_vfc_call_stack, contexts[i], n,
                                             ap);
 
     va_end(ap);

--- a/src/vfcwrapper/main.c
+++ b/src/vfcwrapper/main.c
@@ -184,8 +184,8 @@ __attribute__((destructor(0))) static void vfc_atexit(void) {
 
   /* Send finalize message to backends */
   for (int i = 0; i < loaded_backends; i++)
-    if (backends[i].interflop_finalize)
-      backends[i].interflop_finalize(contexts[i]);
+    if (backends[i].finalize)
+      backends[i].finalize(contexts[i]);
 
 #ifdef DDEBUG
   if (dd_generate_path) {
@@ -208,7 +208,7 @@ __attribute__((destructor(0))) static void vfc_atexit(void) {
   do {                                                                         \
     int res = 0;                                                               \
     for (unsigned char i = 0; i < loaded_backends; i++) {                      \
-      if (backends[i].interflop_##operation##_##precision) {                   \
+      if (backends[i].operation##_##precision) {                   \
         res = 1;                                                               \
         break;                                                                 \
       }                                                                        \
@@ -455,9 +455,9 @@ __attribute__((constructor(0))) static void vfc_init(void) {
 void interflop_call(interflop_call_id id, ...) {
   va_list ap;
   for (unsigned char i = 0; i < loaded_backends; i++) {
-    if (backends[i].interflop_user_call) {
+    if (backends[i].user_call) {
       va_start(ap, id);
-      backends[i].interflop_user_call(contexts[i], id, ap);
+      backends[i].user_call(contexts[i], id, ap);
       va_end(ap);
     }
   }
@@ -468,8 +468,8 @@ void interflop_call(interflop_call_id id, ...) {
     precision c = NAN;                                                         \
     ddebug(operator);                                                          \
     for (unsigned char i = 0; i < loaded_backends; i++) {                      \
-      if (backends[i].interflop_##operation##_##precision) {                   \
-        backends[i].interflop_##operation##_##precision(a, b, &c,              \
+      if (backends[i].operation##_##precision) {                   \
+        backends[i].operation##_##precision(a, b, &c,              \
                                                         contexts[i]);          \
       }                                                                        \
     }                                                                          \
@@ -488,8 +488,8 @@ define_arithmetic_wrapper(double, div, /);
 int _floatcmp(enum FCMP_PREDICATE p, float a, float b) {
   int c;
   for (unsigned int i = 0; i < loaded_backends; i++) {
-    if (backends[i].interflop_cmp_float) {
-      backends[i].interflop_cmp_float(p, a, b, &c, contexts[i]);
+    if (backends[i].cmp_float) {
+      backends[i].cmp_float(p, a, b, &c, contexts[i]);
     }
   }
   return c;
@@ -498,8 +498,8 @@ int _floatcmp(enum FCMP_PREDICATE p, float a, float b) {
 int _doublecmp(enum FCMP_PREDICATE p, double a, double b) {
   int c;
   for (unsigned int i = 0; i < loaded_backends; i++) {
-    if (backends[i].interflop_cmp_double) {
-      backends[i].interflop_cmp_double(p, a, b, &c, contexts[i]);
+    if (backends[i].cmp_double) {
+      backends[i].cmp_double(p, a, b, &c, contexts[i]);
     }
   }
   return c;


### PR DESCRIPTION
Verrou (https://github.com/edf-hpc/verrou) has developed a Stochastic-Rounding backend built upon Error Free Transformations (EFT).
One of the objectives of the Interflop ANR project (https://www.interflop.fr/) is to allow interoperability between numerical tools. In this PR we continue the work of @lathuili to integrate Verrou SR backend into Verificarlo through the common interflop interface.

Status: The backend builds and seems to work ok on simple tests.
Todo:

- [ ] Make the backend thread-safe
- [ ] Normalize names and interface
- [ ] Add verificarlo documentation
- [ ] Add tests
