### PR TITLE
interflop-backend-prism: support prism set_rounding_mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/backends/prism"]
 	path = src/backends/prism
-	url = https://github.com/yohanchatelain/prism.git
+	url = https://github.com/verificarlo/prism.git
+	branch = main

--- a/src/backends/interflop-backend-prism/interflop_prism.c
+++ b/src/backends/interflop-backend-prism/interflop_prism.c
@@ -18,9 +18,10 @@
  *
  *   - CLI arguments --precision-binary32 and --precision-binary64 so that
  *     users can set the virtual precision via VFC_BACKENDS.
- *   - interflop_user_call handling for INTERFLOP_SET_PRECISION_BINARY32 and
- *     INTERFLOP_SET_PRECISION_BINARY64 so that instrumented code can change
- *     precision at runtime via interflop_call().
+ *   - interflop_user_call handling for INTERFLOP_SET_PRECISION_BINARY32,
+ *     INTERFLOP_SET_PRECISION_BINARY64 and INTERFLOP_SET_ROUNDING_MODE so that
+ *     instrumented code can change precision or rounding mode at runtime via
+ *     interflop_call().
  */
 
 #include <argp.h>
@@ -44,6 +45,7 @@ typedef struct {
   uint64_t seed;
   int32_t precision_binary32;
   int32_t precision_binary64;
+  int32_t mode;
   IBool choose_seed;
 } prism_context_t;
 
@@ -60,6 +62,7 @@ typedef enum {
   KEY_PRECISION_BINARY32 = 'f',
   KEY_PRECISION_BINARY64 = 'd',
   KEY_SEED = 's',
+  KEY_MODE = 'm',
 } key_args;
 
 static const struct argp_option options[] = {
@@ -69,6 +72,8 @@ static const struct argp_option options[] = {
      "Virtual precision for binary64 (default: 53)", 0},
     {"seed", KEY_SEED, "SEED", 0,
      "Fix the random generator seed (default: random)", 0},
+    {"mode", KEY_MODE, "MODE", 0,
+     "select PRISM rounding mode among {sr, rn} (default: sr)", 0},
     {0, 0, 0, 0, 0, 0}};
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
@@ -109,6 +114,16 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
     ctx->choose_seed = true;
     break;
   }
+  case KEY_MODE: {
+    if (interflop_strcasecmp(arg, "sr") == 0) {
+      ctx->mode = INTERFLOP_PRISM_SR;
+    } else if (interflop_strcasecmp(arg, "rn") == 0) {
+      ctx->mode = INTERFLOP_PRISM_RN;
+    } else {
+      logger_error("--mode invalid value provided, must be one of: {sr, rn}");
+    }
+    break;
+  }
   default:
     return ARGP_ERR_UNKNOWN;
   }
@@ -132,6 +147,11 @@ static void prism_user_call(void *context, interflop_call_id id, va_list ap) {
     interflop_prism_set_default_virtual_precision_binary64(prec);
     break;
   }
+  case INTERFLOP_SET_ROUNDING_MODE: {
+    int32_t mode = va_arg(ap, int);
+    interflop_prism_set_rounding_mode(mode);
+    break;
+  }
   default:
     break;
   }
