### PR TITLE
ddebug: disable debuginfod in inclusion generation

### DIFF
--- a/src/vfcwrapper/main.c.in
+++ b/src/vfcwrapper/main.c.in
@@ -179,8 +179,8 @@ void ddebug_generate_inclusion(char *dd_generate_path, vfc_hashmap_t map) {
                  (void *)(get_value_at(map->items, i) - CALL_OP_SIZE));
         snprintf(executable, 64, "/proc/%d/exe", getppid());
         dup2(output, 1);
-        execlp(ADDR2LINE_BIN, ADDR2LINE_PATH, "-fpaCs", "-e", executable, addr,
-               NULL);
+        execlp(ADDR2LINE_BIN, ADDR2LINE_PATH, "-fpaCs", "--no-debuginfod", "-e",
+               executable, addr, NULL);
         logger_error("error running " ADDR2LINE_BIN);
       } else {
         int status;

--- a/tests/test_ddebug_gen_include/test.sh
+++ b/tests/test_ddebug_gen_include/test.sh
@@ -2,7 +2,27 @@
 set -e
 verificarlo-c --ddebug -g -O0 test.c -o test
 
-VFC_BACKENDS="libinterflop_ieee.so --debug" VFC_DDEBUG_GEN="inclusion.txt" ./test
+run_with_timeout() {
+  local timeout_s="$1"
+  shift
+  "$@" &
+  local pid=$!
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$timeout_s" ]; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      echo "command timed out after ${timeout_s}s: $*"
+      exit 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+}
+
+run_with_timeout 15 env DEBUGINFOD_URLS="https://example.invalid" \
+  VFC_BACKENDS="libinterflop_ieee.so --debug" VFC_DDEBUG_GEN="inclusion.txt" ./test
 
 # Keep only first four operations (in the inclusion file; does not match the execution order)
 NOP=4
@@ -18,5 +38,4 @@ else
   echo "problem with generation and filtering, expected $NOP operations only after filtering"
   exit 1
 fi
-
 


### PR DESCRIPTION
Pass --no-debuginfod to addr2line in ddebug inclusion generation to avoid hangs when DEBUGINFOD_URLS points to an unreachable endpoint. Add a timeout-based regression check in test_ddebug_gen_include that sets DEBUGINFOD_URLS to an invalid URL and fails quickly if generation blocks.

Fix #379 