### PR TITLE
Separate make and make install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,6 @@
 ACLOCAL_AMFLAGS=-I m4
 
-all: interflop-stdlib-install $(SUBDIRS)
-
-interflop-stdlib-install:
-	make -C src/interflop-stdlib
-	make -C src/interflop-stdlib install
+all: $(SUBDIRS)
 
 SUBDIRS=src/
 
@@ -33,6 +29,8 @@ check:
 	@echo "Tests should be run after install with make installcheck"
 
 install-exec-hook:
+	make -C src/interflop-stdlib install
+
 	$(PYTHON) -m pip install $(PYTHON_INSTALL_FLAGS) . && \
 	echo "Run 'source $(setenvdir)/set-env' to set environment variables"
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS=common libvfcfuncinstrument libvfcinstrument vfcwrapper backends
-include_HEADERS= common/vfc_probes.h
+SUBDIRS=common libvfcfuncinstrument libvfcinstrument vfcwrapper backends interflop-stdlib
+include_HEADERS=common/vfc_probes.h


### PR DESCRIPTION
Currently `make` triggers the installation of the `interflop-stdlib` libraries.
Therefore when running `make` on a system-wide target directory the install commands fail for lack of permissions.

This PR separates the build and install phases for interflop-stdlib. Thus one can do
```
make
sudo make install
```
building as a normal user and installing as root.

@yohanchatelain could you please check that this does not break the new installation process? It does seem to work fine on my side.  