### PR TITLE
Update RELEASE_TAG to use github.ref_name

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       TEST_TAG: verificarlo/verificarlo:test
       LATEST_TAG: ${{ github.repository }}:latest
-      RELEASE_TAG: ${{ github.repository }}:${{ github.ref }}
+      RELEASE_TAG: ${{ github.repository }}:${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Needed for #354.

Should fix usage of slashes in tag name before pushing to docker:

ERROR: failed to build: invalid tag "verificarlo/verificarlo:refs/tags/v2.4.0": invalid reference format