@@ -147,6 +167,7 @@ void interflop_pre_init(interflop_panic_t panic, File *stream, void **context) {
       (prism_context_t *)interflop_malloc(sizeof(prism_context_t));
   ctx->precision_binary32 = DEFAULT_PRECISION_BINARY32;
   ctx->precision_binary64 = DEFAULT_PRECISION_BINARY64;
+  ctx->mode = INTERFLOP_PRISM_SR;
   ctx->seed = 0ULL;
   ctx->choose_seed = false;
   *context = ctx;
@@ -170,12 +191,14 @@ struct interflop_backend_interface_t interflop_init(void *context) {
       ctx->precision_binary32);
   interflop_prism_set_default_virtual_precision_binary64(
       ctx->precision_binary64);
+  interflop_prism_set_rounding_mode(ctx->mode);
 
   if (ctx->choose_seed) {
     interflop_prism_set_seed(ctx->seed);
   }
   logger_info("seed = %lu%s\n", interflop_prism_get_seed(),
               ctx->choose_seed ? " (fixed)" : " (random)");
+  logger_info("mode = %s\n", ctx->mode == INTERFLOP_PRISM_RN ? "rn" : "sr");
 
   struct interflop_backend_interface_t iface = {
       .interflop_add_float = NULL,

--- a/src/interflop-stdlib/interflop.h
+++ b/src/interflop-stdlib/interflop.h
@@ -56,6 +56,9 @@ enum FTYPES {
 };
 
 typedef enum {
+  /* Allows changing rounding mode */
+  /* signature: void set_rounding_mode(int mode) */
+  INTERFLOP_SET_ROUNDING_MODE = 6,
   /* Allows changing current virtual precision range */
   /* signature: void set_range_binary64(int precision) */
   INTERFLOP_SET_RANGE_BINARY64 = 5,

--- a/tests/test_prism_backend_integration/test.c
+++ b/tests/test_prism_backend_integration/test.c
@@ -46,19 +46,26 @@ int main(int argc, char **argv) {
 
   if (test_case == 0) {
     /* Report the precision set at startup via VFC_BACKENDS */
+    get_prec_t get_round_mode = lookup_getter("interflop_prism_get_rounding_mode");
     printf("precision_binary32=%d\n", get_f32());
     printf("precision_binary64=%d\n", get_f64());
+    printf("mode=%d\n", get_round_mode());
 
   } else if (test_case == 1) {
     /* Test that interflop_call changes virtual precision at runtime */
+    get_prec_t get_round_mode = lookup_getter("interflop_prism_get_rounding_mode");
+
     int32_t before_f32 = get_f32();
     int32_t before_f64 = get_f64();
+    int32_t before_mode = get_round_mode();
 
     interflop_call(INTERFLOP_SET_PRECISION_BINARY32, 5);
     interflop_call(INTERFLOP_SET_PRECISION_BINARY64, 10);
+    interflop_call(INTERFLOP_SET_ROUNDING_MODE, 1);
 
     printf("before_f32=%d after_f32=%d\n", before_f32, get_f32());
     printf("before_f64=%d after_f64=%d\n", before_f64, get_f64());
+    printf("before_mode=%d after_mode=%d\n", before_mode, get_round_mode());
 
   } else {
     fprintf(stderr, "Unknown test case %d\n", test_case);

--- a/tests/test_prism_backend_integration/test.sh
+++ b/tests/test_prism_backend_integration/test.sh
@@ -48,6 +48,7 @@ result=$(VFC_BACKENDS="libinterflop_prism.so" ./test 0 2>/dev/null)
 
 p32=$(echo "$result" | grep "precision_binary32=" | cut -d= -f2)
 p64=$(echo "$result" | grep "precision_binary64=" | cut -d= -f2)
+mode=$(echo "$result" | grep "mode=" | cut -d= -f2)
 
 if [ "$p32" != "24" ]; then
     echo "FAIL (default binary32): expected 24, got '$p32'"
@@ -57,7 +58,11 @@ if [ "$p64" != "53" ]; then
     echo "FAIL (default binary64): expected 53, got '$p64'"
     exit 1
 fi
-echo "PASS: default PRISM virtual precision is IEEE hardware precision"
+if [ "$mode" != "0" ]; then
+    echo "FAIL (default mode): expected 0 (SR), got '$mode'"
+    exit 1
+fi
+echo "PASS: default PRISM virtual precision and rounding mode are correct"
 
 # ---------------------------------------------------------------------------
 # Test 3: precision changed at runtime via interflop_call
@@ -68,6 +73,8 @@ before_f32=$(echo "$result" | grep "before_f32=" | sed 's/.*before_f32=\([0-9]*\
 after_f32=$( echo "$result" | grep "after_f32="  | sed 's/.*after_f32=\([0-9]*\).*/\1/')
 before_f64=$(echo "$result" | grep "before_f64=" | sed 's/.*before_f64=\([0-9]*\).*/\1/')
 after_f64=$( echo "$result" | grep "after_f64="  | sed 's/.*after_f64=\([0-9]*\).*/\1/')
+before_mode=$(echo "$result" | grep "before_mode=" | sed 's/.*before_mode=\([0-9]*\).*/\1/')
+after_mode=$( echo "$result" | grep "after_mode="  | sed 's/.*after_mode=\([0-9]*\).*/\1/')
 
 if [ "$before_f32" != "24" ]; then
     echo "FAIL (calluser initial binary32): expected 24, got '$before_f32'"
@@ -85,6 +92,25 @@ if [ "$after_f64" != "10" ]; then
     echo "FAIL (calluser binary64): expected 10 after interflop_call, got '$after_f64'"
     exit 1
 fi
-echo "PASS: interflop_call changes PRISM virtual precision at runtime"
+if [ "$before_mode" != "0" ]; then
+    echo "FAIL (calluser initial mode): expected 0, got '$before_mode'"
+    exit 1
+fi
+if [ "$after_mode" != "1" ]; then
+    echo "FAIL (calluser mode): expected 1 after interflop_call, got '$after_mode'"
+    exit 1
+fi
+echo "PASS: interflop_call changes PRISM virtual precision and rounding mode at runtime"
+
+# ---------------------------------------------------------------------------
+# Test 4: rounding mode set via VFC_BACKENDS string arguments (--mode rn)
+# ---------------------------------------------------------------------------
+result=$(VFC_BACKENDS="libinterflop_prism.so --mode rn" ./test 0 2>/dev/null)
+mode=$(echo "$result" | grep "mode=" | cut -d= -f2)
+if [ "$mode" != "1" ]; then
+    echo "FAIL (env mode rn): expected 1, got '$mode'"
+    exit 1
+fi
+echo "PASS: VFC_BACKENDS sets PRISM rounding mode to RN using string"
 
 exit 0


### PR DESCRIPTION
Add support for prism set_rounding_mode() both as a user-call and through backend args.