### PR TITLE
Porting verificarlo to aarch64 (arm64)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 Verificarlo CHANGELOG
 
+# [master] unreleased
+  * Added support for Aarch64 (arm64) architectures
+  * verificarlo accepts LLVM byte-code as input and can produce byte-code as output
+
 # [v0.9.1] 2022/10/21
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A tool for debugging and assessing floating point precision and reproducibility.
 
 ## Installation
 
-To install Verificarlo please refer to the [installation documentation](doc/01-Install.md).
+To install Verificarlo please refer to the [installation documentation](doc/01-Install.md). Verificarlo supports both amd64 and aarch64 architectures.
 
 ## Using Verificarlo through its Docker image
 

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,14 @@ else
    AC_SUBST(FC, $FLANG)
 fi
 
+# Check for addr2line (required by delta-debug DDEBUG)
+AC_PATH_PROGS([ADDR2LINE], [llvm-addr2line addr2line], "", $LLVM_BINDIR/ $PATH)
+if test -z "$ADDR2LINE"; then
+  AC_MSG_ERROR([Could not find llvm-addr2line or addr2line])
+fi
+AC_DEFINE_UNQUOTED([ADDR2LINE_PATH], ["$ADDR2LINE"], [addr2line path])
+AC_SUBST(ADDR2LINE_PATH, $ADDR2LINE)
+
 # Check for parallel (required for the test infrastructure)
 AC_PATH_PROG(PARALLEL, [parallel], [])
 if test -z "$PARALLEL"; then

--- a/configure.ac
+++ b/configure.ac
@@ -134,10 +134,10 @@ if test "x$cc_have_uint128" = "xno"; then
    AC_MSG_ERROR([__uint128_t is not supported])
 fi
 
-# Checks if __float128 is supported
-AC_CHECK_TYPE(__float128,[cc_have_float128="yes"], [cc_have_float128="no"])
+# Checks if _Float128 is supported
+AC_CHECK_TYPE(_Float128,[cc_have_float128="yes"], [cc_have_float128="no"])
 if test "x$cc_have_float128" = "xno"; then
-   AC_MSG_ERROR([__float128 is not supported])
+   AC_MSG_ERROR([_Float128 is not supported])
 fi
 
 # Checks if _Generic keyword is supported

