### PR TITLE
Better error message when VFC_BACKENDS is undefined

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,4 +44,4 @@ clean-local: cleantests
 cleantests:
 # Clean tests directory
 	cd tests/ && ./clean.sh && cd ..
-	@echo "tests directory are cleaned."
+	@echo "tests directory is clean."

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -117,7 +117,6 @@ typedef enum {
 typedef enum {
   preset_binary16,
   preset_binary32,
-  preset_binary64,
   preset_bfloat16,
   preset_tensorfloat,
   preset_fp24,
@@ -127,7 +126,6 @@ typedef enum {
 typedef enum {
   preset_precision_binary16 = 10,
   preset_precision_binary32 = 23,
-  preset_precision_binary64 = 52,
   preset_precision_bfloat16 = 7,
   preset_precision_tensorfloat = 10,
   preset_precision_fp24 = 16,
@@ -137,16 +135,14 @@ typedef enum {
 typedef enum {
   preset_range_binary16 = 5,
   preset_range_binary32 = 8,
-  preset_range_binary64 = 11,
   preset_range_bfloat16 = 8,
   preset_range_tensorfloat = 8,
   preset_range_fp24 = 7,
   preset_range_PXR24 = 8
 } vprec_preset_range;
 
-static const char *VPREC_PRESET_STR[] = {"binary16", "binary32",    "binary64",
-                                         "bfloat16", "tensorfloat", "fp24",
-                                         "PXR24"};
+static const char *VPREC_PRESET_STR[] = {"binary16",    "binary32", "bfloat16",
+                                         "tensorfloat", "fp24",     "PXR24"};
 
 /* define default environment variables and default parameters */
 
@@ -1316,9 +1312,8 @@ static struct argp_option options[] = {
      "bfloat16, tensorfloat, fp24, PXR24}\n"
      "Format (range, precision) : "
      "binary16 (5, 10), binary32 (8, 23), "
-     "binary64 (11, 52), bfloat16 (8, 7), "
-     "tensorfloat (8, 10), fp24 (7, 16), "
-     "PXR24 (8, 15)",
+     "bfloat16 (8, 7), tensorfloat (8, 10), "
+     "fp24 (7, 16), PXR24 (8, 15)",
      0},
     {key_mode_str, KEY_MODE, "MODE", 0,
      "select VPREC mode among {ieee, full, ib, ob}", 0},
@@ -1493,9 +1488,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     } else if (strcmp(VPREC_PRESET_STR[preset_binary32], arg) == 0) {
       precision = preset_precision_binary32;
       range = preset_range_binary32;
-    } else if (strcmp(VPREC_PRESET_STR[preset_binary64], arg) == 0) {
-      precision = preset_precision_binary64;
-      range = preset_range_binary64;
     } else if (strcmp(VPREC_PRESET_STR[preset_bfloat16], arg) == 0) {
       precision = preset_precision_bfloat16;
       range = preset_range_bfloat16;

--- a/src/common/logger.c
+++ b/src/common/logger.c
@@ -145,7 +145,7 @@ void set_logger_logfile(void) {
   }
   const char *logger_logfile_env = getenv(vfc_backends_logfile);
   if (logger_logfile_env == NULL) {
-    logger_logfile = stdout;
+    logger_logfile = stderr;
   } else {
     /* Create log file specific to TID to avoid non-deterministic output */
     char tmp[1024];

--- a/src/vfcwrapper/main.c
+++ b/src/vfcwrapper/main.c
@@ -313,7 +313,9 @@ __attribute__((constructor(0))) static void vfc_init(void) {
   parse_vfc_backends_env(&vfc_backends, &vfc_backends_env);
 
   if (vfc_backends == NULL) {
-    logger_error("%s is empty, at least one backend should be provided",
+    logger_error("At least one backend should be provided "
+                 "by defining VFC_BACKENDS or VFC_BACKENDS_FROM_FILE "
+                 "environment variables",
                  vfc_backends_env);
   }
 

--- a/tests/test_ieee_backend/test_options.sh
+++ b/tests/test_ieee_backend/test_options.sh
@@ -7,7 +7,7 @@ export VFC_BACKENDS_LOGGER="true"
 run() {
     export VFC_BACKENDS="libinterflop_ieee.so ${DEBUG_MODE} ${OPTIONS}"
     echo -e "\n### ${VFC_BACKENDS}"
-    ./test_options >log
+    ./test_options 2>log
 }
 
 eval_condition() {

--- a/tests/test_logger/test.sh
+++ b/tests/test_logger/test.sh
@@ -68,12 +68,11 @@ run() {
 
 compile
 
-echo "* Test 1: Check logger_info is redirected on stdout by default"
+echo "* Test 1: Check logger_info is redirected on stderr by default"
 reset_env
 run
-check_logger_info $OUTPUT_FILE "Error: logger_info not displayed on stdout"
-check_backend_info $OUTPUT_FILE "Error: logger_info not displayed on stdout"
-check_empty $ERROR_FILE "Error: stderr non empty"
+check_logger_info $ERROR_FILE "Error: logger_info not displayed on stderr"
+check_backend_info $ERROR_FILE "Error: logger_info not displayed on stderr"
 
 echo "* Test 2: Check VFC_BACKENDS_LOGGER=False disables the logger_info"
 reset_env

--- a/tests/test_usercall_change_precision/test.c
+++ b/tests/test_usercall_change_precision/test.c
@@ -25,5 +25,5 @@ int main (int argc, char ** argv)
     for(int i = 0; i < 5; i++)
         r = r * p;
 
-    fprintf(stderr, "%f\n", r);
+    fprintf(stdout, "%f\n", r);
 }

--- a/tests/test_usercall_change_precision/test.sh
+++ b/tests/test_usercall_change_precision/test.sh
@@ -7,9 +7,9 @@ clean() {
 clean
 verificarlo-c test.c -o test
 
-VFC_BACKENDS="libinterflop_mca.so --precision-binary32 23 --seed=1234" ./test 0 0 2> 23.log > /dev/null
-VFC_BACKENDS="libinterflop_mca.so --precision-binary32 10 --seed=1234" ./test 0 0 2> 10.log > /dev/null
-VFC_BACKENDS="libinterflop_mca.so --precision-binary32 23 --seed=1234" ./test 1 0 2> change.log > /dev/null
+VFC_BACKENDS="libinterflop_mca.so --precision-binary32 23 --seed=1234" ./test 0 0 > 23.log 2> /dev/null
+VFC_BACKENDS="libinterflop_mca.so --precision-binary32 10 --seed=1234" ./test 0 0 > 10.log 2> /dev/null
+VFC_BACKENDS="libinterflop_mca.so --precision-binary32 23 --seed=1234" ./test 1 0 > change.log 2> /dev/null
 
 DIFF=$(diff change.log 23.log)
 if [[ $DIFF == "" ]]; then
@@ -23,9 +23,9 @@ if [[ $DIFF != "" ]]; then
         exit 1
     fi
 
-VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23" ./test 0 0 2> 23.log > /dev/null
-VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 10" ./test 0 0 2> 10.log > /dev/null
-VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23" ./test 1 0 2> change.log > /dev/null
+VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23" ./test 0 0 > 23.log 2> /dev/null
+VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 10" ./test 0 0 > 10.log 2> /dev/null
+VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23" ./test 1 0 > change.log 2> /dev/null
 
 DIFF=$(diff change.log 23.log)
 if [[ $DIFF == "" ]]; then
@@ -39,9 +39,9 @@ if [[ $DIFF != "" ]]; then
         exit 1
     fi
 
-VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23 --range-binary32=8" ./test 0 0 2> r8.log > /dev/null
-VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23 --range-binary32=2" ./test 0 0 2> r2.log > /dev/null
-VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23 --range-binary32=8" ./test 0 1 2> change.log > /dev/null
+VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23 --range-binary32=8" ./test 0 0 > r8.log 2> /dev/null
+VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23 --range-binary32=2" ./test 0 0 > r2.log 2> /dev/null
+VFC_BACKENDS="libinterflop_vprec.so --precision-binary32 23 --range-binary32=8" ./test 0 1 > change.log 2> /dev/null
 
 DIFF=$(diff change.log r8.log)
 if [[ $DIFF == "" ]]; then


### PR DESCRIPTION
Before the default error message pointed to VFC_BACKENDS_FROM_FILE only which is not the default way to define backends in the documentation. This could be confusing for new users.

If no logfile is specified send all logger messages to stderr.
Having verificarlo logger messages mixed with the program output
complicates many simple use cases. Because the log files are per pid,
they quickly mess up the working space when working interactively.

For the use case where we need to keep info messages outside of stderr,
we can still do this by explicitly exporting VFC_BACKEND_LOGFILE.