### PR TITLE
Update DOI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tool for debugging and assessing floating point precision and reproducibility.
 ![GitHub Release](https://img.shields.io/github/v/release/verificarlo/verificarlo)
 ![Build Status](https://github.com/verificarlo/verificarlo/actions/workflows/docker-ci.yml/badge.svg?branch=master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/verificarlo/verificarlo)](https://hub.docker.com/r/verificarlo/verificarlo)
-[![DOI](https://zenodo.org/badge/34260221.svg)](https://zenodo.org/badge/latestdoi/34260221)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20629788-blue)](https://zenodo.org/badge/latestdoi/34260221)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://releases.llvm.org/13.0.0/LICENSE.TXT)
 
 - [Verificarlo v2.5.1](#verificarlo-v251)


### PR DESCRIPTION
## Description of contribution

This PR fixes the DOI badge inside the `README.md` file. 

It previously showed up like this:

<img width="38" height="26" alt="image" src="https://github.com/user-attachments/assets/f17b13e7-6871-4fa5-ae84-09c7ee8df685" />


This is now fixed and shows the badge properly:

<img width="147" height="27" alt="image" src="https://github.com/user-attachments/assets/3df6a58a-d5b5-4c29-9360-8b2b0a7de97a" />

## Implementation Details

This PR introduces a simple change to the badge image link changing it from

`https://zenodo.org/badge/34260221.svg` to `https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20629788-blue`.