### PR TITLE
Fix options in MCA integer backend

### DIFF
--- a/doc/02-Backends.md
+++ b/doc/02-Backends.md
@@ -159,13 +159,15 @@ operations count:
 
 The MCA backends implement Montecarlo Arithmetic.
 
-There are two available backends with indentical user options:
+There are two available backends:
 
 - `libinterflop_mca.so`: uses floating point types to represent stochastic
   noise.  It uses quad type to compute MCA operations on doubles and double
   type to compute MCA operations on floats.
 - `libinterflop_mca_int.so`: uses integer types to represent stochastic noise.
-  In most architectures, this backend should be faster.
+  In most architectures, this backend should be faster. The MCA integer backend 
+  only supports default precision and relative error mode; some user options
+  are therefore unavailable.
 
 ```bash
 VFC_BACKENDS="libinterflop_mca.so --help" ./test

--- a/src/backends/interflop-mca-int/interflop_mca_int.c
+++ b/src/backends/interflop-mca-int/interflop_mca_int.c
@@ -365,16 +365,8 @@ _INTERFLOP_OP_CALL(double, mul, mca_mul, _mca_binary64_binary_op)
 _INTERFLOP_OP_CALL(double, div, mca_div, _mca_binary64_binary_op)
 
 static struct argp_option options[] = {
-    {key_prec_b32_str, KEY_PREC_B32, "PRECISION", 0,
-     "select precision for binary32 (PRECISION > 0)", 0},
-    {key_prec_b64_str, KEY_PREC_B64, "PRECISION", 0,
-     "select precision for binary64 (PRECISION > 0)", 0},
     {key_mode_str, KEY_MODE, "MODE", 0,
      "select MCA mode among {ieee, mca, pb, rr}", 0},
-    {key_err_mode_str, KEY_ERR_MODE, "ERROR_MODE", 0,
-     "select error mode among {rel, abs, all}", 0},
-    {key_err_exp_str, KEY_ERR_EXP, "MAX_ABS_ERROR_EXPONENT", 0,
-     "select magnitude of the maximum absolute error", 0},
     {key_seed_str, KEY_SEED, "SEED", 0, "fix the random generator seed", 0},
     {key_daz_str, KEY_DAZ, 0, 0,
      "denormals-are-zero: sets denormals inputs to zero", 0},
@@ -389,28 +381,6 @@ error_t parse_opt(int key, char *arg, struct argp_state *state) {
   char *endptr;
   int val = -1;
   switch (key) {
-  case KEY_PREC_B32:
-    /* precision for binary32 */
-    errno = 0;
-    val = strtol(arg, &endptr, 10);
-    if (errno != 0 || val <= 0) {
-      logger_error("--%s invalid value provided, must be a positive integer",
-                   key_prec_b32_str);
-    } else {
-      _set_mca_precision_binary32(val);
-    }
-    break;
-  case KEY_PREC_B64:
-    /* precision for binary64 */
-    errno = 0;
-    val = strtol(arg, &endptr, 10);
-    if (errno != 0 || val <= 0) {
-      logger_error("--%s invalid value provided, must be a positive integer",
-                   key_prec_b64_str);
-    } else {
-      _set_mca_precision_binary64(val);
-    }
-    break;
   case KEY_MODE:
     /* mca mode */
     if (strcasecmp(MCA_MODE_STR[mcamode_ieee], arg) == 0) {
@@ -425,27 +395,6 @@ error_t parse_opt(int key, char *arg, struct argp_state *state) {
       logger_error("--%s invalid value provided, must be one of: "
                    "{ieee, mca, pb, rr}.",
                    key_mode_str);
-    }
-    break;
-  case KEY_ERR_MODE:
-    /* mca error mode */
-    if (!strcasecmp(MCA_ERR_MODE_STR[mca_err_mode_rel], arg) == 0) {
-      ctx->relErr = true;
-      ctx->absErr = false;
-    } else {
-      logger_error("--%s invalid value provided, must be one of: "
-                   "{rel}.\n"
-                   "interflop_mca_int only supports relative error mode.",
-                   key_err_mode_str);
-    }
-    break;
-  case KEY_ERR_EXP:
-    /* exponent of the maximum absolute error */
-    errno = 0;
-    ctx->absErr_exp = strtol(arg, &endptr, 10);
-    if (errno != 0) {
-      logger_error("--%s invalid value provided, must be an integer",
-                   key_err_exp_str);
     }
     break;
   case KEY_SEED:
@@ -531,6 +480,8 @@ struct interflop_backend_interface_t interflop_init(int argc, char **argv,
   /* Initialize the logger */
   logger_init();
 
+  /* Mca integer backend only supports default precision 
+     and relative error mode */
   _set_mca_precision_binary32(MCA_PRECISION_BINARY32_DEFAULT);
   _set_mca_precision_binary64(MCA_PRECISION_BINARY64_DEFAULT);
   _set_mca_mode(MCA_MODE_DEFAULT);


### PR DESCRIPTION
Some of the user options such as custom precisions and relative error are currently unsupported in the MCA integer backend.

This PR removes the options explicitly and document the missing options.