--- a/src/backends/interflop-mca-int/interflop_mca_int.c
+++ b/src/backends/interflop-mca-int/interflop_mca_int.c
@@ -224,7 +224,7 @@ static void _noise_binary128(_Float128 *x, const int exp,
 /* Generic function for computing the mca noise */
 #define _NOISE(X, EXP, RNG_STATE)                                              \
   _Generic(*X, double                                                          \
-           : _noise_binary64, _Float128                                       \
+           : _noise_binary64, _Float128                                        \
            : _noise_binary128)(X, EXP, RNG_STATE)
 
 /* Macro function that adds mca noise to X
@@ -258,7 +258,7 @@ static void _mca_inexact_binary128(_Float128 *qa, void *context) {
 /* The function is choosen depending on the type of X  */
 #define _INEXACT_BINARYN(X, A, CTX)                                            \
   _Generic(X, double                                                           \
-           : _mca_inexact_binary64, _Float128                                 \
+           : _mca_inexact_binary64, _Float128                                  \
            : _mca_inexact_binary128)(A, CTX)
 
 /******************** MCA ARITHMETIC FUNCTIONS ********************

--- a/src/backends/interflop-mca-int/interflop_mca_int.c
+++ b/src/backends/interflop-mca-int/interflop_mca_int.c
@@ -190,10 +190,10 @@ static inline void _noise_binary64(double *x, const int exp,
 /* is comprised between: */
 /* 1023+1023 = 2046 < QUAD_EXP_MAX (16383)  */
 /* -1022-53+-1022-53 = -2200 > QUAD_EXP_MIN (-16382) */
-static void _noise_binary128(__float128 *x, const int exp,
+static void _noise_binary128(_Float128 *x, const int exp,
                              rng_state_t *rng_state) {
 
-  // Convert preserving-bytes __float128 to __int128
+  // Convert preserving-bytes _Float128 to __int128
   binary128 *b128 = (binary128 *)x;
 
   // amount by which to shift the noise term sign (1) + exp (15) + noise
@@ -224,7 +224,7 @@ static void _noise_binary128(__float128 *x, const int exp,
 /* Generic function for computing the mca noise */
 #define _NOISE(X, EXP, RNG_STATE)                                              \
   _Generic(*X, double                                                          \
-           : _noise_binary64, __float128                                       \
+           : _noise_binary64, _Float128                                       \
            : _noise_binary128)(X, EXP, RNG_STATE)
 
 /* Macro function that adds mca noise to X
@@ -250,7 +250,7 @@ static void _mca_inexact_binary64(double *da, void *context) {
 }
 
 /* Adds the mca noise to qa */
-static void _mca_inexact_binary128(__float128 *qa, void *context) {
+static void _mca_inexact_binary128(_Float128 *qa, void *context) {
   _INEXACT(qa, MCALIB_BINARY64_T, context, rng_state);
 }
 
@@ -258,7 +258,7 @@ static void _mca_inexact_binary128(__float128 *qa, void *context) {
 /* The function is choosen depending on the type of X  */
 #define _INEXACT_BINARYN(X, A, CTX)                                            \
   _Generic(X, double                                                           \
-           : _mca_inexact_binary64, __float128                                 \
+           : _mca_inexact_binary64, _Float128                                 \
            : _mca_inexact_binary128)(A, CTX)
 
 /******************** MCA ARITHMETIC FUNCTIONS ********************
@@ -324,7 +324,7 @@ inline float _mca_binary32_binary_op(const float a, const float b,
 /* Intermediate computations are performed with binary128 */
 inline double _mca_binary64_binary_op(const double a, const double b,
                                       const mca_operations qop, void *context) {
-  _MCA_BINARY_OP(a, b, qop, context, (__float128)0);
+  _MCA_BINARY_OP(a, b, qop, context, (_Float128)0);
 }
 
 /************************* FPHOOKS FUNCTIONS *************************

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -243,7 +243,7 @@ static _Float128 _noise_binary128(const int exp, rng_state_t *rng_state) {
 /* Generic function for computing the mca noise */
 #define _NOISE(X, EXP, RNG_STATE)                                              \
   _Generic(X, double                                                           \
-           : _noise_binary64, _Float128                                       \
+           : _noise_binary64, _Float128                                        \
            : _noise_binary128)(EXP, RNG_STATE)
 
 /* Fast version of _INEXACT macro that adds noise in relative error.
@@ -303,7 +303,7 @@ static void _mca_inexact_binary128(_Float128 *qa, void *context) {
 /* The function is choosen depending on the type of X  */
 #define _INEXACT_BINARYN(X, A, CTX)                                            \
   _Generic(X, double                                                           \
-           : _mca_inexact_binary64, _Float128                                 \
+           : _mca_inexact_binary64, _Float128                                  \
            : _mca_inexact_binary128)(A, CTX)
 
 /******************** MCA ARITHMETIC FUNCTIONS ********************

--- a/src/backends/interflop-mca/interflop_mca.c
+++ b/src/backends/interflop-mca/interflop_mca.c
@@ -213,10 +213,10 @@ static inline double _noise_binary64(const int exp, rng_state_t *rng_state) {
 /* is comprised between: */
 /* 1023+1023 = 2046 < QUAD_EXP_MAX (16383)  */
 /* -1022-53+-1022-53 = -2200 > QUAD_EXP_MIN (-16382) */
-static __float128 _noise_binary128(const int exp, rng_state_t *rng_state) {
+static _Float128 _noise_binary128(const int exp, rng_state_t *rng_state) {
   /* random number in (-0.5, 0.5) */
-  const __float128 noise =
-      (__float128)get_rand_double01(rng_state, &global_tid) - 0.5Q;
+  const _Float128 noise =
+      (_Float128)get_rand_double01(rng_state, &global_tid) - 0.5Q;
   binary128 b128 = {.f128 = noise};
   b128.ieee128.exponent = b128.ieee128.exponent + exp;
   return b128.f128;
@@ -243,7 +243,7 @@ static __float128 _noise_binary128(const int exp, rng_state_t *rng_state) {
 /* Generic function for computing the mca noise */
 #define _NOISE(X, EXP, RNG_STATE)                                              \
   _Generic(X, double                                                           \
-           : _noise_binary64, __float128                                       \
+           : _noise_binary64, _Float128                                       \
            : _noise_binary128)(EXP, RNG_STATE)
 
 /* Fast version of _INEXACT macro that adds noise in relative error.
@@ -295,7 +295,7 @@ static void _mca_inexact_binary64(double *da, void *context) {
 }
 
 /* Adds the mca noise to qa */
-static void _mca_inexact_binary128(__float128 *qa, void *context) {
+static void _mca_inexact_binary128(_Float128 *qa, void *context) {
   _INEXACT(qa, MCALIB_BINARY64_T, context, rng_state);
 }
 
@@ -303,7 +303,7 @@ static void _mca_inexact_binary128(__float128 *qa, void *context) {
 /* The function is choosen depending on the type of X  */
 #define _INEXACT_BINARYN(X, A, CTX)                                            \
   _Generic(X, double                                                           \
-           : _mca_inexact_binary64, __float128                                 \
+           : _mca_inexact_binary64, _Float128                                 \
            : _mca_inexact_binary128)(A, CTX)
 
 /******************** MCA ARITHMETIC FUNCTIONS ********************
@@ -369,7 +369,7 @@ inline float _mca_binary32_binary_op(const float a, const float b,
 /* Intermediate computations are performed with binary128 */
 inline double _mca_binary64_binary_op(const double a, const double b,
                                       const mca_operations qop, void *context) {
-  _MCA_BINARY_OP(a, b, qop, context, (__float128)0);
+  _MCA_BINARY_OP(a, b, qop, context, (_Float128)0);
 }
 
 /************************* FPHOOKS FUNCTIONS *************************
@@ -396,7 +396,7 @@ _INTERFLOP_OP_CALL(double, div, mca_div, _mca_binary64_binary_op)
 
 void _interflop_usercall_inexact(void *context, va_list ap) {
   double xd = 0;
-  __float128 xq = 0;
+  _Float128 xq = 0;
   enum FTYPES ftype;
   void *value = NULL;
   int precision = 0, t = 0;
@@ -417,9 +417,9 @@ void _interflop_usercall_inexact(void *context, va_list ap) {
     *((double *)value) = xq;
     break;
   case FQUAD:
-    xq = *((__float128 *)value);
+    xq = *((_Float128 *)value);
     _FAST_INEXACT(&xq, precision, context, rng_state);
-    *((__float128 *)value) = xq;
+    *((_Float128 *)value) = xq;
     break;
   default:
     logger_warning(

--- a/src/backends/interflop-vprec/interflop_vprec.c
+++ b/src/backends/interflop-vprec/interflop_vprec.c
@@ -653,13 +653,13 @@ typedef struct _vprec_inst_function {
   // Id of the function
   char id[500];
   // Indicate if the function is from library
-  short isLibraryFunction;
+  char isLibraryFunction;
   // Indicate if the function is intrinsic
-  short isIntrinsicFunction;
-  // Counter of Floating Point instruction
-  size_t useFloat;
-  // Counter of Floating Point instruction
-  size_t useDouble;
+  char isIntrinsicFunction;
+  // Uses single Floating Point instruction
+  char useFloat;
+  // Uses double Floating Point instruction
+  char useDouble;
   // Internal Operations Range64
   int OpsRange64;
   // Internal Operations Prec64
@@ -688,7 +688,7 @@ void _vprec_write_hasmap(FILE *fout) {
       _vprec_inst_function_t *function =
           (_vprec_inst_function_t *)get_value_at(_vprec_func_map->items, ii);
 
-      fprintf(fout, "%s\t%hd\t%hd\t%zu\t%zu\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+      fprintf(fout, "%s\t%hhd\t%hhd\t%hhd\t%hhd\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
               function->id, function->isLibraryFunction,
               function->isIntrinsicFunction, function->useFloat,
               function->useDouble, function->OpsPrec64, function->OpsRange64,
@@ -721,7 +721,7 @@ void _vprec_write_hasmap(FILE *fout) {
 void _vprec_read_hasmap(FILE *fin) {
   _vprec_inst_function_t function;
 
-  while (fscanf(fin, "%s\t%hd\t%hd\t%zu\t%zu\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+  while (fscanf(fin, "%s\t%hhd\t%hhd\t%hhd\t%hhd\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
                 function.id, &function.isLibraryFunction,
                 &function.isIntrinsicFunction, &function.useFloat,
                 &function.useDouble, &function.OpsPrec64, &function.OpsRange64,

--- a/src/common/float_struct.h
+++ b/src/common/float_struct.h
@@ -15,12 +15,12 @@
 /* Main union type we use to manipulate the floating-point type.  */
 
 typedef union {
-  __float128 f128;
+  _Float128 f128;
   __uint128_t u128;
   __int128_t i128;
 
   /* Generic fields */
-  __float128 type;
+  _Float128 type;
   __int128_t i;
   __uint128_t u;
 

--- a/src/common/float_utils.h
+++ b/src/common/float_utils.h
@@ -110,7 +110,7 @@ int fpq(_Float128 x) {
              double                                                            \
            : __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL,              \
                                   FP_SUBNORMAL, FP_ZERO, X),                   \
-             _Float128                                                        \
+             _Float128                                                         \
            : __builtin_fpclassify(QUADFP_NAN, QUADFP_INFINITE, QUADFP_NORMAL,  \
                                   QUADFP_SUBNORMAL, QUADFP_ZERO, X))
 #endif
@@ -182,7 +182,7 @@ static inline bool _is_representable_binary128(const _Float128 x,
 #define _IS_REPRESENTABLE(X, VT)                                               \
   _Generic(X, float                                                            \
            : _is_representable_binary32, double                                \
-           : _is_representable_binary64, _Float128                            \
+           : _is_representable_binary64, _Float128                             \
            : _is_representable_binary128)(X, VT)
 
 /* Returns the unbiased exponent of the binary32 f */
@@ -234,7 +234,7 @@ static inline _Float128 _fast_pow2_binary128(const int exp) {
 #define GET_EXP_FLT(X)                                                         \
   _Generic(X, float                                                            \
            : _get_exponent_binary32, double                                    \
-           : _get_exponent_binary64, _Float128                                \
+           : _get_exponent_binary64, _Float128                                 \
            : _get_exponent_binary128)(X)
 
 #endif /* __FLOAT_UTILS_H__ */

--- a/src/common/float_utils.h
+++ b/src/common/float_utils.h
@@ -81,7 +81,7 @@ int fpd(double x) {
   return f;
 }
 
-int fpq(__float128 x) {
+int fpq(_Float128 x) {
   binary128 b128 = {.f128 = x};
   int f = -1;
   if (b128.ieee128.exponent == QUAD_EXP_INF && b128.ieee128.mantissa == 0) {
@@ -101,7 +101,7 @@ int fpq(__float128 x) {
 
 #if __clang__
 #define FPCLASSIFY(X)                                                          \
-  _Generic(X, float : fpf(X), double : fpd(X), __float128 : fpq(X))
+  _Generic(X, float : fpf(X), double : fpd(X), _Float128 : fpq(X))
 #elif __GNUC__
 #define FPCLASSIFY(X)                                                          \
   _Generic(X, float                                                            \
@@ -110,7 +110,7 @@ int fpq(__float128 x) {
              double                                                            \
            : __builtin_fpclassify(FP_NAN, FP_INFINITE, FP_NORMAL,              \
                                   FP_SUBNORMAL, FP_ZERO, X),                   \
-             __float128                                                        \
+             _Float128                                                        \
            : __builtin_fpclassify(QUADFP_NAN, QUADFP_INFINITE, QUADFP_NORMAL,  \
                                   QUADFP_SUBNORMAL, QUADFP_ZERO, X))
 #endif
@@ -156,7 +156,7 @@ static inline bool _is_representable_binary64(const double x,
 
 /* Return true if the binary128 x is representable on the precision
  * virtual_precision  */
-static inline bool _is_representable_binary128(const __float128 x,
+static inline bool _is_representable_binary128(const _Float128 x,
                                                const int virtual_precision) {
   binary128 b128 = {.f128 = x};
   /* We must check if the mantissa is 0 since the behavior of ctzl is undefied
@@ -182,7 +182,7 @@ static inline bool _is_representable_binary128(const __float128 x,
 #define _IS_REPRESENTABLE(X, VT)                                               \
   _Generic(X, float                                                            \
            : _is_representable_binary32, double                                \
-           : _is_representable_binary64, __float128                            \
+           : _is_representable_binary64, _Float128                            \
            : _is_representable_binary128)(X, VT)
 
 /* Returns the unbiased exponent of the binary32 f */
@@ -200,7 +200,7 @@ static inline int32_t _get_exponent_binary64(const double d) {
 }
 
 /* Returns the unbiased exponent of the binary128 q */
-static inline int32_t _get_exponent_binary128(const __float128 q) {
+static inline int32_t _get_exponent_binary128(const _Float128 q) {
   binary128 x = {.f128 = q};
   /* Substracts the bias */
   return x.ieee.exponent - QUAD_EXP_COMP;
@@ -224,7 +224,7 @@ static inline double _fast_pow2_binary64(const int exp) {
 
 /* Returns 2^exp for binary128 */
 /* Fast function that implies no overflow neither underflow */
-static inline __float128 _fast_pow2_binary128(const int exp) {
+static inline _Float128 _fast_pow2_binary128(const int exp) {
   binary128 b128 = {.f128 = 0.0Q};
   b128.ieee128.exponent = exp + QUAD_EXP_COMP;
   return b128.f128;
@@ -234,7 +234,7 @@ static inline __float128 _fast_pow2_binary128(const int exp) {
 #define GET_EXP_FLT(X)                                                         \
   _Generic(X, float                                                            \
            : _get_exponent_binary32, double                                    \
-           : _get_exponent_binary64, __float128                                \
+           : _get_exponent_binary64, _Float128                                \
            : _get_exponent_binary128)(X)
 
 #endif /* __FLOAT_UTILS_H__ */

--- a/src/libvfcfuncinstrument/libVFCFuncInstrument.cpp
+++ b/src/libvfcfuncinstrument/libVFCFuncInstrument.cpp
@@ -427,12 +427,10 @@ struct VfclibFunc : public ModulePass {
     // void vfc_enter_function (char*, char, char, char, char, int, ...)
     func_enter = Function::Create(FunTy, Function::ExternalLinkage,
                                   "vfc_enter_function", &M);
-    func_enter->setCallingConv(CallingConv::C);
 
     // void vfc_exit_function (char*, char, char, char, char, int, ...)
     func_exit = Function::Create(FunTy, Function::ExternalLinkage,
                                  "vfc_exit_function", &M);
-    func_exit->setCallingConv(CallingConv::C);
 
     /*************************************************************************
      *                             Main special case                         *

--- a/src/vfcwrapper/Makefile.am
+++ b/src/vfcwrapper/Makefile.am
@@ -1,7 +1,8 @@
 
 include_HEADERS=vfcwrapper.c
 vfcwrapper.c: main.c hashset.c
-	@echo "// vfcwrapper.c is automatically generated" > vfcwrapper.c
+	@cat ../../config.h | grep 'LLVM_BINDIR' > vfcwrapper.c
+	@echo "// vfcwrapper.c is automatically generated" >> vfcwrapper.c
 	@echo "// do not modify this file directly" >> vfcwrapper.c
 	@cat main.c funcinstr.c ../common/vfc_hashmap.c ../common/logger.c >> vfcwrapper.c
 

--- a/src/vfcwrapper/Makefile.am
+++ b/src/vfcwrapper/Makefile.am
@@ -1,7 +1,7 @@
 
 include_HEADERS=vfcwrapper.c
 vfcwrapper.c: main.c hashset.c
-	@cat ../../config.h | grep 'LLVM_BINDIR' > vfcwrapper.c
+	@cat ../../config.h | grep 'ADDR2LINE_PATH' > vfcwrapper.c
 	@echo "// vfcwrapper.c is automatically generated" >> vfcwrapper.c
 	@echo "// do not modify this file directly" >> vfcwrapper.c
 	@cat main.c funcinstr.c ../common/vfc_hashmap.c ../common/logger.c >> vfcwrapper.c

--- a/src/vfcwrapper/funcinstr.c
+++ b/src/vfcwrapper/funcinstr.c
@@ -120,8 +120,8 @@ void vfc_call_stack_free() {
 
 // Function called before each function's call of the code
 void vfc_enter_function(char *func_name, char isLibraryFunction,
-                        char isIntrinsicFunction, size_t useFloat,
-                        size_t useDouble, int n, ...) {
+                        char isIntrinsicFunction, char useFloat, char useDouble,
+                        int n, ...) {
   // Get a pointer to the function if she is in the table
   interflop_function_info_t *function = vfc_func_table_get(func_name);
 
@@ -137,7 +137,7 @@ void vfc_enter_function(char *func_name, char isLibraryFunction,
     va_list ap;
     // n is the number of arguments intercepted, each argument
     // is represented by a type ID and a pointer
-    va_start(ap, n * 4);
+    va_start(ap, n);
 
     for (int i = 0; i < loaded_backends; i++)
       if (backends[i].interflop_enter_function)
@@ -152,12 +152,12 @@ void vfc_enter_function(char *func_name, char isLibraryFunction,
 void vfc_exit_function(__attribute__((unused)) char *func_name,
                        __attribute__((unused)) char isLibraryFunction,
                        __attribute__((unused)) char isIntrinsicFunction,
-                       size_t useFloat, size_t useDouble, int n, ...) {
+                       char useFloat, char useDouble, int n, ...) {
   if ((useFloat != 0) || (useDouble != 0)) {
     va_list ap;
     // n is the number of arguments intercepted, each argument
     // is represented by a type ID and a pointer
-    va_start(ap, n * 4);
+    va_start(ap, n);
 
     for (int i = 0; i < loaded_backends; i++)
       if (backends[i].interflop_exit_function)

--- a/src/vfcwrapper/main.c
+++ b/src/vfcwrapper/main.c
@@ -167,9 +167,9 @@ void ddebug_generate_inclusion(char *dd_generate_path, vfc_hashmap_t map) {
                  (void *)(get_value_at(map->items, i) - CALL_OP_SIZE));
         snprintf(executable, 64, "/proc/%d/exe", getppid());
         dup2(output, 1);
-        execlp(LLVM_BINDIR "/llvm-addr2line", LLVM_BINDIR "/llvm-addr2line",
-               "-fpaCs", "-e", executable, addr, NULL);
-        logger_error("error running " LLVM_BINDIR "/llvm-addr2line");
+        execlp(ADDR2LINE_PATH, ADDR2LINE_PATH, "-fpaCs", "-e", executable, addr,
+               NULL);
+        logger_error("error running " ADDR2LINE_PATH);
       } else {
         int status;
         wait(&status);

--- a/src/vfcwrapper/main.c
+++ b/src/vfcwrapper/main.c
@@ -167,9 +167,9 @@ void ddebug_generate_inclusion(char *dd_generate_path, vfc_hashmap_t map) {
                  (void *)(get_value_at(map->items, i) - CALL_OP_SIZE));
         snprintf(executable, 64, "/proc/%d/exe", getppid());
         dup2(output, 1);
-        execlp("addr2line", "/usr/bin/addr2line", "-fpaCs", "-e", executable,
-               addr, NULL);
-        logger_error("error running addr2line");
+        execlp(LLVM_BINDIR "/llvm-addr2line", LLVM_BINDIR "/llvm-addr2line",
+               "-fpaCs", "-e", executable, addr, NULL);
+        logger_error("error running " LLVM_BINDIR "/llvm-addr2line");
       } else {
         int status;
         wait(&status);

--- a/tests/test_absolute_error/test_additive.c
+++ b/tests/test_absolute_error/test_additive.c
@@ -4,6 +4,13 @@
 
 #include <time.h>
 
+// _Float128, used in the header files below, is not supported by clang, which
+// causes issues when compiling this test.  This test requires b32 and b64 but
+// does not use the quad types defined in float_{struct/utils}.h. Since we are
+// not using it we redefine, in the context of this test, _Float128 as long
+// double.
+
+#define _Float128 long double
 #include "../../src/common/float_const.h"
 #include "../../src/common/float_struct.h"
 #include "../../src/common/float_utils.h"

--- a/tests/test_absolute_error/test_generative.c
+++ b/tests/test_absolute_error/test_generative.c
@@ -4,6 +4,13 @@
 
 #include <time.h>
 
+// _Float128, used in the header files below, is not supported by clang, which
+// causes issues when compiling this test.  This test requires b32 and b64 but
+// does not use the quad types defined in float_{struct/utils}.h. Since we are
+// not using it we redefine, in the context of this test, _Float128 as long
+// double.
+
+#define _Float128 long double
 #include "../../src/common/float_const.h"
 #include "../../src/common/float_struct.h"
 #include "../../src/common/float_utils.h"

--- a/tests/test_bitmask_backend/pfp128.h
+++ b/tests/test_bitmask_backend/pfp128.h
@@ -1,0 +1,329 @@
+//===-- pfp128.h - Architecture and compiler neutral shims for 128b IEEE FP
+//--------------*- C -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/*
+ * A portability shim header to provide support for IEEE FP128
+ * on machines/compilers which have the underlying support, but don't
+ * provide the C standard interfaces.
+ */
+// Header monotonicity.
+#if (!defined(_PFP128_H_INCLUDED_))
+#define _PFP128_H_INCLUDED_ 1
+
+// Tell the system headers that we want all of the types, please.
+// (Not that it seems to do much good!)
+#define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#include <complex.h>
+#include <float.h>
+#include <math.h>
+
+// Architecture neutral C standard stuff, which we hope will catch what is going
+// on! The compiler supports the IEC 559 specification, however, that does not
+// actually require support for the 128b type. So we check whether the property
+
+// macros for FLT128 are present
+
+// Zeroed out for now, since although GCC sets this on x86_64, linux,
+// the foof128 function names are not present in libm :-(
+#if (0 && ((defined(__STDC_IEC_60559_TYPES__) || defined(__STDC_IEC_559__)) && \
+           defined(FLT128_MAX)))
+#if (PFP128_SHOW_CONFIG)
+#warning __STDC_IEC_60559_TYPES__ or __STDC_IEC_559__ defined with FLT128_MAX
+#endif
+typedef _Float128 FP128;
+typedef _Complex _Float128 COMPLEX_FP128;
+// No format specifier is given in the standard...
+// We assume for now that we're dealing with a GNU implementation and that 'Q'
+// will work.
+#define FP128_FMT_TAG "Q"
+// No way to do this with a static inline because the function takes an ellipsis
+// argument list, and there is no version which takes a va_list.
+#define FP128_snprintf quadmath_snprintf
+#define FP128_CONST(val) val##F128
+#define FP128Name(function) function##f128
+static inline FP128 strtoFP128(char const *s, char **sp) {
+  return strtoflt128(s, sp);
+}
+#if (PFP128_SHOW_CONFIG)
+#warning __LONG_DOUBLE_IEEE128__ defined
+#warning FP128 is _Float128
+#warning FP128_CONST tag is F128
+#warning FP128 function suffix is f128
+#warning strtoFP128 => strtof128
+#warning 
+#endif
+#elif (defined(__LONG_DOUBLE_IEEE128__))
+// No standard conformant support has been promised by the implementation.
+// So we have to guess based on the target and compiler.
+// First check for the case we believe does not provide any support.
+#define FP128_IS_LONGDOUBLE 1
+#elif (__APPLE__ && __MACH__ && __aarch64__)
+#warning No IEEE 128b float seems to be available on MacOS/AArch64...
+#warning FP128 will only be the same as double (i.e. 64b).
+#if (PFP128_SHOW_CONFIG)
+#warning Invoked with PFP128_SHOW_CONFIG: targeting MacOS AArch64
+#endif
+// Use long double, but it'll only be 64b
+#define FP128_IS_LONGDOUBLE 1
+#elif (__arm__)
+#warning No IEEE 128b float seems to be available on 32b Arm...
+#warning FP128 will only be the same as double (i.e. 64b).
+// Use long double, but it'll only be 64b, so this name is a bit misleading
+// but it has the appropriate effect.
+#define FP128_IS_LONGDOUBLE 1
+#elif (__aarch64__)
+// We can use long double with both LLVM and GCC,
+// and, other than on MacOS, that gets us what we want.
+#define FP128_IS_LONGDOUBLE 1
+#if (PFP128_SHOW_CONFIG)
+#warning Invoked with PFP128_SHOW_CONFIG: targeting AArch64 (not MacOS)
+#endif
+#elif (__x86_64__)
+#if (PFP128_SHOW_CONFIG)
+#warning Invoked with PFP128_SHOW_CONFIG: targeting x86_64
+#endif
+
+// long double is not the IEEE 128b format and we need libquadmath
+#include <quadmath.h>
+
+// Need to step very carefully around 80b floats!
+typedef __float128 FP128; // Both LLVM and GCC support the __float128 type,
+typedef __complex128 COMPLEX_FP128;
+
+#define FP128_CONST(val) val##Q
+#define FP128Name(function) function##q
+#define FP128_FMT_TAG "Q"
+// No way to do this with a static inline because the function takes an ellipsis
+// argument list, and there is no version which takes a va_list.
+#define FP128_snprintf quadmath_snprintf
+
+static inline FP128 strtoFP128(char const *s, char **sp) {
+  return strtoflt128(s, sp);
+}
+
+#if (PFP128_SHOW_CONFIG)
+#warning FP128 is __float128
+#warning FP128_CONST tag is Q
+#warning FP128 function suffix is q
+#warning FP128_FMT_TAG is Q
+#warning FP128_snprintf => quadmath_snprintf
+#warning strtoFP128 => strtoflt128
+#endif
+
+#else
+#error On an architecture this code does not understand.
+#endif
+
+#if (FP128_IS_LONGDOUBLE)
+// The compiler supports IEEE 128b float as long double.
+// Or we are pretending that it does...
+// The C standard only requires that long double
+// is at least as large as double, so it  may be accepted
+// syntactically, but not get you any more precision.
+typedef long double FP128; // Both LLVM and GCC support long double
+typedef _Complex long double COMPLEX_FP128;
+
+#define FP128_CONST(val) val##L
+#define FP128Name(function) function##l
+#define FP128_FMT_TAG "L"
+#define FP128_snprintf snprintf
+
+#if (PFP128_SHOW_CONFIG)
+#warning FP128 is long double
+#warning FP128_CONST tag is L
+#warning FP128 function suffix is l
+#warning FP128_FMT_TAG is L
+#warning FP128_snprintf => snprintf
+#warning strtoFP128 => strtold
+#endif
+
+#include <stdlib.h>
+static inline FP128 strtoFP128(char const *s, char **sp) {
+  return strtold(s, sp);
+}
+#endif
+
+// From here on the code is common no matter what the underlying implementation.
+// So if you're adding more functions do it here.
+
+// Maths functions
+// Implememt inline static shims.
+
+// clang-format really messes up the multiple line macro definitions :-(
+// clang-format off
+#define CreateUnaryShim(basename, restype, argtype)	\
+static inline restype basename ## FP128(argtype arg) {	\
+  return FP128Name(basename)(arg);			\
+}
+
+// Could do all of this with one macro if we passed in the argument
+// list rather than the argument types, but it's not much simpler.
+#define CreateBinaryShim(basename, restype, at1, at2)           \
+static inline restype basename ## FP128(at1 arg1, at2 arg2) {	\
+  return FP128Name(basename)(arg1, arg2);			\
+}
+
+#define CreateTernaryShim(basename, restype, at1, at2, at3)             \
+static inline restype basename ## FP128(at1 arg1, at2 arg2, at3 arg3) { \
+  return FP128Name(basename)(arg1, arg2, arg3);				\
+}
+
+#define FOREACH_UNARY_FUNCTION(op)              \
+  op(acos, FP128, FP128)                        \
+  op(acosh, FP128, FP128)                       \
+  op(asin, FP128, FP128)                        \
+  op(asinh, FP128, FP128)                       \
+  op(atan, FP128, FP128)                        \
+  op(atanh, FP128, FP128)                       \
+  op(cbrt, FP128, FP128)                        \
+  op(ceil, FP128, FP128)                        \
+  op(cosh, FP128, FP128)                        \
+  op(cos, FP128, FP128)                         \
+  op(erf, FP128, FP128)                         \
+  op(erfc, FP128, FP128)                        \
+  op(exp, FP128, FP128)                         \
+  op(expm1, FP128, FP128)                       \
+  op(fabs, FP128, FP128)                        \
+  op(floor, FP128, FP128)                       \
+  op(ilogb, int, FP128)                         \
+  op(lgamma, FP128, FP128)                      \
+  op(llrint, long long int, FP128)              \
+  op(llround, long long int, FP128)             \
+  op(logb, FP128, FP128)                        \
+  op(log, FP128, FP128)                         \
+  op(log10, FP128, FP128)                       \
+  op(log2, FP128, FP128)                        \
+  op(log1p, FP128, FP128)                       \
+  op(lrint, long int, FP128)                    \
+  op(lround, long int, FP128)                   \
+  op(nan, FP128, const char *)                  \
+  op(nearbyint, FP128, FP128)                   \
+  op(rint, FP128, FP128)                        \
+  op(round, FP128, FP128)                       \
+  op(sinh, FP128, FP128)                        \
+  op(sin, FP128, FP128)                         \
+  op(sqrt, FP128, FP128)                        \
+  op(tan, FP128, FP128)                         \
+  op(tanh, FP128, FP128)                        \
+  op(tgamma, FP128, FP128)                      \
+  op(trunc, FP128, FP128)                       \
+  op(cabs, FP128, COMPLEX_FP128)                \
+  op(carg, FP128, COMPLEX_FP128)                \
+  op(cimag, FP128, COMPLEX_FP128)               \
+  op(creal, FP128, COMPLEX_FP128)               \
+  op(cacos, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(cacosh, COMPLEX_FP128, COMPLEX_FP128)      \
+  op(casin, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(casinh, COMPLEX_FP128, COMPLEX_FP128)      \
+  op(catan, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(catanh, COMPLEX_FP128, COMPLEX_FP128)      \
+  op(ccos, COMPLEX_FP128, COMPLEX_FP128)        \
+  op(ccosh, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(cexp, COMPLEX_FP128, COMPLEX_FP128)        \
+  op(clog, COMPLEX_FP128, COMPLEX_FP128)        \
+  op(conj, COMPLEX_FP128, COMPLEX_FP128)        \
+  op(cproj, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(csin, COMPLEX_FP128, COMPLEX_FP128)        \
+  op(csinh, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(csqrt, COMPLEX_FP128, COMPLEX_FP128)       \
+  op(ctan, COMPLEX_FP128, COMPLEX_FP128)        \
+  op(ctanh, COMPLEX_FP128, COMPLEX_FP128)
+
+// exp2 doesn't seem to be available everywhere.
+// If you need it, and have it, then add it in the obvious way.
+// op(exp2, FP128, FP128)			
+
+FOREACH_UNARY_FUNCTION(CreateUnaryShim)
+
+// Functions with two arguments
+#define FOREACH_BINARY_FUNCTION(op)                     \
+  op(ldexp, FP128, FP128, int)                          \
+  op(modf, FP128, FP128, FP128 *)                       \
+  op(nextafter, FP128, FP128, FP128)                    \
+  op(pow, FP128, FP128, FP128)                          \
+  op(remainder, FP128, FP128, FP128)                    \
+  op(cpow, COMPLEX_FP128, COMPLEX_FP128, COMPLEX_FP128) \
+  op(atan2, FP128, FP128, FP128)                        \
+  op(copysign, FP128, FP128, FP128)                     \
+  op(fdim, FP128, FP128, FP128)                         \
+  op(fmax, FP128, FP128, FP128)                         \
+  op(fmin, FP128, FP128, FP128)                         \
+  op(fmod, FP128, FP128, FP128)                         \
+  op(frexp, FP128, FP128, int *)                        \
+  op(hypot, FP128, FP128, FP128)
+
+FOREACH_BINARY_FUNCTION(CreateBinaryShim)
+
+// Functions with three arguments
+#define FOREACH_TERNARY_FUNCTION(op)            \
+  op(remquo, FP128, FP128, FP128, int *)        \
+  op(fma, FP128, FP128, FP128, FP128)
+
+FOREACH_TERNARY_FUNCTION(CreateTernaryShim)
+
+// clang-format on
+
+// Constants
+// I have no idea why there is the inconsistency in naming between these
+// constants which have the type at the front, and the others which have the
+// type tag at the end but that's how the standard headers work, so we follow.
+
+// Properties of the type
+// Since the whole point is that this header is giving us IEEE 128b float we can
+// put the actual values in here and not bother to delegate.
+#define FP128_MAX FP128_CONST(1.18973149535723176508575932662800702e4932)
+#define FP128_MIN FP128_CONST(3.36210314311209350626267781732175260e-4932)
+#define FP128_EPSILON FP128_CONST(1.92592994438723585305597794258492732e-34)
+#define FP128_DENORM_MIN                                                       \
+  FP128_CONST(6.475175119438025110924438958227646552e-4966)
+#define FP128_MANT_DIG 113
+#define FP128_MIN_EXP (-16381)
+#define FP128_MAX_EXP 16384
+#define FP128_DIG 33
+#define FP128_MIN_10_EXP (-4931)
+#define FP128_MAX_10_EXP 4932
+#define HUGE_VALFP128 FP128Name(HUGE_VAL)
+
+// Properties of mathematics; we delegate here just for simplicity.
+#define M_E_FP128 FP128_CONST(2.718281828459045235360287471352662498) /* e */
+#define M_LOG2E_FP128                                                          \
+  FP128_CONST(1.442695040888963407359924681001892137) /* log_2 e */
+#define M_LOG10E_FP128                                                         \
+  FP128_CONST(0.434294481903251827651128918916605082) /* log_10 e */
+#define M_LN2_FP128                                                            \
+  FP128_CONST(0.693147180559945309417232121458176568) /* log_e 2 */
+#define M_LN10_FP128                                                           \
+  FP128_CONST(2.302585092994045684017991454684364208) /* log_e 10 */
+#define M_PI_FP128 FP128_CONST(3.141592653589793238462643383279502884) /* pi   \
+                                                                        */
+#define M_PI_2_FP128                                                           \
+  FP128_CONST(1.570796326794896619231321691639751442) /* pi/2 */
+#define M_PI_4_FP128                                                           \
+  FP128_CONST(0.785398163397448309615660845819875721) /* pi/4 */
+#define M_1_PI_FP128                                                           \
+  FP128_CONST(0.318309886183790671537767526745028724) /* 1/pi */
+#define M_2_PI_FP128                                                           \
+  FP128_CONST(0.636619772367581343075535053490057448) /* 2/pi */
+#define M_2_SQRTPI_FP128                                                       \
+  FP128_CONST(1.128379167095512573896158903121545172) /* 2/sqrt(pi) */
+#define M_SQRT2_FP128                                                          \
+  FP128_CONST(1.414213562373095048801688724209698079) /* sqrt(2) */
+#define M_SQRT1_2_FP128                                                        \
+  FP128_CONST(0.707106781186547524400844362104849039) /* 1/sqrt(2) */
+
+// Cleanliness
+#undef FP128_IS_LONGDOUBLE
+#undef FP128Name
+#undef FOREACH_UNARY_FUNCTION
+#undef FOREACH_BINARY_FUNCTION
+#undef FOREACH_TERNARY_FUNCTION
+#undef CreateUnaryShim
+#undef CreateBinaryShim
+#undef CreateTernaryShim
+
+#endif // Header monotonicity

--- a/tests/test_bitmask_backend/quadmath_stats.c
+++ b/tests/test_bitmask_backend/quadmath_stats.c
@@ -1,20 +1,21 @@
+#include "quadmath_stats.h"
 #include <assert.h>
 #include <math.h>
-#include <quadmath.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 
 #ifndef DEBUG
 #define DEBUG 0
 #endif
 
 /* Computes the means */
-__float128 compute_mean(const int N, const __float128 data[]) {
+FP128 compute_mean(const int N, const FP128 data[]) {
   assert(N >= 1);
 
-  __float128 sum = data[0];
-  __float128 c = 0.0, y, t;
+  FP128 sum = data[0];
+  FP128 c = 0.0, y, t;
   int i;
 
   for (i = 1; i < N; i++) {
@@ -24,45 +25,34 @@ __float128 compute_mean(const int N, const __float128 data[]) {
     sum = t;
   }
 
-  return sum / (__float128)N;
+  return sum / (FP128)N;
 }
 
-__float128 compute_variance(const int N, const __float128 mean,
-                            const __float128 data[]) {
+FP128 compute_variance(const int N, const FP128 mean,
+                            const FP128 data[]) {
   /* Knuth compensated online variance */
   assert(N >= 2);
 
   int i;
   int n = 0;
-  __float128 m = mean, M2 = 0.0;
+  FP128 m = mean, M2 = 0.0;
 
   for (i = 0; i < N; i++) {
     n++;
-    __float128 delta = data[i] - m;
-    m += delta / (__float128)n;
+    FP128 delta = data[i] - m;
+    m += delta / (FP128)n;
     M2 += delta * (data[i] - m);
   }
 
-  return M2 / (__float128)(n - 1);
+  return M2 / (FP128)(n - 1);
 }
 
 /* Computes the number of significant digits */
-double compute_sig(const int N, const __float128 data[]) {
-  __float128 mean = compute_mean(N, data);
-  __float128 std = sqrtq(compute_variance(N, mean, data));
+double compute_sig(const int N, const FP128 data[]) {
+  FP128 mean = compute_mean(N, data);
+  FP128 std = sqrtFP128(compute_variance(N, mean, data));
 
-  if (DEBUG) {
-    char mean_str[1024], std_str[1024];
-    quadmath_snprintf(mean_str, sizeof(mean_str), "%.29Qa", mean);
-    quadmath_snprintf(std_str, sizeof(std_str), "%.29Qa", std);
-    fprintf(stderr, "mean %s, std %s\n", mean_str, std_str);
-
-    quadmath_snprintf(mean_str, sizeof(mean_str), "%.29QE", mean);
-    quadmath_snprintf(std_str, sizeof(std_str), "%.29QE", std);
-    fprintf(stderr, "mean %s, std %s\n", mean_str, std_str);
-  }
-
-  return (mean == 0.0q && std == 0.0q) ? 0 : -log2q(fabsq(std / mean));
+  return (mean == 0.0q && std == 0.0q) ? 0 : -log2FP128(fabsFP128(std / mean));
 }
 
 int main(int argc, char *argv[]) {
@@ -72,7 +62,7 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  __float128 data[SAMPLES];
+  FP128 data[SAMPLES];
 
   const int N = atoi(argv[1]);
   FILE *fi = fopen(argv[2], "r");
@@ -84,7 +74,7 @@ int main(int argc, char *argv[]) {
 
   if (fi != NULL) {
     while ((nread = getline(&line, &len, fi) != -1) && i < N) {
-      data[i] = strtoflt128(line, NULL);
+      data[i] = strtoFP128(line, NULL);
       i++;
     }
   }

--- a/tests/test_bitmask_backend/quadmath_stats.h
+++ b/tests/test_bitmask_backend/quadmath_stats.h
@@ -1,12 +1,14 @@
 #ifndef __QUADMATH_STATS_H__
 #define __QUADMATH_STATS_H__
 
+#include "pfp128.h"
+
 /* Computes the means */
-__float128 compute_mean(const int N, const REAL data[]);
+FP128 compute_mean(const int N, const FP128 data[]);
 /* Knuth compensated online variance */
-__float128 compute_variance(const int N, const __float128 mean,
-                            const REAL data[]);
+FP128 compute_variance(const int N, const FP128 mean,
+                            const FP128 data[]);
 /* Computes the number of significant digits */
-double compute_sig(const int N, const REAL data[]);
+double compute_sig(const int N, const FP128 data[]);
 
 #endif /* __QUADMATH_STATS_H__ */

--- a/tests/test_bitmask_backend/test.sh
+++ b/tests/test_bitmask_backend/test.sh
@@ -42,8 +42,13 @@ check() {
 }
 
 GCC=${GCC_PATH}
-$GCC -D REAL=double -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_float -lquadmath
-$GCC -D REAL=float -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_double -lquadmath
+if [[ $(arch) == "x86_64" ]]; then
+   $GCC -D REAL=double -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_float -lquadmath -lm
+   $GCC -D REAL=float -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_double -lquadmath -lm
+else
+   $GCC -D REAL=double -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_float -lm
+   $GCC -D REAL=float -D SAMPLES=$SAMPLES -O3 quadmath_stats.c -o compute_sig_double -lm
+fi
 
 export VFC_BACKENDS_LOGGER=False
 

--- a/tests/test_branch_instrumentation/test.c
+++ b/tests/test_branch_instrumentation/test.c
@@ -7,9 +7,12 @@ bool f_ole(double a, double b) {
   return (a<=b);
 }
 
+// vectorized comparisons in aarch64 are not supported in LLVM15
+#if (__x86_64__)
 typedef double double4 __attribute__((ext_vector_type(4)));
 typedef long long4 __attribute__((ext_vector_type(4)));
 
 long4 f4x_ogt(double4 a, double4 b) {
   return (a > b);
 }
+#endif

--- a/tests/test_branch_instrumentation/test.sh
+++ b/tests/test_branch_instrumentation/test.sh
@@ -21,11 +21,14 @@ else
     echo "comparison operations instrumented"
 fi
 
-if grep "_4xdoublecmp" test.*.2.ll; then
-    echo "vector comparison instrumented"
-else
-    echo "vector comparison NOT instrumented with --inst-fcmp"
-    exit 1
+# Only test vector comparisons in x86_64
+if [[ $(arch) == "x86_64" ]]; then
+    if grep "_4xdoublecmp" test.*.2.ll; then
+        echo "vector comparison instrumented"
+    else
+        echo "vector comparison NOT instrumented with --inst-fcmp"
+        exit 1
+    fi
 fi
 
 # Test correct interposition for scalar and vector cases

--- a/tests/test_ddebug_exclude/test.sh
+++ b/tests/test_ddebug_exclude/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-verificarlo-c --ddebug -g -O0 test.c -o test
+verificarlo-c --ddebug -O0 test.c -o test
 
 # Generation run
 VFC_BACKENDS="libinterflop_ieee.so --debug" VFC_DDEBUG_GEN="operations.txt" ./test

--- a/tests/test_fp80/test.sh
+++ b/tests/test_fp80/test.sh
@@ -4,11 +4,13 @@ set -e
 # Verificarlo should not fail
 verificarlo-c -O2 -c rotg.c 2> error
 
-# But is should report the unsupported type
-if grep "Unsupported operand type: x86_fp80" error; then
-  echo "verificarlo-c correctly reported unsupported x86_fp80 type"
-  exit 0
-else
-  echo "verificarlo-c failed silently"
-  exit 1
+if [[ $(arch) == "x86_64" ]]; then
+    # But is should report the unsupported FP80 type on x86 
+    if grep "Unsupported operand type: x86_fp80" error; then
+      echo "verificarlo-c correctly reported unsupported x86_fp80 type"
+      exit 0
+    else
+      echo "verificarlo-c failed silently"
+      exit 1
+    fi
 fi

--- a/tests/test_tchebychev/test.sh
+++ b/tests/test_tchebychev/test.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# required so that seq behaves correctly in all locales
+export LC_ALL=C
+
 # Compile tchebychev.c using MCA lib instrumentation
 
 # Tchebychev polynom becomes unstable around 1, when computed with

--- a/tests/test_vectorization/operation.c
+++ b/tests/test_vectorization/operation.c
@@ -2,7 +2,7 @@
 
 #define define_arithmetic_vector_operation(type, operation, operator, size)    \
   type##size __attribute__((noinline))                                         \
-      operation##_##size##x##_##type(type##size a, type x) {                   \
+  operation##_##size##x##_##type(type##size a, type x) {                       \
     type##size res;                                                            \
     _Pragma("unroll") for (int i = 0; i < size; i++) {                         \
       res[i] = a[i] operator x;                                                \
@@ -12,7 +12,7 @@
 
 #define define_comparison_vector_operation(type, operation, operator, size)    \
   int##size __attribute__((noinline))                                          \
-      operation##_##size##x##_##type##_cmp(type##size a, int x) {              \
+  operation##_##size##x##_##type##_cmp(type##size a, int x) {                  \
     int##size res;                                                             \
     _Pragma("unroll") for (int i = 0; i < size; i++) {                         \
       int o = i % x;                                                           \
@@ -46,6 +46,7 @@ define_comparison_vector_operation(double, fge, >=, 2);
 define_comparison_vector_operation(double, feq, ==, 2);
 define_comparison_vector_operation(double, fneq, !=, 2);
 
+#if defined(__x86_64__)
 /* Vector size 4  */
 define_arithmetic_vector_operation(float, add, +, 4);
 define_arithmetic_vector_operation(float, sub, -, 4);
@@ -120,3 +121,4 @@ define_comparison_vector_operation(double, fgt, >, 16);
 define_comparison_vector_operation(double, fge, >=, 16);
 define_comparison_vector_operation(double, feq, ==, 16);
 define_comparison_vector_operation(double, fneq, !=, 16);
+#endif

--- a/tests/test_vectorization/test.c
+++ b/tests/test_vectorization/test.c
@@ -28,142 +28,157 @@
   }
 
 define_arithmetic_test(float, add, 2);
+define_arithmetic_test(double, add, 2);
+define_arithmetic_test(float, sub, 2);
+define_arithmetic_test(double, sub, 2);
+define_arithmetic_test(float, mul, 2);
+define_arithmetic_test(double, mul, 2);
+define_arithmetic_test(float, div, 2);
+define_arithmetic_test(double, div, 2);
+define_comparison_test(float, flt, 2);
+define_comparison_test(double, flt, 2);
+define_comparison_test(float, fle, 2);
+define_comparison_test(double, fle, 2);
+define_comparison_test(float, fgt, 2);
+define_comparison_test(double, fgt, 2);
+define_comparison_test(float, fge, 2);
+define_comparison_test(double, fge, 2);
+define_comparison_test(float, feq, 2);
+define_comparison_test(double, feq, 2);
+define_comparison_test(float, fneq, 2);
+define_comparison_test(double, fneq, 2);
+
+#if defined(__x86_64__)
 define_arithmetic_test(float, add, 4);
 define_arithmetic_test(float, add, 8);
 define_arithmetic_test(float, add, 16);
 
-define_arithmetic_test(double, add, 2);
 define_arithmetic_test(double, add, 4);
 define_arithmetic_test(double, add, 8);
 define_arithmetic_test(double, add, 16);
 
-define_arithmetic_test(float, sub, 2);
 define_arithmetic_test(float, sub, 4);
 define_arithmetic_test(float, sub, 8);
 define_arithmetic_test(float, sub, 16);
 
-define_arithmetic_test(double, sub, 2);
 define_arithmetic_test(double, sub, 4);
 define_arithmetic_test(double, sub, 8);
 define_arithmetic_test(double, sub, 16);
 
-define_arithmetic_test(float, mul, 2);
 define_arithmetic_test(float, mul, 4);
 define_arithmetic_test(float, mul, 8);
 define_arithmetic_test(float, mul, 16);
 
-define_arithmetic_test(double, mul, 2);
 define_arithmetic_test(double, mul, 4);
 define_arithmetic_test(double, mul, 8);
 define_arithmetic_test(double, mul, 16);
 
-define_arithmetic_test(float, div, 2);
 define_arithmetic_test(float, div, 4);
 define_arithmetic_test(float, div, 8);
 define_arithmetic_test(float, div, 16);
 
-define_arithmetic_test(double, div, 2);
 define_arithmetic_test(double, div, 4);
 define_arithmetic_test(double, div, 8);
 define_arithmetic_test(double, div, 16);
 
-define_comparison_test(float, flt, 2);
 define_comparison_test(float, flt, 4);
 define_comparison_test(float, flt, 8);
 define_comparison_test(float, flt, 16);
-define_comparison_test(double, flt, 2);
 define_comparison_test(double, flt, 4);
 define_comparison_test(double, flt, 8);
 define_comparison_test(double, flt, 16);
 
-define_comparison_test(float, fle, 2);
 define_comparison_test(float, fle, 4);
 define_comparison_test(float, fle, 8);
 define_comparison_test(float, fle, 16);
-define_comparison_test(double, fle, 2);
 define_comparison_test(double, fle, 4);
 define_comparison_test(double, fle, 8);
 define_comparison_test(double, fle, 16);
 
-define_comparison_test(float, fgt, 2);
 define_comparison_test(float, fgt, 4);
 define_comparison_test(float, fgt, 8);
 define_comparison_test(float, fgt, 16);
-define_comparison_test(double, fgt, 2);
 define_comparison_test(double, fgt, 4);
 define_comparison_test(double, fgt, 8);
 define_comparison_test(double, fgt, 16);
 
-define_comparison_test(float, fge, 2);
 define_comparison_test(float, fge, 4);
 define_comparison_test(float, fge, 8);
 define_comparison_test(float, fge, 16);
-define_comparison_test(double, fge, 2);
 define_comparison_test(double, fge, 4);
 define_comparison_test(double, fge, 8);
 define_comparison_test(double, fge, 16);
 
-define_comparison_test(float, feq, 2);
 define_comparison_test(float, feq, 4);
 define_comparison_test(float, feq, 8);
 define_comparison_test(float, feq, 16);
-define_comparison_test(double, feq, 2);
 define_comparison_test(double, feq, 4);
 define_comparison_test(double, feq, 8);
 define_comparison_test(double, feq, 16);
 
-define_comparison_test(float, fneq, 2);
 define_comparison_test(float, fneq, 4);
 define_comparison_test(float, fneq, 8);
 define_comparison_test(float, fneq, 16);
-define_comparison_test(double, fneq, 2);
 define_comparison_test(double, fneq, 4);
 define_comparison_test(double, fneq, 8);
 define_comparison_test(double, fneq, 16);
+#endif
 
 int main(int argc, char *argv[]) {
 
   run_test_add_float_2();
+  run_test_add_double_2();
+  run_test_sub_float_2();
+  run_test_sub_double_2();
+  run_test_mul_float_2();
+  run_test_mul_double_2();
+  run_test_div_float_2();
+  run_test_div_double_2();
+  run_test_flt_float_2();
+  run_test_fle_float_2();
+  run_test_fle_double_2();
+  run_test_fgt_float_2();
+  run_test_fgt_double_2();
+  run_test_fge_float_2();
+  run_test_fge_double_2();
+  run_test_feq_float_2();
+  run_test_feq_double_2();
+  run_test_fneq_float_2();
+  run_test_fneq_double_2();
+
+#if defined(__x86_64__)
   run_test_add_float_4();
   run_test_add_float_8();
   run_test_add_float_16();
 
-  run_test_add_double_2();
   run_test_add_double_4();
   run_test_add_double_8();
   run_test_add_double_16();
 
-  run_test_sub_float_2();
   run_test_sub_float_4();
   run_test_sub_float_8();
   run_test_sub_float_16();
 
-  run_test_sub_double_2();
   run_test_sub_double_4();
   run_test_sub_double_8();
   run_test_sub_double_16();
 
-  run_test_mul_float_2();
   run_test_mul_float_4();
   run_test_mul_float_8();
   run_test_mul_float_16();
 
-  run_test_mul_double_2();
   run_test_mul_double_4();
   run_test_mul_double_8();
   run_test_mul_double_16();
 
-  run_test_div_float_2();
   run_test_div_float_4();
   run_test_div_float_8();
   run_test_div_float_16();
 
-  run_test_div_double_2();
   run_test_div_double_4();
   run_test_div_double_8();
   run_test_div_double_16();
 
-  run_test_flt_float_2();
   run_test_flt_float_4();
   run_test_flt_float_8();
   run_test_flt_float_16();
@@ -172,50 +187,41 @@ int main(int argc, char *argv[]) {
   run_test_flt_double_8();
   run_test_flt_double_16();
 
-  run_test_fle_float_2();
   run_test_fle_float_4();
   run_test_fle_float_8();
   run_test_fle_float_16();
-  run_test_fle_double_2();
+
   run_test_fle_double_4();
   run_test_fle_double_8();
   run_test_fle_double_16();
 
-  run_test_fgt_float_2();
   run_test_fgt_float_4();
   run_test_fgt_float_8();
   run_test_fgt_float_16();
-  run_test_fgt_double_2();
   run_test_fgt_double_4();
   run_test_fgt_double_8();
   run_test_fgt_double_16();
 
-  run_test_fge_float_2();
   run_test_fge_float_4();
   run_test_fge_float_8();
   run_test_fge_float_16();
-  run_test_fge_double_2();
   run_test_fge_double_4();
   run_test_fge_double_8();
   run_test_fge_double_16();
 
-  run_test_feq_float_2();
   run_test_feq_float_4();
   run_test_feq_float_8();
   run_test_feq_float_16();
-  run_test_feq_double_2();
   run_test_feq_double_4();
   run_test_feq_double_8();
   run_test_feq_double_16();
 
-  run_test_fneq_float_2();
   run_test_fneq_float_4();
   run_test_fneq_float_8();
   run_test_fneq_float_16();
-  run_test_fneq_double_2();
   run_test_fneq_double_4();
   run_test_fneq_double_8();
   run_test_fneq_double_16();
-
+#endif
   return 0;
 }

--- a/verificarlo.in.in
+++ b/verificarlo.in.in
@@ -150,12 +150,18 @@ def linker_mode(sources, options, libraries, output, args):
 
     compile_vfcwrapper(vfcwrapper, vfcwrapper_o, args)
 
+    # Force no-pie when using ddebug and inst_func; since we use addresses to
+    # indentify the instrumented instructions, we require that the .text segment
+    # is loaded a a statically known address.
+    nopie = '-no-pie' if args.inst_func or args.ddebug else ''
+
     f = tempfile.NamedTemporaryFile(mode='w+')
     sources = ' '.join([os.path.splitext(s)[0]+'.o' for s in sources])
     if args.static:
-        cmd = f'{output} {sources} {options} {libraries} {vfcwrapper_o} -static -lgmp -lm -ldl'
+        cmd = f'{nopie} {output} {sources} {options} {libraries} {vfcwrapper_o} -static -lgmp -lm -ldl'
     else:
-        cmd = f'{output} {sources} {options} {libraries} {vfcwrapper_o} {mcalib_options} -ldl'
+        cmd = f'{nopie} {output} {sources} {options} {libraries} {vfcwrapper_o} {mcalib_options} -ldl'
+
 
     f.write(cmd)
     f.flush()
@@ -199,7 +205,7 @@ def compiler_mode(sources, options, output, args):
         compiler = linkers[args.linker]
         include = f" -I {mcalib_includes} "
 
-        debug = '-g' if args.inst_func else ''
+        debug = '-g' if args.inst_func or args.ddebug else ''
 
         if is_assembly(source):
             if not output:


### PR DESCRIPTION
This PR tracks efforts to port verificarlo to aarch64 (arm64) / Linux platforms. This should fix https://github.com/verificarlo/verificarlo/issues/332.

I am working on the port thanks to an access to Turpan (https://www.calmip.univ-toulouse.fr/espace-utilisateurs/doc-technique-turpan) kindly provided by CALMIP. Nodes are equipped with Ampere Altra Q80-30 processors and RHEL is installed.

A first issue is that __float128 type is not supported on aarch64. Fortunately, it appears that _Float128 (specified in the C programming language, ISO/IEC TS 18661) is supported by GCC both in amd64/linux and aarch64/linux. To ensure portability we could use the pfp128 shim (https://github.com/UoB-HPC/PortableFP128/) under LLVM/Apache licence. Thanks to this patch I can build and install verificarlo on aarch64 and run basic tests.

We might also have issues with the call stack code used in the funcInstrumentation pass. I will tackle this next.