### PR TITLE
Fix CI workflow templates by setting safe.directory

### DIFF
--- a/src/tools/ci/workflow_templates/gitlab-ci.j2.yml
+++ b/src/tools/ci/workflow_templates/gitlab-ci.j2.yml
@@ -12,6 +12,7 @@ run_verificarlo_tests:
   stage: run_verificarlo_tests
 
   before_script:
+  - git config --global --add safe.directory "$(pwd)"
   - git remote set-url origin https://{{username}}:${CI_PUSH_TOKEN}@{{remote_url}}.git
   - git config --global user.email "{{email}}"
   - git config --global user.name "{{username}}"

--- a/src/tools/ci/workflow_templates/vfc_test_workflow.j2.yml
+++ b/src/tools/ci/workflow_templates/vfc_test_workflow.j2.yml
@@ -22,7 +22,9 @@ jobs:
             fetch-depth: 0
 
       - name: Run tests
-        run: vfc_ci test -g -r
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          vfc_ci test -g -r
 
       - name: Commit test results
         run: |


### PR DESCRIPTION
After a recent security vulnerability, Git changed the way it looks for repositories in parent directories (https://github.blog/2022-04-12-git-security-vulnerability-announced/). The easiest fix seems to set the safe.directory variable at the beginning at the workflow to set an exception to the old behavious, which caused the repository to not be detected in the CI runner.